### PR TITLE
Fix filter type handling in Subscribe encoding

### DIFF
--- a/moq-transport/src/message/subscribe.rs
+++ b/moq-transport/src/message/subscribe.rs
@@ -113,14 +113,18 @@ impl Encode for Subscribe {
         if self.filter_type == FilterType::AbsoluteStart
             || self.filter_type == FilterType::AbsoluteRange
         {
-            if self.start.is_none() || self.end.is_none() {
-                return Err(EncodeError::MissingField);
-            }
             if let Some(start) = &self.start {
                 start.encode(w)?;
+            } else {
+                return Err(EncodeError::MissingField);
             }
+        }
+
+        if self.filter_type == FilterType::AbsoluteRange {
             if let Some(end) = &self.end {
                 end.encode(w)?;
+            } else {
+                return Err(EncodeError::MissingField);
             }
         }
 


### PR DESCRIPTION
## Brief description
According to the draft, the `EndGroup` must only be specified when the filter type is set to `AbsoluteRange`, while `StartGroup` must be present for both `AbsoluteStart` and `AbsoluteRange`.

Despite this, the encoding of this in [message/subscribe.rs](https://github.com/englishm/moq-rs/blob/ebc843de8504e37d36c3134a1181513ebdf7a34a/moq-transport/src/message/subscribe.rs#L113-L118) requires the `EndGroup` to be present for both of the mentioned filter types.

## Relevant parts of the draft

[link](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-10#section-8.6-6)
> AbsoluteStart (0x3): Specifies an open-ended subscription beginning from the object identified in the StartGroup and StartObject fields. If the StartGroup is prior to the current group, the subscription starts at the beginning of the current object like the 'Latest Object' filter.

[link](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-10#section-8.6-12.8.1)
> StartGroup: The start Group ID. Only present for "AbsoluteStart" and "AbsoluteRange" filter types.

[link](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-10#section-8.6-12.10.1)
> EndGroup: The end Group ID, inclusive. Only present for the "AbsoluteRange" filter type.