### PR TITLE
Avoid out-of-bounds panics

### DIFF
--- a/moq-transport/src/serve/stream.rs
+++ b/moq-transport/src/serve/stream.rs
@@ -303,7 +303,7 @@ impl StreamGroupReader {
         loop {
             {
                 let state = self.state.lock();
-                if self.index < state.objects.len() {
+                if self.index < state.objects.len() - 1 {
                     self.index += 1;
                     return Ok(Some(state.objects[self.index].clone()));
                 }


### PR DESCRIPTION
The logic here pretty clearly allows situations where the access to `state.objects` will be out of bounds.  This PR just makes the obvious fix to keep `state.index` in-bounds.