### PR TITLE
feat: package with nix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 target/
 logs/
 *.mp4
+result

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,48 @@
+{
+  pkgs ? import <nixpkgs> { },
+}:
+rec {
+  moq-rs = pkgs.callPackage ./package.nix { };
+  default = moq-rs;
+  publish = pkgs.dockerTools.buildLayeredImage {
+    name = "moq-pub";
+    tag = "latest";
+    contents = pkgs.buildEnv {
+      name = "image-root";
+      paths = with pkgs; [
+        bashInteractive
+        coreutils
+        ffmpeg
+        wget
+        moq-rs
+      ];
+      pathsToLink = [ "/bin" ];
+    };
+    config = {
+      Entrypoint = [ "bash" ];
+      Cmd = [ deploy/publish ];
+    };
+  };
+  relay = pkgs.dockerTools.buildLayeredImage {
+    name = "moq-relay";
+    tag = "latest";
+    contents = pkgs.buildEnv {
+      name = "image-root";
+      paths = with pkgs; [
+        bashInteractive
+        coreutils
+        curl
+        dockerTools.caCertificates
+        moq-rs
+      ];
+      pathsToLink = [
+        "/bin"
+        "/etc"
+      ];
+    };
+    config = {
+      Entrypoint = [ "bash" ];
+      Cmd = [ "moq-relay" ];
+    };
+  };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1729850857,
+        "narHash": "sha256-WvLXzNNnnw+qpFOmgaM3JUlNEH+T4s22b5i2oyyCpXE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "41dea55321e5a999b17033296ac05fe8a8b5a257",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,22 @@
+{
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  outputs =
+    { nixpkgs, ... }:
+    let
+      supportedSystems = [
+        "x86_64-linux"
+        "x86_64-darwin"
+        "aarch64-linux"
+        "aarch64-darwin"
+      ];
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+    in
+    {
+      packages = forAllSystems (
+        system:
+        import ./default.nix {
+          pkgs = nixpkgs.legacyPackages.${system};
+        }
+      );
+    };
+}

--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  rustPlatform,
+  pkg-config,
+  openssl,
+  stdenv,
+  darwin,
+}:
+
+rustPlatform.buildRustPackage {
+  name = "moq-rs";
+
+  src =
+    let
+      ignoredPaths = [
+        "default.nix"
+        "flake.nix"
+        "flake.lock"
+        "package.nix"
+      ];
+    in
+    lib.cleanSourceWith {
+      filter = name: type: !(builtins.elem (baseNameOf name) ignoredPaths);
+      src = lib.cleanSource ./.;
+    };
+
+  cargoLock = {
+    lockFile = ./Cargo.lock;
+    allowBuiltinFetchGit = true;
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    rustPlatform.bindgenHook
+  ];
+
+  buildInputs =
+    [
+      openssl
+    ]
+    ++ lib.optionals stdenv.isDarwin [
+      darwin.apple_sdk.frameworks.Security
+      darwin.apple_sdk.frameworks.SystemConfiguration
+    ];
+
+  meta = {
+    description = "Fork of kixelated/moq-rs to continue tracking the IETF MoQ Working Group drafts";
+    homepage = "https://github.com/englishm/moq-rs";
+    license = with lib.licenses; [
+      asl20
+      mit
+    ];
+    maintainers = with lib.maintainers; [ niklaskorz ];
+    mainProgram = "moq-pub";
+  };
+}


### PR DESCRIPTION
This PR introduces Nix packages for the binaries as well as the two docker images. Note that while the docker image builds can be run on macOS, they only make sense on Linux, as otherwise the produced image will contain macOS-native binaries, which will not work in an OCI image.

Building the `moq-rs` package that contains all binaries (works on macOS and Linux):

```
# with flakes enabled
$ nix build
# without flakes
$ nix-build -A moq-rs
# produced binaries
$ ls ./result/bin
moq-api  moq-clock-ietf  moq-dir  moq-pub  moq-relay-ietf  moq-sub
```

Building the publish image (similar to the one produced by the repository's Dockerfile, only useful on Linux):

```
# with flakes enabled
$ nix build .#publish
# without flakes
$ nix-build -A publish
```


Building the relay image (similar to the one produced by the repository's Dockerfile):

```
# with flakes enabled
$ nix build .#relay
# without flakes
$ nix-build -A relay
```
