### PR TITLE
Add moq-gst

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,6 +123,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "atomic_refcell"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41e67cd8309bbd06cd603a9e693a784ac2e5d1e955f11286e355089fcab3047c"
+
+[[package]]
 name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -237,10 +243,10 @@ version = "0.69.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "cexpr",
  "clang-sys",
- "itertools",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "log",
@@ -262,9 +268,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "bumpalo"
@@ -308,6 +314,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
  "nom",
+]
+
+[[package]]
+name = "cfg-expr"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0890061c4d3223e7267f3bad2ec40b997d64faac1c2815a4a9d95018e2b9e9c"
+dependencies = [
+ "smallvec",
+ "target-lexicon",
 ]
 
 [[package]]
@@ -641,10 +657,152 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
+name = "gio-sys"
+version = "0.20.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217f464cad5946ae4369c355155e2d16b488c08920601083cb4891e352ae777b"
+dependencies = [
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "glib"
+version = "0.20.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "358431b0e0eb15b9d02db52e1f19c805b953c5c168099deb3de88beab761768c"
+dependencies = [
+ "bitflags 2.6.0",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-task",
+ "futures-util",
+ "gio-sys",
+ "glib-macros",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "memchr",
+ "smallvec",
+]
+
+[[package]]
+name = "glib-macros"
+version = "0.20.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7d21ca27acfc3e91da70456edde144b4ac7c36f78ee77b10189b3eb4901c156"
+dependencies = [
+ "heck",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "glib-sys"
+version = "0.20.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a5911863ab7ecd4a6f8d5976f12eeba076b23669c49b066d877e742544aa389"
+dependencies = [
+ "libc",
+ "system-deps",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
+name = "gobject-sys"
+version = "0.20.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4c674d2ff8478cf0ec29d2be730ed779fef54415a2fb4b565c52def62696462"
+dependencies = [
+ "glib-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
+name = "gst-plugin-version-helper"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e5e874f1660252fd2ec81c602066df3633b3a6fcbe2b196f7f93c27cf069b2a"
+dependencies = [
+ "chrono",
+ "toml_edit",
+]
+
+[[package]]
+name = "gstreamer"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680006694e79692f831ca4f3ba6e147b8c23db289b2df1d33a4a97fd038145d7"
+dependencies = [
+ "cfg-if",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "glib",
+ "gstreamer-sys",
+ "itertools 0.13.0",
+ "libc",
+ "muldiv",
+ "num-integer",
+ "num-rational",
+ "once_cell",
+ "option-operations",
+ "paste",
+ "pin-project-lite",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gstreamer-base"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a11df90e3abf1d9747111c41902338fc1bd13b1c23b27fb828d43e57bd190134"
+dependencies = [
+ "atomic_refcell",
+ "cfg-if",
+ "glib",
+ "gstreamer",
+ "gstreamer-base-sys",
+ "libc",
+]
+
+[[package]]
+name = "gstreamer-base-sys"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d691b2bb51a9e5727fb33c3b53fb64ee5b80c40cbbd250941a6d44b142f7a6a0"
+dependencies = [
+ "glib-sys",
+ "gobject-sys",
+ "gstreamer-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
+name = "gstreamer-sys"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db89964774a97d5b092e2d124debc6bbcaf34b5c7cdef1759f4a9e1e3f8326ef"
+dependencies = [
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
+]
 
 [[package]]
 name = "h2"
@@ -667,9 +825,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
 
 [[package]]
 name = "heck"
@@ -883,9 +1041,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.6"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -908,6 +1066,15 @@ name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -1014,9 +1181,9 @@ checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "memchr"
-version = "2.7.2"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "mime"
@@ -1082,6 +1249,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "moq-catalog"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2619fa9d01bf7d9540692e8c6699f8462df6af02b3ebd23b9cd9686a38be793b"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "moq-clock-ietf"
 version = "0.6.2"
 dependencies = [
@@ -1090,8 +1266,8 @@ dependencies = [
  "clap",
  "env_logger",
  "log",
- "moq-native-ietf",
- "moq-transport",
+ "moq-native-ietf 0.5.2",
+ "moq-transport 0.8.0",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -1108,12 +1284,30 @@ dependencies = [
  "env_logger",
  "futures",
  "log",
- "moq-native-ietf",
- "moq-transport",
+ "moq-native-ietf 0.5.2",
+ "moq-transport 0.8.0",
  "tokio",
  "tracing",
  "tracing-subscriber",
  "web-transport",
+]
+
+[[package]]
+name = "moq-gst"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "env_logger",
+ "gst-plugin-version-helper",
+ "gstreamer",
+ "gstreamer-base",
+ "moq-native-ietf 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "moq-pub 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "moq-transport 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "once_cell",
+ "tokio",
+ "url",
 ]
 
 [[package]]
@@ -1125,7 +1319,31 @@ dependencies = [
  "futures",
  "hex",
  "log",
- "moq-transport",
+ "moq-transport 0.8.0",
+ "quinn",
+ "ring",
+ "rustls 0.23.7",
+ "rustls-native-certs",
+ "rustls-pemfile",
+ "tokio",
+ "url",
+ "web-transport",
+ "web-transport-quinn",
+ "webpki",
+]
+
+[[package]]
+name = "moq-native-ietf"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39b631331a29beb91fd91aa906c9391a37f8cae19a1f96b4953661db4b4361c7"
+dependencies = [
+ "anyhow",
+ "clap",
+ "futures",
+ "hex",
+ "log",
+ "moq-transport 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quinn",
  "ring",
  "rustls 0.23.7",
@@ -1147,9 +1365,32 @@ dependencies = [
  "clap",
  "env_logger",
  "log",
- "moq-catalog",
- "moq-native-ietf",
- "moq-transport",
+ "moq-catalog 0.2.1",
+ "moq-native-ietf 0.5.2",
+ "moq-transport 0.8.0",
+ "mp4",
+ "rfc6381-codec",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "url",
+]
+
+[[package]]
+name = "moq-pub"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdc673305674b2c13c1a3dbca15b1d6d5724dd199fe18e2cddea61613829e9c0"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "clap",
+ "env_logger",
+ "log",
+ "moq-catalog 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "moq-native-ietf 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "moq-transport 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mp4",
  "rfc6381-codec",
  "serde_json",
@@ -1172,8 +1413,8 @@ dependencies = [
  "hyper-serve",
  "log",
  "moq-api",
- "moq-native-ietf",
- "moq-transport",
+ "moq-native-ietf 0.5.2",
+ "moq-transport 0.8.0",
  "tokio",
  "tower-http",
  "tracing",
@@ -1189,8 +1430,8 @@ dependencies = [
  "clap",
  "env_logger",
  "log",
- "moq-native-ietf",
- "moq-transport",
+ "moq-native-ietf 0.5.2",
+ "moq-transport 0.8.0",
  "mp4",
  "tokio",
  "tracing",
@@ -1201,6 +1442,21 @@ dependencies = [
 [[package]]
 name = "moq-transport"
 version = "0.8.0"
+dependencies = [
+ "bytes",
+ "futures",
+ "log",
+ "paste",
+ "thiserror",
+ "tokio",
+ "web-transport",
+]
+
+[[package]]
+name = "moq-transport"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4839a5cb144549cc0f654a03e50c7d96c95ebb6f887ef19f3378a9f261ad2c95"
 dependencies = [
  "bytes",
  "futures",
@@ -1239,6 +1495,12 @@ name = "mpeg4-audio-const"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96a1fe2275b68991faded2c80aa4a33dba398b77d276038b8f50701a22e55918"
+
+[[package]]
+name = "muldiv"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "956787520e75e9bd233246045d19f42fb73242759cc57fba9611d940ae96d4b0"
 
 [[package]]
 name = "native-tls"
@@ -1349,7 +1611,7 @@ version = "0.10.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1385,6 +1647,15 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "option-operations"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c26d27bb1aeab65138e4bf7666045169d1717febcc9ff870166be8348b223d0"
+dependencies = [
+ "paste",
 ]
 
 [[package]]
@@ -1480,6 +1751,15 @@ checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
 dependencies = [
  "proc-macro2",
  "syn",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]
@@ -1613,7 +1893,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
 ]
 
 [[package]]
@@ -1741,7 +2021,7 @@ version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1888,7 +2168,7 @@ version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c627723fd09706bacdb5cf41499e95098555af3c3c29d014dc3c458ef6be11c0"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -1944,6 +2224,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
 dependencies = [
  "itoa",
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+dependencies = [
  "serde",
 ]
 
@@ -2075,6 +2364,25 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "system-deps"
+version = "7.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66d23aaf9f331227789a99e8de4c91bf46703add012bdfd45fdecdfb2975a005"
+dependencies = [
+ "cfg-expr",
+ "heck",
+ "pkg-config",
+ "toml",
+ "version-compare",
+]
+
+[[package]]
+name = "target-lexicon"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tempfile"
@@ -2220,6 +2528,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
 name = "tower"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2241,7 +2583,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "bytes",
  "http",
  "http-body",
@@ -2383,6 +2725,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version-compare"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "852e951cb7832cb45cb1169900d19760cfa39b82bc0ea9c0e5a14ae88411c98b"
 
 [[package]]
 name = "walkdir"
@@ -2749,6 +3097,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+
+[[package]]
+name = "winnow"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
 	"moq-dir",
 	"moq-native-ietf",
 	"moq-catalog",
+	"moq-gst",
 ]
 resolver = "2"
 

--- a/moq-gst/Cargo.toml
+++ b/moq-gst/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "moq-gst"
+description = "Media over QUIC - gstreamer plugin"
+authors = ["Luke Curley"]
+repository = "https://github.com/kixelated/moq-gst"
+license = "MIT OR Apache-2.0"
+
+version = "0.1.0"
+edition = "2021"
+
+keywords = ["quic", "http3", "webtransport", "media", "live"]
+categories = ["multimedia", "network-programming", "web-programming"]
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+moq-transport = "0.8"
+moq-native-ietf = "0.5"
+moq-pub = "0.8"
+
+gst = { package = "gstreamer", version = "0.23" }
+gst-base = { package = "gstreamer-base", version = "0.23" }
+once_cell = "1"
+bytes = "1"
+url = "2"
+tokio = { version = "1", features = ["full"] }
+env_logger = "0.11"
+anyhow = { version = "1", features = ["backtrace"] }
+
+[build-dependencies]
+gst-plugin-version-helper = "0.8"
+
+[lib]
+name = "gstmoq"
+crate-type = ["cdylib","rlib"]
+path = "src/lib.rs"

--- a/moq-gst/README.md
+++ b/moq-gst/README.md
@@ -1,0 +1,22 @@
+A gstreamer plugin utilizing [moq-rs](https://github.com/englishm/moq-rs).
+
+# Usage
+Check out the `run` script for an example pipeline.
+
+```bash
+./run
+```
+
+By default this uses a localhost relay.
+You can change the ENV args if you want to make it watchable on production instead:
+
+```bash
+ADDR=relay.quic.video NAME=something ./run
+```
+
+# License
+
+Licensed under either:
+
+-   Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+-   MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)

--- a/moq-gst/build.rs
+++ b/moq-gst/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    gst_plugin_version_helper::info()
+}

--- a/moq-gst/run
+++ b/moq-gst/run
@@ -1,0 +1,43 @@
+#!/bin/bash
+set -euo pipefail
+
+# Change directory to the root of the project
+cd "$(dirname "$0")"
+
+# Use info logging by default
+export RUST_LOG="${RUST_LOG:-info}"
+
+# Connect to localhost by default.
+HOST="${HOST:-localhost}"
+PORT="${PORT:-4443}"
+ADDR="${ADDR:-$HOST:$PORT}"
+SCHEME="${SCHEME:-https}"
+
+# Use the name "bbb" for the broadcast.
+NAME="${NAME:-bbb}"
+
+# Combine the host into a URL.
+URL="${URL:-"$SCHEME://$ADDR"}"
+
+# Default to a source video
+INPUT="${INPUT:-bbb.mp4}"
+
+# Print out the watch URL
+echo "Watch URL: https://quic.video/watch/$NAME?server=$ADDR"
+
+# Make sure we build the gstreamer plugin
+cargo build
+
+export GST_PLUGIN_PATH="${PWD}/../target/debug${GST_PLUGIN_PATH:+:$GST_PLUGIN_PATH}"
+#export GST_DEBUG=*:5
+
+# Download the Big Buck Bunny video if it doesn't exist
+if [[ $INPUT == "bbb.mp4" && ! -f $INPUT ]]; then
+	echo "Downloading ya boye Big Buck Bunny..."
+	wget http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4 -O bbb.mp4
+fi
+
+# Run gstreamer and pipe the output to moq-pub
+gst-launch-1.0 -v -e multifilesrc location="$INPUT" loop=true ! qtdemux name=demux \
+    demux.video_0 ! h264parse ! queue ! identity sync=true ! isofmp4mux name=mux chunk-duration=1 fragment-duration=1 ! moqsink url="$URL" namespace="$NAME" \
+    # demux.audio_0 ! aacparse ! queue ! mux.

--- a/moq-gst/src/lib.rs
+++ b/moq-gst/src/lib.rs
@@ -1,0 +1,20 @@
+use gst::glib;
+
+mod sink;
+
+pub fn plugin_init(plugin: &gst::Plugin) -> Result<(), glib::BoolError> {
+    sink::register(plugin)?;
+    Ok(())
+}
+
+gst::plugin_define!(
+    moq,
+    env!("CARGO_PKG_DESCRIPTION"),
+    plugin_init,
+    concat!(env!("CARGO_PKG_VERSION"), "-", env!("COMMIT_ID")),
+    "MIT/Apache-2.0",
+    env!("CARGO_PKG_NAME"),
+    env!("CARGO_PKG_NAME"),
+    env!("CARGO_PKG_REPOSITORY"),
+    env!("BUILD_REL_DATE")
+);

--- a/moq-gst/src/sink/imp.rs
+++ b/moq-gst/src/sink/imp.rs
@@ -1,0 +1,217 @@
+use anyhow::Context;
+use gst::glib;
+use gst::prelude::*;
+use gst::subclass::prelude::*;
+use gst_base::subclass::prelude::*;
+
+use moq_native_ietf::quic;
+use moq_native_ietf::tls;
+use moq_transport::serve::Tracks;
+use moq_transport::serve::TracksReader;
+use once_cell::sync::Lazy;
+use std::sync::Mutex;
+use url::Url;
+
+pub static RUNTIME: Lazy<tokio::runtime::Runtime> = Lazy::new(|| {
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .worker_threads(1)
+        .build()
+        .unwrap()
+});
+
+#[derive(Default)]
+struct Settings {
+    pub url: Option<String>,
+    pub namespace: Option<String>,
+    pub tls_disable_verify: bool,
+}
+
+#[derive(Default)]
+struct State {
+    pub media: Option<moq_pub::Media>,
+    pub buffer: bytes::BytesMut,
+}
+
+#[derive(Default)]
+pub struct MoqSink {
+    settings: Mutex<Settings>,
+    state: Mutex<State>,
+}
+
+#[glib::object_subclass]
+impl ObjectSubclass for MoqSink {
+    const NAME: &'static str = "MoqSink";
+    type Type = super::MoqSink;
+    type ParentType = gst_base::BaseSink;
+
+    fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl ObjectImpl for MoqSink {
+    fn properties() -> &'static [glib::ParamSpec] {
+        static PROPERTIES: Lazy<Vec<glib::ParamSpec>> = Lazy::new(|| {
+            vec![
+                glib::ParamSpecString::builder("url")
+                    .nick("URL")
+                    .blurb("Connect to the subscriber at the given URL")
+                    .build(),
+                glib::ParamSpecString::builder("namespace")
+                    .nick("Namespace")
+                    .blurb("Publish the broadcast under the given namespace")
+                    .build(),
+                glib::ParamSpecBoolean::builder("tls-disable-verify")
+                    .nick("TLS disable verify")
+                    .blurb("Disable TLS verification")
+                    .default_value(false)
+                    .build(),
+            ]
+        });
+        PROPERTIES.as_ref()
+    }
+
+    fn set_property(&self, _id: usize, value: &glib::Value, pspec: &glib::ParamSpec) {
+        let mut settings = self.settings.lock().unwrap();
+
+        match pspec.name() {
+            "url" => settings.url = Some(value.get().unwrap()),
+            "namespace" => settings.namespace = Some(value.get().unwrap()),
+            "tls-disable-verify" => settings.tls_disable_verify = value.get().unwrap(),
+            _ => unimplemented!(),
+        }
+    }
+
+    fn property(&self, _id: usize, pspec: &glib::ParamSpec) -> glib::Value {
+        let settings = self.settings.lock().unwrap();
+
+        match pspec.name() {
+            "url" => settings.url.to_value(),
+            "namespace" => settings.namespace.to_value(),
+            "tls-disable-verify" => settings.tls_disable_verify.to_value(),
+            _ => unimplemented!(),
+        }
+    }
+}
+
+impl GstObjectImpl for MoqSink {}
+
+impl ElementImpl for MoqSink {
+    fn metadata() -> Option<&'static gst::subclass::ElementMetadata> {
+        static ELEMENT_METADATA: Lazy<gst::subclass::ElementMetadata> = Lazy::new(|| {
+            gst::subclass::ElementMetadata::new(
+                "MoQ Sink",
+                "Sink",
+                "Transmits media over the network via MoQ",
+                "Luke Curley <kixelated@gmail.com>",
+            )
+        });
+
+        Some(&*ELEMENT_METADATA)
+    }
+
+    fn pad_templates() -> &'static [gst::PadTemplate] {
+        static PAD_TEMPLATES: Lazy<Vec<gst::PadTemplate>> = Lazy::new(|| {
+            let caps = gst::Caps::builder("video/quicktime")
+                .field("variant", "iso-fragmented")
+                .build();
+
+            let pad_template = gst::PadTemplate::new(
+                "sink",
+                gst::PadDirection::Sink,
+                gst::PadPresence::Always,
+                &caps,
+            )
+            .unwrap();
+
+            vec![pad_template]
+        });
+        PAD_TEMPLATES.as_ref()
+    }
+}
+
+impl BaseSinkImpl for MoqSink {
+    fn start(&self) -> Result<(), gst::ErrorMessage> {
+        let _guard = RUNTIME.enter();
+        self.setup()
+            .map_err(|e| gst::error_msg!(gst::ResourceError::Failed, ["Failed to connect: {}", e]))
+    }
+
+    fn stop(&self) -> Result<(), gst::ErrorMessage> {
+        Ok(())
+    }
+
+    fn render(&self, buffer: &gst::Buffer) -> Result<gst::FlowSuccess, gst::FlowError> {
+        let data = buffer.map_readable().map_err(|_| gst::FlowError::Error)?;
+
+        let mut state = self.state.lock().unwrap();
+
+        let mut buffer = state.buffer.split_off(0);
+        buffer.extend_from_slice(&data);
+
+        let media = state.media.as_mut().expect("not initialized");
+
+        // TODO avoid full media parsing? gst should be able to provide the necessary info
+        media.parse(&mut buffer).expect("failed to parse");
+
+        state.buffer = buffer;
+
+        Ok(gst::FlowSuccess::Ok)
+    }
+}
+
+impl MoqSink {
+    fn setup(&self) -> anyhow::Result<()> {
+        let settings = self.settings.lock().unwrap();
+        let namespace = settings.namespace.clone().context("missing namespace")?;
+        let (writer, _, reader) = Tracks::new(namespace).produce();
+
+        let mut state = self.state.lock().unwrap();
+        state.media = Some(moq_pub::Media::new(writer)?);
+
+        let url = settings.url.clone().context("missing url")?;
+        let url = url.parse().context("invalid URL")?;
+
+        // TODO support TLS certs and other options
+        let config = quic::Args {
+            bind: "[::]:0".parse().unwrap(),
+            tls: tls::Args {
+                disable_verify: settings.tls_disable_verify,
+                ..Default::default()
+            },
+        }
+        .load()?;
+        let client = quic::Endpoint::new(config)?.client;
+
+        let session = Session {
+            client,
+            url,
+            tracks: reader,
+        };
+
+        tokio::spawn(async move { session.run().await.expect("failed to run session") });
+
+        Ok(())
+    }
+}
+
+struct Session {
+    pub client: quic::Client,
+    pub url: Url,
+    pub tracks: TracksReader,
+}
+
+impl Session {
+    async fn run(self) -> anyhow::Result<()> {
+        let session = self.client.connect(&self.url).await?;
+        let (session, mut publisher) = moq_transport::session::Publisher::connect(session).await?;
+
+        tokio::select! {
+            res = publisher.announce(self.tracks) => res?,
+            res = session.run() => res?,
+        };
+
+        Ok(())
+    }
+}

--- a/moq-gst/src/sink/mod.rs
+++ b/moq-gst/src/sink/mod.rs
@@ -1,0 +1,18 @@
+use gst::glib;
+use gst::prelude::*;
+
+mod imp;
+
+glib::wrapper! {
+    pub struct MoqSink(ObjectSubclass<imp::MoqSink>) @extends gst_base::BaseSink, gst::Element, gst::Object;
+}
+
+pub fn register(plugin: &gst::Plugin) -> Result<(), glib::BoolError> {
+    env_logger::init();
+    gst::Element::register(
+        Some(plugin),
+        "moqsink",
+        gst::Rank::NONE,
+        MoqSink::static_type(),
+    )
+}


### PR DESCRIPTION
The moqsink GStreamer element depends on moq_native ([code](https://github.com/englishm/moq-rs/blob/6d1a6b788bf2a76bfac08f04e65feaa483a9d3e1/moq-gst/src/sink/imp.rs#L7)). So, it needs adjustments to make it work with the IETF version of moq-relay. This PR fixes this issue and adds moq-gst to the workspace. Initially, it was developed in a separate repo to avoid dependency on GStreamer. Let me know your thoughts.