### PR TITLE
Added required fields for announce_cancel (draft-06)

### DIFF
--- a/moq-transport/src/message/announce_cancel.rs
+++ b/moq-transport/src/message/announce_cancel.rs
@@ -6,22 +6,21 @@ pub struct AnnounceCancel {
     // Echo back the namespace that was reset
     pub namespace: Tuple,
     // An error code.
-    //pub code: u64,
-
+    pub error_code: u64,
     // An optional, human-readable reason.
-    //pub reason: String,
+    pub reason_phrase: String,
 }
 
 impl Decode for AnnounceCancel {
     fn decode<R: bytes::Buf>(r: &mut R) -> Result<Self, DecodeError> {
         let namespace = Tuple::decode(r)?;
-        //let code = u64::decode(r)?;
-        //let reason = String::decode(r)?;
+        let error_code = u64::decode(r)?;
+        let reason_phrase = String::decode(r)?;
 
         Ok(Self {
             namespace,
-            //code,
-            //reason,
+            error_code,
+            reason_phrase,
         })
     }
 }
@@ -29,8 +28,8 @@ impl Decode for AnnounceCancel {
 impl Encode for AnnounceCancel {
     fn encode<W: bytes::BufMut>(&self, w: &mut W) -> Result<(), EncodeError> {
         self.namespace.encode(w)?;
-        //self.code.encode(w)?;
-        //self.reason.encode(w)?;
+        self.error_code.encode(w)?;
+        self.reason_phrase.encode(w)?;
 
         Ok(())
     }

--- a/moq-transport/src/message/announce_error.rs
+++ b/moq-transport/src/message/announce_error.rs
@@ -7,22 +7,22 @@ pub struct AnnounceError {
     pub namespace: Tuple,
 
     // An error code.
-    pub code: u64,
+    pub error_code: u64,
 
     // An optional, human-readable reason.
-    pub reason: String,
+    pub reason_phrase: String,
 }
 
 impl Decode for AnnounceError {
     fn decode<R: bytes::Buf>(r: &mut R) -> Result<Self, DecodeError> {
         let namespace = Tuple::decode(r)?;
-        let code = u64::decode(r)?;
-        let reason = String::decode(r)?;
+        let error_code = u64::decode(r)?;
+        let reason_phrase = String::decode(r)?;
 
         Ok(Self {
             namespace,
-            code,
-            reason,
+            error_code,
+            reason_phrase,
         })
     }
 }
@@ -30,8 +30,8 @@ impl Decode for AnnounceError {
 impl Encode for AnnounceError {
     fn encode<W: bytes::BufMut>(&self, w: &mut W) -> Result<(), EncodeError> {
         self.namespace.encode(w)?;
-        self.code.encode(w)?;
-        self.reason.encode(w)?;
+        self.error_code.encode(w)?;
+        self.reason_phrase.encode(w)?;
 
         Ok(())
     }

--- a/moq-transport/src/session/announced.rs
+++ b/moq-transport/src/session/announced.rs
@@ -83,15 +83,18 @@ impl Drop for Announced {
     fn drop(&mut self) {
         let err = self.error.clone().unwrap_or(ServeError::Done);
 
+        // TODO: Not sure if the error code is correct.
         if self.ok {
             self.session.send_message(message::AnnounceCancel {
                 namespace: self.namespace.clone(),
+                error_code: 0_u64,
+                reason_phrase: "".into(),
             });
         } else {
             self.session.send_message(message::AnnounceError {
                 namespace: self.namespace.clone(),
-                code: err.code(),
-                reason: err.to_string(),
+                error_code: err.code(),
+                reason_phrase: err.to_string(),
             });
         }
     }

--- a/moq-transport/src/session/publisher.rs
+++ b/moq-transport/src/session/publisher.rs
@@ -202,13 +202,15 @@ impl Publisher {
 
     fn recv_announce_error(&mut self, msg: message::AnnounceError) -> Result<(), SessionError> {
         if let Some(announce) = self.announces.lock().unwrap().remove(&msg.namespace) {
-            announce.recv_error(ServeError::Closed(msg.code))?;
+            announce.recv_error(ServeError::Closed(msg.error_code))?;
         }
 
         Ok(())
     }
 
     fn recv_announce_cancel(&mut self, msg: message::AnnounceCancel) -> Result<(), SessionError> {
+        // TODO: If a publisher receives new subscriptions for that namespace after receiving an ANNOUNCE_CANCEL,
+        // it SHOULD close the session as a 'Protocol Violation'.
         if let Some(announce) = self.announces.lock().unwrap().remove(&msg.namespace) {
             announce.recv_error(ServeError::Cancel)?;
         }


### PR DESCRIPTION
This pull request adds the required fields (error_code and reason_phrase) to the ANNOUNCE_CANCEL message. Also, fixes the naming for ANNOUNCE message.

Related #25.