### PR TITLE
moq-transport: Fix u8 encoding

### DIFF
--- a/moq-transport/src/coding/varint.rs
+++ b/moq-transport/src/coding/varint.rs
@@ -245,10 +245,11 @@ impl Encode for usize {
 }
 
 impl Encode for u8 {
-	/// Encode a varint to the given writer.
+	/// Encode a u8 to the given writer.
 	fn encode<W: bytes::BufMut>(&self, w: &mut W) -> Result<(), EncodeError> {
-		let var = VarInt::from(*self);
-		var.encode(w)
+		let x = *self;
+		w.put_u8(x);
+		Ok(())
 	}
 }
 


### PR DESCRIPTION
Fixes u8 encoding so we can encode values larger than 64.

Previously we were incorrectly encoding values larger than 64 as
varints, including the current default subscriber priority of 127, and
then incorrectly decoding those mis-encoded values as 64.

I introduced this bug in 7eeecb7

Thanks to @TilsonJoji for helping to identify the issue in https://github.com/englishm/moq-rs/pull/9
