### PR TITLE
Defend crash due to probable buffer issues while attempting to decode…

### DIFF
--- a/moq-transport/src/coding/varint.rs
+++ b/moq-transport/src/coding/varint.rs
@@ -255,6 +255,7 @@ impl Encode for u8 {
 
 impl Decode for u8 {
 	fn decode<R: bytes::Buf>(r: &mut R) -> Result<Self, DecodeError> {
+		Self::decode_remaining(r, 1)?;
 		Ok(r.get_u8())
 	}
 }


### PR DESCRIPTION
Hello Mike @englishm ,

At times crash was observed during decoding u8 while testing interop with draft-05 Publish endpoint of moq-js attempted in this [PR](https://github.com/englishm/moq-js/pull/2) , This PR holds minor change to attempt defending crash due to probable buffer issues while trying to decode u8.