### PR TITLE
MAX_SUBSCRIBE_ID control message (draft-06)

### DIFF
--- a/moq-transport/src/coding/varint.rs
+++ b/moq-transport/src/coding/varint.rs
@@ -207,13 +207,13 @@ impl Encode for VarInt {
             w.put_u8(x as u8)
         } else if x < 2u64.pow(14) {
             Self::encode_remaining(w, 2)?;
-            w.put_u16(0b01 << 14 | x as u16)
+            w.put_u16((0b01 << 14) | x as u16)
         } else if x < 2u64.pow(30) {
             Self::encode_remaining(w, 4)?;
-            w.put_u32(0b10 << 30 | x as u32)
+            w.put_u32((0b10 << 30) | x as u32)
         } else if x < 2u64.pow(62) {
             Self::encode_remaining(w, 8)?;
-            w.put_u64(0b11 << 62 | x)
+            w.put_u64((0b11 << 62) | x)
         } else {
             return Err(BoundsExceeded.into());
         }

--- a/moq-transport/src/error.rs
+++ b/moq-transport/src/error.rs
@@ -1,13 +1,12 @@
-/*
 /// An error that causes the session to close.
 #[derive(thiserror::Error, Debug)]
 pub enum SessionError {
     // Official error codes
-    #[error("closed")]
-    Closed,
+    #[error("no error")]
+    NoError,
 
     #[error("internal error")]
-    Internal,
+    InternalError,
 
     #[error("unauthorized")]
     Unauthorized,
@@ -27,12 +26,14 @@ pub enum SessionError {
     #[error("goaway timeout")]
     GoawayTimeout,
 
-
-
-
     #[error("unknown error: code={0}")]
     Unknown(u64),
     // Unofficial error codes
+}
+
+pub trait MoqError {
+    /// An integer code that is sent over the wire.
+    fn code(&self) -> u64;
 }
 
 impl MoqError for SessionError {
@@ -40,8 +41,8 @@ impl MoqError for SessionError {
     fn code(&self) -> u64 {
         match self {
             // Official error codes
-            Self::Closed => 0x0,
-            Self::Internal => 0x1,
+            Self::NoError => 0x0,
+            Self::InternalError => 0x1,
             Self::Unauthorized => 0x2,
             Self::ProtocolViolation => 0x3,
             Self::DuplicateTrackAlias => 0x4,
@@ -50,7 +51,7 @@ impl MoqError for SessionError {
             Self::GoawayTimeout => 0x10,
             Self::Unknown(code) => *code,
             // Unofficial error codes
-        })
+        }
     }
 }
 
@@ -59,13 +60,22 @@ impl MoqError for SessionError {
 pub enum SubscribeError {
     // Official error codes
     #[error("internal error")]
-    Internal,
+    InternalError,
 
     #[error("invalid range")]
     InvalidRange,
 
-    #[error("retry alias")]
-    RetryAlias,
+    #[error("retry track alias")]
+    RetryTrackAlias,
+
+    #[error("track does not exist")]
+    TrackDoesNotExist,
+
+    #[error("unauthorized")]
+    Unauthorized,
+
+    #[error("timeout")]
+    Timeout,
 
     #[error("unknown error: code={0}")]
     Unknown(u64),
@@ -77,9 +87,12 @@ impl MoqError for SubscribeError {
     fn code(&self) -> u64 {
         match self {
             // Official error codes
-            Self::Internal => 0x0,
+            Self::InternalError => 0x0,
             Self::InvalidRange => 0x1,
-            Self::RetryAlias => 0x2,
+            Self::RetryTrackAlias => 0x2,
+            Self::TrackDoesNotExist => 0x3,
+            Self::Unauthorized => 0x4,
+            Self::Timeout => 0x5,
             Self::Unknown(code) => *code,
             // Unofficial error codes
         }
@@ -94,7 +107,7 @@ pub enum SubscribeDone {
     Unsubscribed,
 
     #[error("internal error")]
-    Internal,
+    InternalError,
 
     // TODO This should be in SubscribeError
     #[error("unauthorized")]
@@ -119,9 +132,9 @@ pub enum SubscribeDone {
 
 impl From<u64> for SubscribeDone {
     fn from(code: u64) -> Self {
-        match code.into_inner() {
+        match code {
             0x0 => Self::Unsubscribed,
-            0x1 => Self::Internal,
+            0x1 => Self::InternalError,
             0x2 => Self::Unauthorized,
             0x3 => Self::TrackEnded,
             0x4 => Self::SubscriptionEnded,
@@ -138,7 +151,7 @@ impl MoqError for SubscribeDone {
         match self {
             // Official error codes
             Self::Unsubscribed => 0x0,
-            Self::Internal => 0x1,
+            Self::InternalError => 0x1,
             Self::Unauthorized => 0x2,
             Self::TrackEnded => 0x3,
             Self::SubscriptionEnded => 0x4,
@@ -149,4 +162,3 @@ impl MoqError for SubscribeDone {
         }
     }
 }
-*/

--- a/moq-transport/src/message/publisher.rs
+++ b/moq-transport/src/message/publisher.rs
@@ -50,5 +50,6 @@ publisher_msgs! {
     SubscribeOk,
     SubscribeError,
     SubscribeDone,
+    MaxSubscribeId,
     TrackStatus,
 }

--- a/moq-transport/src/session/subscriber.rs
+++ b/moq-transport/src/session/subscriber.rs
@@ -148,7 +148,7 @@ impl Subscriber {
         Ok(())
     }
 
-    fn recv_max_subscribe_id(&mut self, msg: &message::MaxSubscribeId) -> Result<(), SessionError> {
+    fn recv_max_subscribe_id(&mut self, _msg: &message::MaxSubscribeId) -> Result<(), SessionError> {
         // TODO: The Maximum Subscribe Id MUST only increase within a session,
         // and receipt of a MAX_SUBSCRIBE_ID message with an equal or smaller
         // Subscribe ID value is a 'Protocol Violation'

--- a/moq-transport/src/session/subscriber.rs
+++ b/moq-transport/src/session/subscriber.rs
@@ -148,7 +148,10 @@ impl Subscriber {
         Ok(())
     }
 
-    fn recv_max_subscribe_id(&mut self, _msg: &message::MaxSubscribeId) -> Result<(), SessionError> {
+    fn recv_max_subscribe_id(
+        &mut self,
+        _msg: &message::MaxSubscribeId,
+    ) -> Result<(), SessionError> {
         // TODO: The Maximum Subscribe Id MUST only increase within a session,
         // and receipt of a MAX_SUBSCRIBE_ID message with an equal or smaller
         // Subscribe ID value is a 'Protocol Violation'

--- a/moq-transport/src/session/subscriber.rs
+++ b/moq-transport/src/session/subscriber.rs
@@ -85,6 +85,7 @@ impl Subscriber {
             message::Publisher::SubscribeOk(msg) => self.recv_subscribe_ok(msg),
             message::Publisher::SubscribeError(msg) => self.recv_subscribe_error(msg),
             message::Publisher::SubscribeDone(msg) => self.recv_subscribe_done(msg),
+            message::Publisher::MaxSubscribeId(msg) => self.recv_max_subscribe_id(msg),
             message::Publisher::TrackStatus(msg) => self.recv_track_status(msg),
         };
 
@@ -144,6 +145,14 @@ impl Subscriber {
             subscribe.error(ServeError::Closed(msg.code))?;
         }
 
+        Ok(())
+    }
+
+    fn recv_max_subscribe_id(&mut self, msg: &message::MaxSubscribeId) -> Result<(), SessionError> {
+        // TODO: The Maximum Subscribe Id MUST only increase within a session,
+        // and receipt of a MAX_SUBSCRIBE_ID message with an equal or smaller
+        // Subscribe ID value is a 'Protocol Violation'
+        // The session should be accessible here to check the max_subscribe_id
         Ok(())
     }
 


### PR DESCRIPTION
This change adds the MAX_SUBSCRIBE_ID control message. 
However, it doesn't validate it. We'll revisit this while implementing draft-08.
Related issue: #25 
