### PR TITLE
Add basic qlog support and other logging improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ target/
 logs/
 *.mp4
 result
+qlog/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,29 +130,25 @@ checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.7.1"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8487b59d62764df8231cb371c459314df895b41756df457a1fb1243d65c89195"
+checksum = "5c953fe1ba023e6b7730c0d4b031d06f267f23a46167dcbd40316644b10a17ba"
 dependencies = [
  "aws-lc-sys",
- "mirai-annotations",
- "paste",
  "zeroize",
 ]
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.16.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c15eb61145320320eb919d9bab524617a7aa4216c78d342fae3a758bc33073e4"
+checksum = "dbfd150b5dbdb988bcc8fb1fe787eb6b7ee6180ca24da683b61ea5405f3d43ff"
 dependencies = [
  "bindgen",
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
- "libc",
- "paste",
 ]
 
 [[package]]
@@ -242,9 +238,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bindgen"
-version = "0.69.4"
+version = "0.69.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
+checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
 dependencies = [
  "bitflags 2.9.4",
  "cexpr",
@@ -295,13 +291,14 @@ checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
 name = "cc"
-version = "1.0.97"
+version = "1.2.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099a5357d84c4c61eb35fc8eafa9a79a902c2f76911e5747ced4e032edd8d9b4"
+checksum = "e1d05d92f4b1fd76aad469d46cdd858ca761576082cd37df81416691e50199fb"
 dependencies = [
+ "find-msvc-tools",
  "jobserver",
  "libc",
- "once_cell",
+ "shlex",
 ]
 
 [[package]]
@@ -324,6 +321,12 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -506,10 +509,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastbloom"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18c1ddb9231d8554c2d6bdf4cfaabf0c59251658c68b6c95cd52dd0c513a912a"
+dependencies = [
+ "getrandom 0.3.3",
+ "libm",
+ "rand",
+ "siphasher",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0399f9d26e5191ce32c498bebd31e7a3ceabc2745f0ac54af3f335126c3f24b3"
 
 [[package]]
 name = "fnv"
@@ -649,8 +670,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi",
+ "wasi 0.14.7+wasi-0.2.4",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -822,7 +859,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "pin-project-lite",
- "rustls 0.23.7",
+ "rustls 0.23.31",
  "rustls-pemfile",
  "rustls-pki-types",
  "tokio",
@@ -939,16 +976,18 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "jni"
-version = "0.19.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6df18c2e3db7e453d3c6ac5b3e9d5182664d28788126d39b91f2d1e22b017ec"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
 dependencies = [
  "cesu8",
+ "cfg-if",
  "combine",
  "jni-sys",
  "log",
- "thiserror",
+ "thiserror 1.0.61",
  "walkdir",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -968,10 +1007,11 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.69"
+version = "0.3.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
+checksum = "ec48937a97411dcb524a265206ccd4c90bb711fca92b2792c407f268825b9305"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
@@ -1000,8 +1040,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1024,6 +1070,12 @@ name = "log"
 version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "matchit"
@@ -1065,15 +1117,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.48.0",
 ]
-
-[[package]]
-name = "mirai-annotations"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9be0862c1b3f26a88803c4a49de6889c10e608b3ee9344e6ef5b45fb37ad3d1"
 
 [[package]]
 name = "moq-api"
@@ -1088,7 +1134,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.61",
  "tokio",
  "url",
 ]
@@ -1129,7 +1175,7 @@ dependencies = [
  "moq-transport",
  "quinn",
  "ring",
- "rustls 0.23.7",
+ "rustls 0.23.31",
  "rustls-native-certs 0.7.0",
  "rustls-pemfile",
  "tokio",
@@ -1209,7 +1255,7 @@ dependencies = [
  "futures",
  "log",
  "paste",
- "thiserror",
+ "thiserror 1.0.61",
  "tokio",
  "web-transport",
 ]
@@ -1225,7 +1271,7 @@ dependencies = [
  "num-rational",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.61",
 ]
 
 [[package]]
@@ -1487,59 +1533,68 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quinn"
-version = "0.11.0"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bb80dc034523335a9fcc34271931dd97e9132d1fb078695db500339eb72e712"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
 dependencies = [
  "bytes",
+ "cfg_aliases",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 1.1.0",
- "rustls 0.23.7",
- "thiserror",
+ "rustc-hash 2.0.0",
+ "rustls 0.23.31",
+ "socket2 0.6.0",
+ "thiserror 2.0.17",
  "tokio",
  "tracing",
+ "web-time",
 ]
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.8"
+version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fadfaed2cd7f389d0161bb73eeb07b7b78f8691047a6f3e73caaeae55310a4a6"
+checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
 dependencies = [
  "bytes",
+ "fastbloom",
+ "getrandom 0.3.3",
+ "lru-slab",
  "rand",
  "ring",
  "rustc-hash 2.0.0",
- "rustls 0.23.7",
+ "rustls 0.23.31",
+ "rustls-pki-types",
  "rustls-platform-verifier",
  "slab",
- "thiserror",
+ "thiserror 2.0.17",
  "tinyvec",
  "tracing",
+ "web-time",
 ]
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.0"
+version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7ad7bc932e4968523fa7d9c320ee135ff779de720e9350fee8728838551764"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
 dependencies = [
+ "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.7",
+ "socket2 0.6.0",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1552,21 +1607,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand"
-version = "0.8.5"
+name = "r-efi"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "libc",
  "rand_chacha",
  "rand_core",
 ]
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core",
@@ -1574,11 +1634,11 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.4"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.3",
 ]
 
 [[package]]
@@ -1598,7 +1658,7 @@ dependencies = [
  "num-bigint",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.23.7",
+ "rustls 0.23.31",
  "rustls-native-certs 0.8.1",
  "ryu",
  "sha1_smol",
@@ -1712,7 +1772,7 @@ checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "libc",
  "spin",
  "untrusted",
@@ -1759,23 +1819,23 @@ dependencies = [
  "log",
  "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.102.4",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.7"
+version = "0.23.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebbbdb961df0ad3f2652da8f3fdc4b36122f568f968f45ad3316f26c025c677b"
+checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
 dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.103.4",
  "subtle",
  "zeroize",
 ]
@@ -1821,28 +1881,29 @@ version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.3.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5f0d26fa1ce3c790f9590868f0109289a044acb954525f933e2aa3b871c157d"
+checksum = "be59af91596cac372a6942530653ad0c3a246cdd491aaa9dcaee47f88d67d5a0"
 dependencies = [
- "core-foundation 0.9.4",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.7",
- "rustls-native-certs 0.7.0",
+ "rustls 0.23.31",
+ "rustls-native-certs 0.8.1",
  "rustls-platform-verifier-android",
- "rustls-webpki",
- "security-framework 2.11.0",
+ "rustls-webpki 0.103.4",
+ "security-framework 3.4.0",
  "security-framework-sys",
- "webpki-roots",
- "winapi",
+ "webpki-root-certs",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1856,6 +1917,17 @@ name = "rustls-webpki"
 version = "0.102.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff448f7e92e913c4b7d4c6d8e4540a1724b319b4152b8aef6d4cf8339712b33e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -1909,7 +1981,6 @@ dependencies = [
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
- "num-bigint",
  "security-framework-sys",
 ]
 
@@ -2020,6 +2091,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "siphasher"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2074,9 +2151,9 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
-version = "2.0.70"
+version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0209b68b3613b093e0ec905354eccaedcfe83b8cb37cbdeae64026c3064c16"
+checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2134,7 +2211,16 @@ version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.61",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+dependencies = [
+ "thiserror-impl 2.0.17",
 ]
 
 [[package]]
@@ -2142,6 +2228,17 @@ name = "thiserror-impl"
 version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2230,7 +2327,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
- "rustls 0.23.7",
+ "rustls 0.23.31",
  "rustls-pki-types",
  "tokio",
 ]
@@ -2439,24 +2536,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.92"
+name = "wasi"
+version = "0.14.7+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1da10c01ae9f1ae40cbfac0bac3b1e724b320abfcf52229f80b547c0d250e2d"
 dependencies = [
  "cfg-if",
+ "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.92"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
+checksum = "671c9a5a66f49d8a47345ab942e2cb93c7d1d0339065d4f8139c486121b43b19"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
  "syn",
@@ -2477,9 +2594,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.92"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+checksum = "7ca60477e4c59f5f2986c50191cd972e3a50d8a95603bc9434501cf156a9a119"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2487,9 +2604,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.92"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+checksum = "9f07d2f20d4da7b26400c9f4a0511e6e0345b040694e8a75bd41d578fa4421d7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2500,9 +2617,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.92"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+checksum = "bad67dc8b2a1a6e5448428adec4c3e84c43e561d8c9ee8a9e5aabeb193ec41d1"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "web-sys"
@@ -2515,13 +2635,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web-transport"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5793aee9b4cf993212042c6b1656d877de9ad32b9eb3281d7bc95f4dce3f6591"
 dependencies = [
  "bytes",
- "thiserror",
+ "thiserror 1.0.61",
  "web-transport-quinn",
  "web-transport-wasm",
 ]
@@ -2534,7 +2664,7 @@ checksum = "df0922f754c890ceb9741c00a0f5c730aaa4b52fe8772934a0ad19a03daee0ca"
 dependencies = [
  "bytes",
  "http",
- "thiserror",
+ "thiserror 1.0.61",
  "url",
 ]
 
@@ -2550,7 +2680,7 @@ dependencies = [
  "log",
  "quinn",
  "quinn-proto",
- "thiserror",
+ "thiserror 1.0.61",
  "tokio",
  "url",
  "web-transport-proto",
@@ -2577,6 +2707,15 @@ checksum = "ed63aea5ce73d0ff405984102c42de94fc55a6b75765d621c65262469b3c9b53"
 dependencies = [
  "ring",
  "untrusted",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e4ffd8df1c57e87c325000a3d6ef93db75279dc3a231125aac571650f22b12a"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -2642,6 +2781,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -2665,6 +2813,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -2700,6 +2863,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -2712,6 +2881,12 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -2721,6 +2896,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2742,6 +2923,12 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -2751,6 +2938,12 @@ name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2766,6 +2959,12 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -2775,6 +2974,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2797,6 +3002,12 @@ dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "zeroize"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -449,6 +449,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dunce"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -926,6 +961,12 @@ checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -1541,6 +1582,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "qlog"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f15b83c59e6b945f2261c95a1dd9faf239187f32ff0a96af1d1d28c4557f919"
+dependencies = [
+ "serde",
+ "serde_json",
+ "serde_with",
+ "smallvec",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1570,6 +1623,7 @@ dependencies = [
  "fastbloom",
  "getrandom 0.3.3",
  "lru-slab",
+ "qlog",
  "rand",
  "ring",
  "rustc-hash 2.0.0",
@@ -2033,6 +2087,7 @@ version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
 dependencies = [
+ "indexmap",
  "itoa",
  "ryu",
  "serde",
@@ -2058,6 +2113,29 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2c45cd61fefa9db6f254525d46e392b852e0e61d9a1fd36e5bd183450a556d5"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "serde_with_macros",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de90945e6565ce0d9a25098082ed4ee4002e047cb59892c318d66821e14bb30f"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2110,6 +2188,9 @@ name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"

--- a/deploy/QLOG_SETUP.md
+++ b/deploy/QLOG_SETUP.md
@@ -1,0 +1,76 @@
+# Qlog Setup on Fly.io
+
+This guide explains how to enable qlog logging for your moq-relay deployment on Fly.io.
+
+## What is Qlog?
+
+Qlog is a structured logging format for QUIC connections that captures detailed protocol-level events. The qlog files can be visualized using tools like [qvis.quictools.info](https://qvis.quictools.info/).
+
+## Quick Start (Ephemeral Storage)
+
+Qlog is **enabled by default** and writes to `/tmp/qlog` (ephemeral storage).
+
+### Deploy
+
+```bash
+fly deploy
+```
+
+### Verify
+
+Check the logs to confirm qlog is enabled:
+
+```bash
+fly logs
+```
+
+You should see:
+```
+qlog enabled: writing to /tmp/qlog
+[INFO moq_native_ietf::quic] qlog output enabled: /tmp/qlog
+```
+
+### Access qlog files
+
+SSH into a Machine and list the qlog files:
+
+```bash
+fly ssh console
+ls -lh /tmp/qlog/
+```
+
+Download a qlog file to analyze:
+
+```bash
+fly ssh sftp get /tmp/qlog/<connection_id>_server.qlog
+```
+
+Then upload to [qvis.quictools.info](https://qvis.quictools.info/) for visualization.
+
+### Disabling Qlog
+
+To disable qlog, remove or comment out the `QLOG_DIR` environment variable in `fly.toml`:
+
+```toml
+[env]
+# QLOG_DIR="/tmp/qlog"
+```
+
+Then redeploy:
+
+```bash
+fly deploy
+```
+
+## Important Notes
+
+**Ephemeral Storage**: Files in `/tmp/qlog/` are **lost on restart/redeploy**. This is fine for debugging but not suitable for long-term logging.
+
+**For Persistent Storage**: If you need qlog files to survive restarts, set up Fly Volumes:
+1. Create volumes: `fly volumes create qlog_data --region <region> --size 1` (one per Machine)
+2. Add mount in `fly.toml`: `[mounts] source = "qlog_data", destination = "/data"`
+3. Change `QLOG_DIR="/data/qlog"`
+
+**File Names**: Qlog files are named using the QUIC Connection ID: `<cid>_server.qlog`
+
+**Disk Usage**: Each connection creates one qlog file. Files accumulate until restart. Monitor with `du -sh /tmp/qlog/` if running for extended periods.

--- a/deploy/fly-relay.sh
+++ b/deploy/fly-relay.sh
@@ -8,4 +8,12 @@ mkdir cert
 echo "$MOQ_CRT" | base64 -d > dev/moq-demo.crt
 echo "$MOQ_KEY" | base64 -d > dev/moq-demo.key
 
-moq-relay-ietf --bind "[::]:${PORT}" --tls-cert dev/moq-demo.crt --tls-key dev/moq-demo.key
+# Set up qlog directory if QLOG_DIR is set
+QLOG_ARGS=""
+if [ -n "${QLOG_DIR}" ]; then
+    mkdir -p "${QLOG_DIR}"
+    QLOG_ARGS="--qlog-dir ${QLOG_DIR}"
+    echo "qlog enabled: writing to ${QLOG_DIR}"
+fi
+
+moq-relay-ietf --bind "[::]:${PORT}" --tls-cert dev/moq-demo.crt --tls-key dev/moq-demo.key ${QLOG_ARGS}

--- a/dev/relay
+++ b/dev/relay
@@ -19,6 +19,15 @@ KEY="${KEY:-dev/localhost.key}"
 PORT="${PORT:-4443}"
 BIND="${BIND:-[::]:$PORT}"
 
+# Enable qlog logging if QLOG_DIR is set
+QLOG_DIR="${QLOG_DIR:-}"
+if [ -n "$QLOG_DIR" ]; then
+	QLOG="--qlog-dir $QLOG_DIR"
+else
+	QLOG=""
+fi
+
+
 # A list of optional args
 ARGS=""
 
@@ -36,4 +45,4 @@ fi
 echo "Publish URL: https://quic.video/publish/?server=localhost:$PORT"
 
 # Run the relay and forward any arguments
-cargo run --bin moq-relay-ietf -- --bind "$BIND" --tls-cert "$CERT" --tls-key "$KEY" --dev $ARGS -- "$@"
+cargo run --bin moq-relay-ietf -- --bind "$BIND" --tls-cert "$CERT" --tls-key "$KEY" --dev $QLOG $ARGS -- "$@"

--- a/dev/relay
+++ b/dev/relay
@@ -45,4 +45,4 @@ fi
 echo "Publish URL: https://quic.video/publish/?server=localhost:$PORT"
 
 # Run the relay and forward any arguments
-cargo run --bin moq-relay-ietf -- --bind "$BIND" --tls-cert "$CERT" --tls-key "$KEY" --dev $QLOG $ARGS -- "$@"
+cargo run --bin moq-relay-ietf -- --bind "$BIND" --tls-cert "$CERT" --tls-key "$KEY" --dev $QLOG $ARGS "$@"

--- a/fly.toml
+++ b/fly.toml
@@ -5,6 +5,8 @@ kill_timeout = 5
 [env]
 PORT = "443"
 RUST_LOG="info"
+# Qlog files for debugging (ephemeral - lost on restart)
+QLOG_DIR="/tmp/qlog"
 
 [experimental]
 cmd = "./fly-relay.sh"

--- a/moq-clock-ietf/src/main.rs
+++ b/moq-clock-ietf/src/main.rs
@@ -55,6 +55,7 @@ async fn main() -> anyhow::Result<()> {
 
     let quic = quic::Endpoint::new(quic::Config {
         bind: config.bind,
+        qlog_dir: None,
         tls,
     })?;
 

--- a/moq-native-ietf/Cargo.toml
+++ b/moq-native-ietf/Cargo.toml
@@ -19,7 +19,7 @@ web-transport-quinn = "0.3"
 rustls = { version = "0.23", features = ["ring"] }
 rustls-pemfile = "2"
 rustls-native-certs = "0.7"
-quinn = { version = "0.11.9", features = ["ring"] }
+quinn = { version = "0.11.9", features = ["ring", "qlog"] }
 ring = "0.17"
 webpki = "0.22"
 

--- a/moq-native-ietf/Cargo.toml
+++ b/moq-native-ietf/Cargo.toml
@@ -19,7 +19,7 @@ web-transport-quinn = "0.3"
 rustls = { version = "0.23", features = ["ring"] }
 rustls-pemfile = "2"
 rustls-native-certs = "0.7"
-quinn = { version = "0.11", features = ["ring"] }
+quinn = { version = "0.11.9", features = ["ring"] }
 ring = "0.17"
 webpki = "0.22"
 

--- a/moq-native-ietf/src/quic.rs
+++ b/moq-native-ietf/src/quic.rs
@@ -58,6 +58,17 @@ pub struct Endpoint {
 
 impl Endpoint {
     pub fn new(config: Config) -> anyhow::Result<Self> {
+        // Validate qlog directory if provided
+        if let Some(qlog_dir) = &config.qlog_dir {
+            if !qlog_dir.exists() {
+                anyhow::bail!("qlog directory does not exist: {}", qlog_dir.display());
+            }
+            if !qlog_dir.is_dir() {
+                anyhow::bail!("qlog path is not a directory: {}", qlog_dir.display());
+            }
+            log::info!("qlog output enabled: {}", qlog_dir.display());
+        }
+
         // Enable BBR congestion control
         // TODO validate the implementation
         let mut transport = quinn::TransportConfig::default();

--- a/moq-native-ietf/src/quic.rs
+++ b/moq-native-ietf/src/quic.rs
@@ -1,4 +1,4 @@
-use std::{net, sync::Arc, time};
+use std::{net, path::PathBuf, sync::Arc, time};
 
 use anyhow::Context;
 use clap::Parser;
@@ -16,6 +16,10 @@ pub struct Args {
     #[arg(long, default_value = "[::]:0")]
     pub bind: net::SocketAddr,
 
+    /// Directory to write qlog files (one per connection)
+    #[arg(long)]
+    pub qlog_dir: Option<PathBuf>,
+
     #[command(flatten)]
     pub tls: tls::Args,
 }
@@ -24,6 +28,7 @@ impl Default for Args {
     fn default() -> Self {
         Self {
             bind: "[::]:0".parse().unwrap(),
+            qlog_dir: None,
             tls: Default::default(),
         }
     }
@@ -34,6 +39,7 @@ impl Args {
         let tls = self.tls.load()?;
         Ok(Config {
             bind: self.bind,
+            qlog_dir: self.qlog_dir.clone(),
             tls,
         })
     }
@@ -41,6 +47,7 @@ impl Args {
 
 pub struct Config {
     pub bind: net::SocketAddr,
+    pub qlog_dir: Option<PathBuf>,
     pub tls: tls::Config,
 }
 

--- a/moq-pub/src/main.rs
+++ b/moq-pub/src/main.rs
@@ -59,6 +59,7 @@ async fn main() -> anyhow::Result<()> {
 
     let quic = quic::Endpoint::new(moq_native_ietf::quic::Config {
         bind: cli.bind,
+        qlog_dir: None,
         tls: tls.clone(),
     })?;
 

--- a/moq-relay-ietf/src/main.rs
+++ b/moq-relay-ietf/src/main.rs
@@ -18,7 +18,7 @@ pub use remote::*;
 pub use session::*;
 pub use web::*;
 
-use std::net;
+use std::{net, path::PathBuf};
 use url::Url;
 
 #[derive(Parser, Clone)]
@@ -30,6 +30,10 @@ pub struct Cli {
     /// The TLS configuration.
     #[command(flatten)]
     pub tls: moq_native_ietf::tls::Args,
+
+    /// Directory to write qlog files (one per connection)
+    #[arg(long)]
+    pub qlog_dir: Option<PathBuf>,
 
     /// Forward all announces to the provided server for authentication/routing.
     /// If not provided, the relay accepts every unique announce.
@@ -73,6 +77,7 @@ async fn main() -> anyhow::Result<()> {
     let relay = Relay::new(RelayConfig {
         tls: tls.clone(),
         bind: cli.bind,
+        qlog_dir: cli.qlog_dir,
         node: cli.node,
         api: cli.api,
         announce: cli.announce,

--- a/moq-relay-ietf/src/relay.rs
+++ b/moq-relay-ietf/src/relay.rs
@@ -1,4 +1,4 @@
-use std::net;
+use std::{net, path::PathBuf};
 
 use anyhow::Context;
 
@@ -14,6 +14,9 @@ pub struct RelayConfig {
 
     /// The TLS configuration.
     pub tls: moq_native_ietf::tls::Config,
+
+    /// Directory to write qlog files (one per connection)
+    pub qlog_dir: Option<PathBuf>,
 
     /// Forward all announcements to the (optional) URL.
     pub announce: Option<Url>,
@@ -39,7 +42,7 @@ impl Relay {
     pub fn new(config: RelayConfig) -> anyhow::Result<Self> {
         let quic = quic::Endpoint::new(quic::Config {
             bind: config.bind,
-            qlog_dir: None, // TODO: Pass through from CLI
+            qlog_dir: config.qlog_dir,
             tls: config.tls,
         })?;
 

--- a/moq-relay-ietf/src/relay.rs
+++ b/moq-relay-ietf/src/relay.rs
@@ -39,6 +39,7 @@ impl Relay {
     pub fn new(config: RelayConfig) -> anyhow::Result<Self> {
         let quic = quic::Endpoint::new(quic::Config {
             bind: config.bind,
+            qlog_dir: None, // TODO: Pass through from CLI
             tls: config.tls,
         })?;
 

--- a/moq-relay-ietf/src/web.rs
+++ b/moq-relay-ietf/src/web.rs
@@ -80,7 +80,6 @@ impl Web {
 async fn serve_fingerprint(State(state): State<WebState>) -> impl IntoResponse {
     state.fingerprint
 }
-
 async fn serve_qlog(
     Path(cid): Path<String>,
     State(state): State<WebState>,
@@ -91,8 +90,11 @@ async fn serve_qlog(
         "Qlog serving not enabled".to_string(),
     ))?;
 
+    // Strip _server.qlog suffix if present to get the base CID
+    let base_cid = cid.strip_suffix("_server.qlog").unwrap_or(&cid);
+
     // Construct the expected filename
-    let filename = format!("{}_server.qlog", cid);
+    let filename = format!("{}_server.qlog", base_cid);
     let file_path = qlog_dir.join(&filename);
 
     // Security: Ensure the path is still within qlog_dir (prevent path traversal)

--- a/moq-relay-ietf/src/web.rs
+++ b/moq-relay-ietf/src/web.rs
@@ -1,12 +1,25 @@
-use std::{net, sync::Arc};
+use std::{net, path::PathBuf, sync::Arc};
 
-use axum::{extract::State, http::Method, response::IntoResponse, routing::get, Router};
+use axum::{
+    extract::{Path, State},
+    http::{Method, StatusCode},
+    response::IntoResponse,
+    routing::get,
+    Router,
+};
 use hyper_serve::tls_rustls::RustlsAcceptor;
 use tower_http::cors::{Any, CorsLayer};
 
 pub struct WebConfig {
     pub bind: net::SocketAddr,
     pub tls: moq_native_ietf::tls::Config,
+    pub qlog_dir: Option<PathBuf>,
+}
+
+#[derive(Clone)]
+struct WebState {
+    fingerprint: String,
+    qlog_dir: Option<Arc<PathBuf>>,
 }
 
 // Run a HTTP server using Axum
@@ -31,14 +44,27 @@ impl Web {
         tls.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
         let tls = hyper_serve::tls_rustls::RustlsConfig::from_config(Arc::new(tls));
 
-        let app = Router::new()
-            .route("/fingerprint", get(serve_fingerprint))
-            .layer(
-                CorsLayer::new()
-                    .allow_origin(Any)
-                    .allow_methods([Method::GET]),
-            )
-            .with_state(fingerprint);
+        // Create shared state
+        let state = WebState {
+            fingerprint,
+            qlog_dir: config.qlog_dir.map(Arc::new),
+        };
+
+        // Build router with fingerprint endpoint
+        let mut app = Router::new().route("/fingerprint", get(serve_fingerprint));
+
+        // Optionally add qlog serving endpoint
+        if state.qlog_dir.is_some() {
+            app = app.route("/qlog/:cid", get(serve_qlog));
+            log::info!("qlog files available at /qlog/:cid");
+        }
+
+        // Add state and CORS layer
+        let app = app.with_state(state).layer(
+            CorsLayer::new()
+                .allow_origin(Any)
+                .allow_methods([Method::GET]),
+        );
 
         let server = hyper_serve::bind_rustls(config.bind, tls);
 
@@ -51,6 +77,48 @@ impl Web {
     }
 }
 
-async fn serve_fingerprint(State(fingerprint): State<String>) -> impl IntoResponse {
-    fingerprint
+async fn serve_fingerprint(State(state): State<WebState>) -> impl IntoResponse {
+    state.fingerprint
+}
+
+async fn serve_qlog(
+    Path(cid): Path<String>,
+    State(state): State<WebState>,
+) -> Result<Vec<u8>, (StatusCode, String)> {
+    // Get qlog directory or return 404
+    let qlog_dir = state.qlog_dir.as_ref().ok_or((
+        StatusCode::NOT_FOUND,
+        "Qlog serving not enabled".to_string(),
+    ))?;
+
+    // Construct the expected filename
+    let filename = format!("{}_server.qlog", cid);
+    let file_path = qlog_dir.join(&filename);
+
+    // Security: Ensure the path is still within qlog_dir (prevent path traversal)
+    let canonical_dir = qlog_dir.canonicalize().map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("Invalid qlog directory: {}", e),
+        )
+    })?;
+
+    let canonical_file = file_path.canonicalize().map_err(|_| {
+        (
+            StatusCode::NOT_FOUND,
+            format!("Qlog file not found: {}", filename),
+        )
+    })?;
+
+    if !canonical_file.starts_with(&canonical_dir) {
+        return Err((StatusCode::FORBIDDEN, "Invalid path".to_string()));
+    }
+
+    // Read and return the file
+    tokio::fs::read(&canonical_file).await.map_err(|e| {
+        (
+            StatusCode::NOT_FOUND,
+            format!("Failed to read qlog file: {}", e),
+        )
+    })
 }

--- a/moq-sub/src/main.rs
+++ b/moq-sub/src/main.rs
@@ -24,6 +24,7 @@ async fn main() -> anyhow::Result<()> {
     let tls = config.tls.load()?;
     let quic = quic::Endpoint::new(quic::Config {
         bind: config.bind,
+        qlog_dir: None,
         tls,
     })?;
 

--- a/moq-transport/src/coding/hex_dump.rs
+++ b/moq-transport/src/coding/hex_dump.rs
@@ -1,0 +1,72 @@
+/// Utility functions for debugging byte sequences
+
+/// Format bytes as a hex string with spaces between bytes
+/// Example: [0x01, 0x02, 0x03] => "01 02 03"
+pub fn format_hex(data: &[u8]) -> String {
+    data.iter()
+        .map(|b| format!("{:02x}", b))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Format bytes as a hex string with detailed information
+/// Similar to hexdump output but more compact
+/// Example output: "01 02 03 04 05  |.....|"
+pub fn format_hex_detailed(data: &[u8], max_bytes: usize) -> String {
+    let truncated = data.len() > max_bytes;
+    let display_data = if truncated {
+        &data[..max_bytes]
+    } else {
+        data
+    };
+
+    let hex_part = display_data
+        .iter()
+        .map(|b| format!("{:02x}", b))
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    let ascii_part: String = display_data
+        .iter()
+        .map(|&b| {
+            if b >= 32 && b <= 126 {
+                b as char
+            } else {
+                '.'
+            }
+        })
+        .collect();
+
+    if truncated {
+        format!("{} ... (truncated, total {} bytes)  |{}...|", 
+                hex_part, data.len(), ascii_part)
+    } else {
+        format!("{}  |{}|", hex_part, ascii_part)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_format_hex() {
+        let data = vec![0x01, 0x02, 0x03, 0x10, 0xff];
+        assert_eq!(format_hex(&data), "01 02 03 10 ff");
+    }
+
+    #[test]
+    fn test_format_hex_detailed() {
+        let data = vec![0x48, 0x65, 0x6c, 0x6c, 0x6f]; // "Hello"
+        let result = format_hex_detailed(&data, 10);
+        assert_eq!(result, "48 65 6c 6c 6f  |Hello|");
+    }
+
+    #[test]
+    fn test_format_hex_detailed_truncated() {
+        let data = vec![0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x20, 0x77, 0x6f, 0x72, 0x6c, 0x64];
+        let result = format_hex_detailed(&data, 5);
+        assert!(result.contains("truncated"));
+        assert!(result.contains("11 bytes"));
+    }
+}

--- a/moq-transport/src/coding/hex_dump.rs
+++ b/moq-transport/src/coding/hex_dump.rs
@@ -1,4 +1,4 @@
-/// Utility functions for debugging byte sequences
+//! Utility functions for debugging byte sequences
 
 /// Format bytes as a hex string with spaces between bytes
 /// Example: [0x01, 0x02, 0x03] => "01 02 03"

--- a/moq-transport/src/coding/hex_dump.rs
+++ b/moq-transport/src/coding/hex_dump.rs
@@ -14,11 +14,7 @@ pub fn format_hex(data: &[u8]) -> String {
 /// Example output: "01 02 03 04 05  |.....|"
 pub fn format_hex_detailed(data: &[u8], max_bytes: usize) -> String {
     let truncated = data.len() > max_bytes;
-    let display_data = if truncated {
-        &data[..max_bytes]
-    } else {
-        data
-    };
+    let display_data = if truncated { &data[..max_bytes] } else { data };
 
     let hex_part = display_data
         .iter()
@@ -38,8 +34,12 @@ pub fn format_hex_detailed(data: &[u8], max_bytes: usize) -> String {
         .collect();
 
     if truncated {
-        format!("{} ... (truncated, total {} bytes)  |{}...|", 
-                hex_part, data.len(), ascii_part)
+        format!(
+            "{} ... (truncated, total {} bytes)  |{}...|",
+            hex_part,
+            data.len(),
+            ascii_part
+        )
     } else {
         format!("{}  |{}|", hex_part, ascii_part)
     }
@@ -64,7 +64,9 @@ mod tests {
 
     #[test]
     fn test_format_hex_detailed_truncated() {
-        let data = vec![0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x20, 0x77, 0x6f, 0x72, 0x6c, 0x64];
+        let data = vec![
+            0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x20, 0x77, 0x6f, 0x72, 0x6c, 0x64,
+        ];
         let result = format_hex_detailed(&data, 5);
         assert!(result.contains("truncated"));
         assert!(result.contains("11 bytes"));

--- a/moq-transport/src/coding/hex_dump.rs
+++ b/moq-transport/src/coding/hex_dump.rs
@@ -29,7 +29,7 @@ pub fn format_hex_detailed(data: &[u8], max_bytes: usize) -> String {
     let ascii_part: String = display_data
         .iter()
         .map(|&b| {
-            if b >= 32 && b <= 126 {
+            if (32..=126).contains(&b) {
                 b as char
             } else {
                 '.'

--- a/moq-transport/src/coding/mod.rs
+++ b/moq-transport/src/coding/mod.rs
@@ -1,6 +1,7 @@
 mod bounded_string;
 mod decode;
 mod encode;
+mod hex_dump;
 mod integer;
 mod kvp;
 mod location;
@@ -12,6 +13,7 @@ mod varint;
 pub use bounded_string::*;
 pub use decode::*;
 pub use encode::*;
+pub use hex_dump::*;
 pub use kvp::*;
 pub use location::*;
 pub use track_namespace::*;

--- a/moq-transport/src/data/header.rs
+++ b/moq-transport/src/data/header.rs
@@ -58,14 +58,28 @@ impl StreamHeaderType {
 impl Encode for StreamHeaderType {
     fn encode<W: bytes::BufMut>(&self, w: &mut W) -> Result<(), EncodeError> {
         let val = *self as u64;
+        log::trace!(
+            "[ENCODE] StreamHeaderType: encoding {:?} as {:#x}",
+            self,
+            val
+        );
         val.encode(w)?;
+        log::trace!("[ENCODE] StreamHeaderType: encoded successfully");
         Ok(())
     }
 }
 
 impl Decode for StreamHeaderType {
     fn decode<R: bytes::Buf>(r: &mut R) -> Result<Self, DecodeError> {
-        let header_type = match u64::decode(r)? {
+        log::trace!(
+            "[DECODE] StreamHeaderType: starting decode, buffer_remaining={} bytes",
+            r.remaining()
+        );
+
+        let type_value = u64::decode(r)?;
+        log::trace!("[DECODE] StreamHeaderType: decoded type value={:#x}", type_value);
+
+        let header_type = match type_value {
             0x10_u64 => Ok(Self::SubgroupZeroId),
             0x11_u64 => Ok(Self::SubgroupZeroIdExt),
             0x12_u64 => Ok(Self::SubgroupOjbectId),
@@ -79,11 +93,19 @@ impl Decode for StreamHeaderType {
             0x1c_u64 => Ok(Self::SubgroupIdEndOfGroup),
             0x1d_u64 => Ok(Self::SubgroupIdExtEndOfGroup),
             0x05_u64 => Ok(Self::Fetch),
-            _ => Err(DecodeError::InvalidHeaderType),
+            _ => {
+                log::error!("[DECODE] StreamHeaderType: INVALID type value={:#x}", type_value);
+                Err(DecodeError::InvalidHeaderType)
+            }
         };
 
-        if let Ok(header_type_inner) = header_type {
-            log::trace!("stream header type: {header_type_inner}");
+        if let Ok(header_type_inner) = &header_type {
+            log::debug!(
+                "[DECODE] StreamHeaderType: {}, has_subgroup_id={}, has_extension_headers={}",
+                header_type_inner,
+                header_type_inner.has_subgroup_id(),
+                header_type_inner.has_extension_headers()
+            );
         }
 
         header_type
@@ -110,17 +132,43 @@ pub struct StreamHeader {
 
 impl Decode for StreamHeader {
     fn decode<R: bytes::Buf>(r: &mut R) -> Result<Self, DecodeError> {
+        log::trace!(
+            "[DECODE] StreamHeader: starting decode, buffer_remaining={} bytes",
+            r.remaining()
+        );
+
         let header_type = StreamHeaderType::decode(r)?;
+        log::trace!("[DECODE] StreamHeader: decoded header_type={:?}", header_type);
 
         let subgroup_header = match header_type.is_subgroup() {
-            true => Some(SubgroupHeader::decode(header_type, r)?),
-            false => None,
+            true => {
+                log::trace!("[DECODE] StreamHeader: decoding subgroup header");
+                Some(SubgroupHeader::decode(header_type, r)?)
+            }
+            false => {
+                log::trace!("[DECODE] StreamHeader: no subgroup header (not a subgroup type)");
+                None
+            }
         };
 
         let fetch_header = match header_type.is_fetch() {
-            true => Some(FetchHeader::decode(header_type, r)?),
-            false => None,
+            true => {
+                log::trace!("[DECODE] StreamHeader: decoding fetch header");
+                Some(FetchHeader::decode(header_type, r)?)
+            }
+            false => {
+                log::trace!("[DECODE] StreamHeader: no fetch header (not a fetch type)");
+                None
+            }
         };
+
+        log::debug!(
+            "[DECODE] StreamHeader complete: type={:?}, has_subgroup={}, has_fetch={}, buffer_remaining={} bytes",
+            header_type,
+            subgroup_header.is_some(),
+            fetch_header.is_some(),
+            r.remaining()
+        );
 
         Ok(Self {
             header_type,
@@ -132,20 +180,39 @@ impl Decode for StreamHeader {
 
 impl Encode for StreamHeader {
     fn encode<W: bytes::BufMut>(&self, w: &mut W) -> Result<(), EncodeError> {
+        log::trace!(
+            "[ENCODE] StreamHeader: starting encode for type={:?}, has_subgroup={}, has_fetch={}",
+            self.header_type,
+            self.subgroup_header.is_some(),
+            self.fetch_header.is_some()
+        );
+
         // Note: we are intentionally not encoding the header_type here, it will be encoded in the
         //       appropriate substructures.
         //self.header_type.encode(w)?;
         if self.header_type.is_subgroup() {
             if let Some(subgroup_header) = &self.subgroup_header {
+                log::trace!("[ENCODE] StreamHeader: encoding subgroup header");
                 subgroup_header.encode(w)?;
             } else {
+                log::error!(
+                    "[ENCODE] StreamHeader: MISSING subgroup header for subgroup type={:?}",
+                    self.header_type
+                );
                 return Err(EncodeError::MissingField("SubgroupHeader".to_string()));
             }
         } else if let Some(fetch_header) = &self.fetch_header {
+            log::trace!("[ENCODE] StreamHeader: encoding fetch header");
             fetch_header.encode(w)?;
         } else {
+            log::error!(
+                "[ENCODE] StreamHeader: MISSING fetch header for fetch type={:?}",
+                self.header_type
+            );
             return Err(EncodeError::MissingField("FetchHeader".to_string()));
         }
+
+        log::debug!("[ENCODE] StreamHeader complete");
 
         Ok(())
     }

--- a/moq-transport/src/data/header.rs
+++ b/moq-transport/src/data/header.rs
@@ -77,7 +77,10 @@ impl Decode for StreamHeaderType {
         );
 
         let type_value = u64::decode(r)?;
-        log::trace!("[DECODE] StreamHeaderType: decoded type value={:#x}", type_value);
+        log::trace!(
+            "[DECODE] StreamHeaderType: decoded type value={:#x}",
+            type_value
+        );
 
         let header_type = match type_value {
             0x10_u64 => Ok(Self::SubgroupZeroId),
@@ -94,7 +97,10 @@ impl Decode for StreamHeaderType {
             0x1d_u64 => Ok(Self::SubgroupIdExtEndOfGroup),
             0x05_u64 => Ok(Self::Fetch),
             _ => {
-                log::error!("[DECODE] StreamHeaderType: INVALID type value={:#x}", type_value);
+                log::error!(
+                    "[DECODE] StreamHeaderType: INVALID type value={:#x}",
+                    type_value
+                );
                 Err(DecodeError::InvalidHeaderType)
             }
         };
@@ -138,7 +144,10 @@ impl Decode for StreamHeader {
         );
 
         let header_type = StreamHeaderType::decode(r)?;
-        log::trace!("[DECODE] StreamHeader: decoded header_type={:?}", header_type);
+        log::trace!(
+            "[DECODE] StreamHeader: decoded header_type={:?}",
+            header_type
+        );
 
         let subgroup_header = match header_type.is_subgroup() {
             true => {

--- a/moq-transport/src/data/subgroup.rs
+++ b/moq-transport/src/data/subgroup.rs
@@ -26,37 +26,96 @@ impl SubgroupHeader {
         header_type: StreamHeaderType,
         r: &mut R,
     ) -> Result<Self, DecodeError> {
-        let track_alias = u64::decode(r)?;
-        let group_id = u64::decode(r)?;
-        let subgroup_id = match header_type.has_subgroup_id() {
-            true => Some(u64::decode(r)?),
-            false => None,
-        };
-        let publisher_priority = u8::decode(r)?;
+        log::trace!(
+            "[DECODE] SubgroupHeader: starting decode with header_type={:?}, buffer_remaining={} bytes",
+            header_type,
+            r.remaining()
+        );
 
-        Ok(Self {
+        let track_alias = u64::decode(r)?;
+        log::trace!("[DECODE] SubgroupHeader: track_alias={}", track_alias);
+
+        let group_id = u64::decode(r)?;
+        log::trace!("[DECODE] SubgroupHeader: group_id={}", group_id);
+
+        let subgroup_id = match header_type.has_subgroup_id() {
+            true => {
+                let id = u64::decode(r)?;
+                log::trace!("[DECODE] SubgroupHeader: subgroup_id={}", id);
+                Some(id)
+            }
+            false => {
+                log::trace!("[DECODE] SubgroupHeader: subgroup_id=None (not present for this header type)");
+                None
+            }
+        };
+
+        let publisher_priority = u8::decode(r)?;
+        log::trace!(
+            "[DECODE] SubgroupHeader: publisher_priority={}, buffer_remaining={} bytes",
+            publisher_priority,
+            r.remaining()
+        );
+
+        let result = Self {
             header_type,
             track_alias,
             group_id,
             subgroup_id,
             publisher_priority,
-        })
+        };
+
+        log::debug!(
+            "[DECODE] SubgroupHeader complete: track_alias={}, group_id={}, subgroup_id={:?}, priority={}",
+            result.track_alias,
+            result.group_id,
+            result.subgroup_id,
+            result.publisher_priority
+        );
+
+        Ok(result)
     }
 }
 
 impl Encode for SubgroupHeader {
     fn encode<W: bytes::BufMut>(&self, w: &mut W) -> Result<(), EncodeError> {
+        log::trace!(
+            "[ENCODE] SubgroupHeader: starting encode - track_alias={}, group_id={}, subgroup_id={:?}, priority={}, header_type={:?}",
+            self.track_alias,
+            self.group_id,
+            self.subgroup_id,
+            self.publisher_priority,
+            self.header_type
+        );
+
+        let start_pos = w.remaining_mut();
+
         self.header_type.encode(w)?;
+        log::trace!("[ENCODE] SubgroupHeader: encoded header_type");
+
         self.track_alias.encode(w)?;
+        log::trace!("[ENCODE] SubgroupHeader: encoded track_alias={}", self.track_alias);
+
         self.group_id.encode(w)?;
+        log::trace!("[ENCODE] SubgroupHeader: encoded group_id={}", self.group_id);
+
         if self.header_type.has_subgroup_id() {
             if let Some(subgroup_id) = self.subgroup_id {
                 subgroup_id.encode(w)?;
+                log::trace!("[ENCODE] SubgroupHeader: encoded subgroup_id={}", subgroup_id);
             } else {
+                log::error!("[ENCODE] SubgroupHeader: MISSING subgroup_id for header_type={:?}", self.header_type);
                 return Err(EncodeError::MissingField("SubgroupId".to_string()));
             }
+        } else {
+            log::trace!("[ENCODE] SubgroupHeader: subgroup_id not encoded (not required for this header type)");
         }
+
         self.publisher_priority.encode(w)?;
+        log::trace!("[ENCODE] SubgroupHeader: encoded publisher_priority={}", self.publisher_priority);
+
+        let bytes_written = start_pos - w.remaining_mut();
+        log::debug!("[ENCODE] SubgroupHeader complete: wrote {} bytes", bytes_written);
 
         Ok(())
     }
@@ -73,15 +132,39 @@ pub struct SubgroupObject {
 
 impl Decode for SubgroupObject {
     fn decode<R: bytes::Buf>(r: &mut R) -> Result<Self, DecodeError> {
+        log::trace!(
+            "[DECODE] SubgroupObject: starting decode, buffer_remaining={} bytes",
+            r.remaining()
+        );
+
         let object_id_delta = u64::decode(r)?;
+        log::trace!("[DECODE] SubgroupObject: object_id_delta={}", object_id_delta);
+
         let payload_length = usize::decode(r)?;
+        log::trace!("[DECODE] SubgroupObject: payload_length={}", payload_length);
+
         let status = match payload_length {
-            0 => Some(ObjectStatus::decode(r)?),
-            _ => None,
+            0 => {
+                let s = ObjectStatus::decode(r)?;
+                log::trace!("[DECODE] SubgroupObject: status={:?} (payload_length=0)", s);
+                Some(s)
+            }
+            _ => {
+                log::trace!("[DECODE] SubgroupObject: status=None (payload_length > 0)");
+                None
+            }
         };
 
         //Self::decode_remaining(r, payload_length);
         //let payload = r.copy_to_bytes(payload_length);
+
+        log::debug!(
+            "[DECODE] SubgroupObject complete: object_id_delta={}, payload_length={}, status={:?}, buffer_remaining={} bytes",
+            object_id_delta,
+            payload_length,
+            status,
+            r.remaining()
+        );
 
         Ok(Self {
             object_id_delta,
@@ -94,17 +177,32 @@ impl Decode for SubgroupObject {
 
 impl Encode for SubgroupObject {
     fn encode<W: bytes::BufMut>(&self, w: &mut W) -> Result<(), EncodeError> {
+        log::trace!(
+            "[ENCODE] SubgroupObject: starting encode - object_id_delta={}, payload_length={}, status={:?}",
+            self.object_id_delta,
+            self.payload_length,
+            self.status
+        );
+
         self.object_id_delta.encode(w)?;
+        log::trace!("[ENCODE] SubgroupObject: encoded object_id_delta={}", self.object_id_delta);
+
         self.payload_length.encode(w)?;
+        log::trace!("[ENCODE] SubgroupObject: encoded payload_length={}", self.payload_length);
+
         if self.payload_length == 0 {
             if let Some(status) = self.status {
                 status.encode(w)?;
+                log::trace!("[ENCODE] SubgroupObject: encoded status={:?}", status);
             } else {
+                log::error!("[ENCODE] SubgroupObject: MISSING status for payload_length=0");
                 return Err(EncodeError::MissingField("Status".to_string()));
             }
         }
         //Self::encode_remaining(w, self.payload.len())?;
         //w.put_slice(&self.payload);
+
+        log::debug!("[ENCODE] SubgroupObject complete");
 
         Ok(())
     }
@@ -122,16 +220,42 @@ pub struct SubgroupObjectExt {
 
 impl Decode for SubgroupObjectExt {
     fn decode<R: bytes::Buf>(r: &mut R) -> Result<Self, DecodeError> {
+        log::trace!(
+            "[DECODE] SubgroupObjectExt: starting decode, buffer_remaining={} bytes",
+            r.remaining()
+        );
+
         let object_id_delta = u64::decode(r)?;
+        log::trace!("[DECODE] SubgroupObjectExt: object_id_delta={}", object_id_delta);
+
         let extension_headers = KeyValuePairs::decode(r)?;
+        log::trace!("[DECODE] SubgroupObjectExt: extension_headers={:?}", extension_headers);
+
         let payload_length = usize::decode(r)?;
+        log::trace!("[DECODE] SubgroupObjectExt: payload_length={}", payload_length);
+
         let status = match payload_length {
-            0 => Some(ObjectStatus::decode(r)?),
-            _ => None,
+            0 => {
+                let s = ObjectStatus::decode(r)?;
+                log::trace!("[DECODE] SubgroupObjectExt: status={:?} (payload_length=0)", s);
+                Some(s)
+            }
+            _ => {
+                log::trace!("[DECODE] SubgroupObjectExt: status=None (payload_length > 0)");
+                None
+            }
         };
 
         //Self::decode_remaining(r, payload_length);
         //let payload = r.copy_to_bytes(payload_length);
+
+        log::debug!(
+            "[DECODE] SubgroupObjectExt complete: object_id_delta={}, payload_length={}, status={:?}, buffer_remaining={} bytes",
+            object_id_delta,
+            payload_length,
+            status,
+            r.remaining()
+        );
 
         Ok(Self {
             object_id_delta,
@@ -145,18 +269,36 @@ impl Decode for SubgroupObjectExt {
 
 impl Encode for SubgroupObjectExt {
     fn encode<W: bytes::BufMut>(&self, w: &mut W) -> Result<(), EncodeError> {
+        log::trace!(
+            "[ENCODE] SubgroupObjectExt: starting encode - object_id_delta={}, payload_length={}, status={:?}, extension_headers={:?}",
+            self.object_id_delta,
+            self.payload_length,
+            self.status,
+            self.extension_headers
+        );
+
         self.object_id_delta.encode(w)?;
+        log::trace!("[ENCODE] SubgroupObjectExt: encoded object_id_delta={}", self.object_id_delta);
+
         self.extension_headers.encode(w)?;
+        log::trace!("[ENCODE] SubgroupObjectExt: encoded extension_headers");
+
         self.payload_length.encode(w)?;
+        log::trace!("[ENCODE] SubgroupObjectExt: encoded payload_length={}", self.payload_length);
+
         if self.payload_length == 0 {
             if let Some(status) = self.status {
                 status.encode(w)?;
+                log::trace!("[ENCODE] SubgroupObjectExt: encoded status={:?}", status);
             } else {
+                log::error!("[ENCODE] SubgroupObjectExt: MISSING status for payload_length=0");
                 return Err(EncodeError::MissingField("Status".to_string()));
             }
         }
         //Self::encode_remaining(w, self.payload.len())?;
         //w.put_slice(&self.payload);
+
+        log::debug!("[ENCODE] SubgroupObjectExt complete");
 
         Ok(())
     }

--- a/moq-transport/src/data/subgroup.rs
+++ b/moq-transport/src/data/subgroup.rs
@@ -45,7 +45,9 @@ impl SubgroupHeader {
                 Some(id)
             }
             false => {
-                log::trace!("[DECODE] SubgroupHeader: subgroup_id=None (not present for this header type)");
+                log::trace!(
+                    "[DECODE] SubgroupHeader: subgroup_id=None (not present for this header type)"
+                );
                 None
             }
         };
@@ -94,17 +96,29 @@ impl Encode for SubgroupHeader {
         log::trace!("[ENCODE] SubgroupHeader: encoded header_type");
 
         self.track_alias.encode(w)?;
-        log::trace!("[ENCODE] SubgroupHeader: encoded track_alias={}", self.track_alias);
+        log::trace!(
+            "[ENCODE] SubgroupHeader: encoded track_alias={}",
+            self.track_alias
+        );
 
         self.group_id.encode(w)?;
-        log::trace!("[ENCODE] SubgroupHeader: encoded group_id={}", self.group_id);
+        log::trace!(
+            "[ENCODE] SubgroupHeader: encoded group_id={}",
+            self.group_id
+        );
 
         if self.header_type.has_subgroup_id() {
             if let Some(subgroup_id) = self.subgroup_id {
                 subgroup_id.encode(w)?;
-                log::trace!("[ENCODE] SubgroupHeader: encoded subgroup_id={}", subgroup_id);
+                log::trace!(
+                    "[ENCODE] SubgroupHeader: encoded subgroup_id={}",
+                    subgroup_id
+                );
             } else {
-                log::error!("[ENCODE] SubgroupHeader: MISSING subgroup_id for header_type={:?}", self.header_type);
+                log::error!(
+                    "[ENCODE] SubgroupHeader: MISSING subgroup_id for header_type={:?}",
+                    self.header_type
+                );
                 return Err(EncodeError::MissingField("SubgroupId".to_string()));
             }
         } else {
@@ -112,10 +126,16 @@ impl Encode for SubgroupHeader {
         }
 
         self.publisher_priority.encode(w)?;
-        log::trace!("[ENCODE] SubgroupHeader: encoded publisher_priority={}", self.publisher_priority);
+        log::trace!(
+            "[ENCODE] SubgroupHeader: encoded publisher_priority={}",
+            self.publisher_priority
+        );
 
         let bytes_written = start_pos - w.remaining_mut();
-        log::debug!("[ENCODE] SubgroupHeader complete: wrote {} bytes", bytes_written);
+        log::debug!(
+            "[ENCODE] SubgroupHeader complete: wrote {} bytes",
+            bytes_written
+        );
 
         Ok(())
     }
@@ -138,7 +158,10 @@ impl Decode for SubgroupObject {
         );
 
         let object_id_delta = u64::decode(r)?;
-        log::trace!("[DECODE] SubgroupObject: object_id_delta={}", object_id_delta);
+        log::trace!(
+            "[DECODE] SubgroupObject: object_id_delta={}",
+            object_id_delta
+        );
 
         let payload_length = usize::decode(r)?;
         log::trace!("[DECODE] SubgroupObject: payload_length={}", payload_length);
@@ -185,10 +208,16 @@ impl Encode for SubgroupObject {
         );
 
         self.object_id_delta.encode(w)?;
-        log::trace!("[ENCODE] SubgroupObject: encoded object_id_delta={}", self.object_id_delta);
+        log::trace!(
+            "[ENCODE] SubgroupObject: encoded object_id_delta={}",
+            self.object_id_delta
+        );
 
         self.payload_length.encode(w)?;
-        log::trace!("[ENCODE] SubgroupObject: encoded payload_length={}", self.payload_length);
+        log::trace!(
+            "[ENCODE] SubgroupObject: encoded payload_length={}",
+            self.payload_length
+        );
 
         if self.payload_length == 0 {
             if let Some(status) = self.status {
@@ -226,18 +255,30 @@ impl Decode for SubgroupObjectExt {
         );
 
         let object_id_delta = u64::decode(r)?;
-        log::trace!("[DECODE] SubgroupObjectExt: object_id_delta={}", object_id_delta);
+        log::trace!(
+            "[DECODE] SubgroupObjectExt: object_id_delta={}",
+            object_id_delta
+        );
 
         let extension_headers = KeyValuePairs::decode(r)?;
-        log::trace!("[DECODE] SubgroupObjectExt: extension_headers={:?}", extension_headers);
+        log::trace!(
+            "[DECODE] SubgroupObjectExt: extension_headers={:?}",
+            extension_headers
+        );
 
         let payload_length = usize::decode(r)?;
-        log::trace!("[DECODE] SubgroupObjectExt: payload_length={}", payload_length);
+        log::trace!(
+            "[DECODE] SubgroupObjectExt: payload_length={}",
+            payload_length
+        );
 
         let status = match payload_length {
             0 => {
                 let s = ObjectStatus::decode(r)?;
-                log::trace!("[DECODE] SubgroupObjectExt: status={:?} (payload_length=0)", s);
+                log::trace!(
+                    "[DECODE] SubgroupObjectExt: status={:?} (payload_length=0)",
+                    s
+                );
                 Some(s)
             }
             _ => {
@@ -278,13 +319,19 @@ impl Encode for SubgroupObjectExt {
         );
 
         self.object_id_delta.encode(w)?;
-        log::trace!("[ENCODE] SubgroupObjectExt: encoded object_id_delta={}", self.object_id_delta);
+        log::trace!(
+            "[ENCODE] SubgroupObjectExt: encoded object_id_delta={}",
+            self.object_id_delta
+        );
 
         self.extension_headers.encode(w)?;
         log::trace!("[ENCODE] SubgroupObjectExt: encoded extension_headers");
 
         self.payload_length.encode(w)?;
-        log::trace!("[ENCODE] SubgroupObjectExt: encoded payload_length={}", self.payload_length);
+        log::trace!(
+            "[ENCODE] SubgroupObjectExt: encoded payload_length={}",
+            self.payload_length
+        );
 
         if self.payload_length == 0 {
             if let Some(status) = self.status {

--- a/moq-transport/src/session/reader.rs
+++ b/moq-transport/src/session/reader.rs
@@ -20,27 +20,75 @@ impl Reader {
     }
 
     pub async fn decode<T: Decode>(&mut self) -> Result<T, SessionError> {
+        log::trace!(
+            "[READER] decode: attempting to decode {} (buffer_len={})",
+            std::any::type_name::<T>(),
+            self.buffer.len()
+        );
+
         loop {
             let mut cursor = io::Cursor::new(&self.buffer);
 
             // Try to decode with the current buffer.
             let required = match T::decode(&mut cursor) {
                 Ok(msg) => {
-                    self.buffer.advance(cursor.position() as usize);
+                    let consumed = cursor.position() as usize;
+                    self.buffer.advance(consumed);
+                    log::debug!(
+                        "[READER] decode: successfully decoded {} (consumed={} bytes, buffer_remaining={})",
+                        std::any::type_name::<T>(),
+                        consumed,
+                        self.buffer.len()
+                    );
                     return Ok(msg);
                 }
-                Err(DecodeError::More(required)) => self.buffer.len() + required, // Try again with more data
-                Err(err) => return Err(err.into()),
+                Err(DecodeError::More(required)) => {
+                    let total_needed = self.buffer.len() + required;
+                    log::trace!(
+                        "[READER] decode: need more data for {} (current={} bytes, need={} more, total_required={})",
+                        std::any::type_name::<T>(),
+                        self.buffer.len(),
+                        required,
+                        total_needed
+                    );
+                    total_needed
+                }
+                Err(err) => {
+                    log::error!(
+                        "[READER] decode: ERROR decoding {} - {:?} (buffer_len={})",
+                        std::any::type_name::<T>(),
+                        err,
+                        self.buffer.len()
+                    );
+                    return Err(err.into());
+                }
             };
 
             // Read in more data until we reach the requested amount.
             // We always read at least once to avoid an infinite loop if some dingus puts remain=0
             loop {
+                let before_read = self.buffer.len();
                 if !self.stream.read_buf(&mut self.buffer).await? {
+                    log::warn!(
+                        "[READER] decode: stream ended while waiting for data (have={} bytes, need={})",
+                        self.buffer.len(),
+                        required
+                    );
                     return Err(DecodeError::More(required - self.buffer.len()).into());
                 };
 
+                let read_amount = self.buffer.len() - before_read;
+                log::trace!(
+                    "[READER] decode: read {} bytes from stream (buffer_len={})",
+                    read_amount,
+                    self.buffer.len()
+                );
+
                 if self.buffer.len() >= required {
+                    log::trace!(
+                        "[READER] decode: have enough data now (buffer_len={}), retrying decode",
+                        self.buffer.len()
+                    );
                     break;
                 }
             }
@@ -48,13 +96,30 @@ impl Reader {
     }
 
     pub async fn read_chunk(&mut self, max: usize) -> Result<Option<Bytes>, SessionError> {
+        log::trace!(
+            "[READER] read_chunk: requested max={} bytes (buffer_len={})",
+            max,
+            self.buffer.len()
+        );
+
         if !self.buffer.is_empty() {
             let size = cmp::min(max, self.buffer.len());
             let data = self.buffer.split_to(size).freeze();
+            log::trace!(
+                "[READER] read_chunk: returned {} bytes from buffer (buffer_remaining={})",
+                data.len(),
+                self.buffer.len()
+            );
             return Ok(Some(data));
         }
 
-        Ok(self.stream.read_chunk(max).await?)
+        let chunk = self.stream.read_chunk(max).await?;
+        if let Some(ref data) = chunk {
+            log::trace!("[READER] read_chunk: read {} bytes from stream", data.len());
+        } else {
+            log::trace!("[READER] read_chunk: stream returned None");
+        }
+        Ok(chunk)
     }
 
     pub async fn done(&mut self) -> Result<bool, SessionError> {

--- a/moq-transport/src/session/subscribed.rs
+++ b/moq-transport/src/session/subscribed.rs
@@ -226,17 +226,33 @@ impl Subscribed {
         mut publisher: Publisher,
         state: State<SubscribedState>,
     ) -> Result<(), SessionError> {
+        log::debug!(
+            "[PUBLISHER] serve_subgroup: starting - group_id={}, subgroup_id={:?}, priority={}",
+            subgroup_reader.group_id,
+            subgroup_reader.subgroup_id,
+            subgroup_reader.priority
+        );
+
         let mut send_stream = publisher.open_uni().await?;
+        log::trace!("[PUBLISHER] serve_subgroup: opened unidirectional stream");
 
         // TODO figure out u32 vs u64 priority
         send_stream.set_priority(subgroup_reader.priority as i32);
 
         let mut writer = Writer::new(send_stream);
 
-        log::trace!("sending subgroup header: {:?}", header);
+        log::debug!(
+            "[PUBLISHER] serve_subgroup: sending header - track_alias={}, group_id={}, subgroup_id={:?}, priority={}, header_type={:?}",
+            header.track_alias,
+            header.group_id,
+            header.subgroup_id,
+            header.publisher_priority,
+            header.header_type
+        );
 
         writer.encode(&header).await?;
 
+        let mut object_count = 0;
         while let Some(mut subgroup_object_reader) = subgroup_reader.next().await? {
             let subgroup_object = data::SubgroupObject {
                 object_id_delta: 0, // before delta logic, used to be subgroup_object_reader.object_id,
@@ -249,6 +265,15 @@ impl Subscribed {
                 },
             };
 
+            log::debug!(
+                "[PUBLISHER] serve_subgroup: sending object #{} - object_id={}, object_id_delta={}, payload_length={}, status={:?}",
+                object_count + 1,
+                subgroup_object_reader.object_id,
+                subgroup_object.object_id_delta,
+                subgroup_object.payload_length,
+                subgroup_object.status
+            );
+
             writer.encode(&subgroup_object).await?;
 
             state
@@ -259,16 +284,35 @@ impl Subscribed {
                     subgroup_object_reader.object_id,
                 )?;
 
-            log::trace!("sent subgroup object: {:?}", subgroup_object);
-
+            let mut chunks_sent = 0;
+            let mut bytes_sent = 0;
             while let Some(chunk) = subgroup_object_reader.read().await? {
+                log::trace!(
+                    "[PUBLISHER] serve_subgroup: sending payload chunk #{} for object #{} ({} bytes)",
+                    chunks_sent + 1,
+                    object_count + 1,
+                    chunk.len()
+                );
+                bytes_sent += chunk.len();
                 writer.write(&chunk).await?;
-                // payload length already logged when subgroup object is logged
-                //log::trace!("sent group payload len: {:?}", chunk.len());
+                chunks_sent += 1;
             }
 
-            //log::trace!("sent subgroup done");
+            log::trace!(
+                "[PUBLISHER] serve_subgroup: completed object #{} ({} chunks, {} bytes total)",
+                object_count + 1,
+                chunks_sent,
+                bytes_sent
+            );
+            object_count += 1;
         }
+
+        log::info!(
+            "[PUBLISHER] serve_subgroup: completed subgroup (group_id={}, subgroup_id={:?}, {} objects sent)",
+            subgroup_reader.group_id,
+            subgroup_reader.subgroup_id,
+            object_count
+        );
 
         Ok(())
     }
@@ -277,8 +321,11 @@ impl Subscribed {
         &mut self,
         mut datagrams: serve::DatagramsReader,
     ) -> Result<(), SessionError> {
+        log::debug!("[PUBLISHER] serve_datagrams: starting");
+
+        let mut datagram_count = 0;
         while let Some(datagram) = datagrams.read().await? {
-            let datagram = data::Datagram {
+            let encoded_datagram = data::Datagram {
                 datagram_type: data::DatagramType::ObjectIdPayload, // TODO SLG
                 track_alias: self.msg.id, //  TODO SLG - use subscription id for now
                 group_id: datagram.group_id,
@@ -289,19 +336,36 @@ impl Subscribed {
                 payload: Some(datagram.payload),
             };
 
+            let payload_len = encoded_datagram.payload.as_ref().map(|p| p.len()).unwrap_or(0);
             let mut buffer =
-                bytes::BytesMut::with_capacity(datagram.payload.as_ref().unwrap().len() + 100);
-            datagram.encode(&mut buffer)?;
+                bytes::BytesMut::with_capacity(payload_len + 100);
+            encoded_datagram.encode(&mut buffer)?;
+
+            log::debug!(
+                "[PUBLISHER] serve_datagrams: sending datagram #{} - group_id={}, object_id={}, priority={}, payload_len={}, total_encoded_len={}",
+                datagram_count + 1,
+                encoded_datagram.group_id,
+                encoded_datagram.object_id.unwrap(),
+                encoded_datagram.publisher_priority,
+                payload_len,
+                buffer.len()
+            );
 
             self.publisher.send_datagram(buffer.into()).await?;
-            log::trace!("sent datagram: {:?}", datagram);
 
             self.state
                 .lock_mut()
                 .ok_or(ServeError::Done)?
-                .update_largest_location(datagram.group_id, datagram.object_id.unwrap())?;
+                .update_largest_location(encoded_datagram.group_id, encoded_datagram.object_id.unwrap())?;
             // TODO SLG - fix up safety of unwrap()
+
+            datagram_count += 1;
         }
+
+        log::info!(
+            "[PUBLISHER] serve_datagrams: completed ({} datagrams sent)",
+            datagram_count
+        );
 
         Ok(())
     }

--- a/moq-transport/src/session/subscribed.rs
+++ b/moq-transport/src/session/subscribed.rs
@@ -336,9 +336,12 @@ impl Subscribed {
                 payload: Some(datagram.payload),
             };
 
-            let payload_len = encoded_datagram.payload.as_ref().map(|p| p.len()).unwrap_or(0);
-            let mut buffer =
-                bytes::BytesMut::with_capacity(payload_len + 100);
+            let payload_len = encoded_datagram
+                .payload
+                .as_ref()
+                .map(|p| p.len())
+                .unwrap_or(0);
+            let mut buffer = bytes::BytesMut::with_capacity(payload_len + 100);
             encoded_datagram.encode(&mut buffer)?;
 
             log::debug!(
@@ -356,7 +359,10 @@ impl Subscribed {
             self.state
                 .lock_mut()
                 .ok_or(ServeError::Done)?
-                .update_largest_location(encoded_datagram.group_id, encoded_datagram.object_id.unwrap())?;
+                .update_largest_location(
+                    encoded_datagram.group_id,
+                    encoded_datagram.object_id.unwrap(),
+                )?;
             // TODO SLG - fix up safety of unwrap()
 
             datagram_count += 1;

--- a/moq-transport/src/session/subscriber.rs
+++ b/moq-transport/src/session/subscriber.rs
@@ -196,7 +196,10 @@ impl Subscriber {
         // No fetch support yet, so panic if fetch_header for now (via unwrap below)
         // TODO SLG - used to use subscribe_id, using track_alias for now, needs fixing
         let id = stream_header.subgroup_header.as_ref().unwrap().track_alias;
-        log::trace!("[SUBSCRIBER] recv_stream: stream for subscription id={}", id);
+        log::trace!(
+            "[SUBSCRIBER] recv_stream: stream for subscription id={}",
+            id
+        );
 
         let res = self.recv_stream_inner(reader, stream_header).await;
         if let Err(SessionError::Serve(err)) = &res {
@@ -223,7 +226,10 @@ impl Subscriber {
         // No fetch support yet, so panic if fetch_header for now (via unwrap below)
         // TODO SLG - used to use subscribe_id, using track_alias for now, needs fixing
         let id = stream_header.subgroup_header.as_ref().unwrap().track_alias;
-        log::trace!("[SUBSCRIBER] recv_stream_inner: processing stream for id={}", id);
+        log::trace!(
+            "[SUBSCRIBER] recv_stream_inner: processing stream for id={}",
+            id
+        );
 
         // This is super silly, but I couldn't figure out a way to avoid the mutex guard across awaits.
         enum Writer {
@@ -257,7 +263,10 @@ impl Subscriber {
             }
         };
 
-        log::debug!("[SUBSCRIBER] recv_stream_inner: completed processing stream for id={}", id);
+        log::debug!(
+            "[SUBSCRIBER] recv_stream_inner: completed processing stream for id={}",
+            id
+        );
         Ok(())
     }
 

--- a/moq-transport/src/session/subscriber.rs
+++ b/moq-transport/src/session/subscriber.rs
@@ -183,17 +183,28 @@ impl Subscriber {
         mut self,
         stream: web_transport::RecvStream,
     ) -> Result<(), SessionError> {
+        log::trace!("[SUBSCRIBER] recv_stream: new stream received, decoding header");
         let mut reader = Reader::new(stream);
 
         // Decode the stream header
         let stream_header: data::StreamHeader = reader.decode().await?;
+        log::debug!(
+            "[SUBSCRIBER] recv_stream: decoded stream header type={:?}",
+            stream_header.header_type
+        );
 
         // No fetch support yet, so panic if fetch_header for now (via unwrap below)
         // TODO SLG - used to use subscribe_id, using track_alias for now, needs fixing
         let id = stream_header.subgroup_header.as_ref().unwrap().track_alias;
+        log::trace!("[SUBSCRIBER] recv_stream: stream for subscription id={}", id);
 
         let res = self.recv_stream_inner(reader, stream_header).await;
         if let Err(SessionError::Serve(err)) = &res {
+            log::warn!(
+                "[SUBSCRIBER] recv_stream: stream processing error for id={}: {:?}",
+                id,
+                err
+            );
             // The writer is closed, so we should teriminate.
             // TODO it would be nice to do this immediately when the Writer is closed.
             if let Some(subscribe) = self.subscribes.lock().unwrap().remove(&id) {
@@ -212,6 +223,7 @@ impl Subscriber {
         // No fetch support yet, so panic if fetch_header for now (via unwrap below)
         // TODO SLG - used to use subscribe_id, using track_alias for now, needs fixing
         let id = stream_header.subgroup_header.as_ref().unwrap().track_alias;
+        log::trace!("[SUBSCRIBER] recv_stream_inner: processing stream for id={}", id);
 
         // This is super silly, but I couldn't figure out a way to avoid the mutex guard across awaits.
         enum Writer {
@@ -221,9 +233,16 @@ impl Subscriber {
 
         let writer = {
             let mut subscribes = self.subscribes.lock().unwrap();
-            let subscribe = subscribes.get_mut(&id).ok_or(ServeError::NotFound)?;
+            let subscribe = subscribes.get_mut(&id).ok_or_else(|| {
+                log::error!(
+                    "[SUBSCRIBER] recv_stream_inner: subscription id={} not found",
+                    id
+                );
+                ServeError::NotFound
+            })?;
 
             if stream_header.header_type.is_subgroup() {
+                log::trace!("[SUBSCRIBER] recv_stream_inner: creating subgroup writer");
                 Writer::Subgroup(subscribe.subgroup(stream_header.subgroup_header.unwrap())?)
             } else {
                 panic!("Fetch not implemented yet!")
@@ -233,10 +252,12 @@ impl Subscriber {
         match writer {
             //Writer::Fetch(fetch) => Self::recv_fetch(fetch, reader).await?,
             Writer::Subgroup(subgroup) => {
+                log::trace!("[SUBSCRIBER] recv_stream_inner: receiving subgroup data");
                 Self::recv_subgroup(stream_header.header_type, subgroup, reader).await?
             }
         };
 
+        log::debug!("[SUBSCRIBER] recv_stream_inner: completed processing stream for id={}", id);
         Ok(())
     }
 
@@ -245,23 +266,44 @@ impl Subscriber {
         mut subgroup_writer: serve::SubgroupWriter,
         mut reader: Reader,
     ) -> Result<(), SessionError> {
-        log::trace!("received subgroup: {:?}", subgroup_writer.info);
+        log::debug!(
+            "[SUBSCRIBER] recv_subgroup: starting - group_id={}, subgroup_id={}, priority={}",
+            subgroup_writer.info.group_id,
+            subgroup_writer.info.subgroup_id,
+            subgroup_writer.info.priority
+        );
 
+        let mut object_count = 0;
         while !reader.done().await? {
+            log::trace!(
+                "[SUBSCRIBER] recv_subgroup: reading object #{} (has_ext_headers={})",
+                object_count + 1,
+                stream_header_type.has_extension_headers()
+            );
+
             // Need to be able to decode the subgroup object conditionally based on the stream header type
             // read the object payload length into remaining_bytes
             let mut remaining_bytes = match stream_header_type.has_extension_headers() {
                 true => {
                     let object = reader.decode::<data::SubgroupObjectExt>().await?;
-                    log::trace!(
-                        "received subgroup object with extension headers: {:?}",
-                        object
+                    log::debug!(
+                        "[SUBSCRIBER] recv_subgroup: object #{} with extension headers - object_id_delta={}, payload_length={}, status={:?}",
+                        object_count + 1,
+                        object.object_id_delta,
+                        object.payload_length,
+                        object.status
                     );
                     object.payload_length
                 }
                 false => {
                     let object = reader.decode::<data::SubgroupObject>().await?;
-                    log::trace!("received subgroup object: {:?}", object);
+                    log::debug!(
+                        "[SUBSCRIBER] recv_subgroup: object #{} - object_id_delta={}, payload_length={}, status={:?}",
+                        object_count + 1,
+                        object.object_id_delta,
+                        object.payload_length,
+                        object.status
+                    );
                     object.payload_length
                 }
             };
@@ -269,17 +311,51 @@ impl Subscriber {
             // TODO SLG - object_id_delta, extension headers and object status are being ignored and not passed on
 
             let mut object_writer = subgroup_writer.create(remaining_bytes)?;
+            log::trace!(
+                "[SUBSCRIBER] recv_subgroup: reading payload for object #{} ({} bytes)",
+                object_count + 1,
+                remaining_bytes
+            );
 
+            let mut chunks_read = 0;
             while remaining_bytes > 0 {
                 let data = reader
                     .read_chunk(remaining_bytes)
                     .await?
-                    .ok_or(SessionError::WrongSize)?;
-                //log::trace!("received subgroup payload: {:?}", data.len());
+                    .ok_or_else(|| {
+                        log::error!(
+                            "[SUBSCRIBER] recv_subgroup: ERROR - stream ended with {} bytes remaining for object #{}",
+                            remaining_bytes,
+                            object_count + 1
+                        );
+                        SessionError::WrongSize
+                    })?;
+                log::trace!(
+                    "[SUBSCRIBER] recv_subgroup: received payload chunk #{} for object #{} ({} bytes, {} remaining)",
+                    chunks_read + 1,
+                    object_count + 1,
+                    data.len(),
+                    remaining_bytes - data.len()
+                );
                 remaining_bytes -= data.len();
                 object_writer.write(data)?;
+                chunks_read += 1;
             }
+
+            log::trace!(
+                "[SUBSCRIBER] recv_subgroup: completed object #{} ({} chunks)",
+                object_count + 1,
+                chunks_read
+            );
+            object_count += 1;
         }
+
+        log::info!(
+            "[SUBSCRIBER] recv_subgroup: completed subgroup (group_id={}, subgroup_id={}, {} objects received)",
+            subgroup_writer.info.group_id,
+            subgroup_writer.info.subgroup_id,
+            object_count
+        );
 
         Ok(())
     }

--- a/moq-transport/src/session/writer.rs
+++ b/moq-transport/src/session/writer.rs
@@ -20,24 +20,68 @@ impl Writer {
 
     pub async fn encode<T: Encode>(&mut self, msg: &T) -> Result<(), SessionError> {
         self.buffer.clear();
-        msg.encode(&mut self.buffer)?;
+        log::trace!(
+            "[WRITER] encode: encoding {} to buffer",
+            std::any::type_name::<T>()
+        );
 
+        msg.encode(&mut self.buffer)?;
+        let encoded_len = self.buffer.len();
+        log::debug!(
+            "[WRITER] encode: encoded {} ({} bytes), sending to stream",
+            std::any::type_name::<T>(),
+            encoded_len
+        );
+
+        let mut total_written = 0;
         while !self.buffer.is_empty() {
-            self.stream.write_buf(&mut self.buffer).await?;
+            let written = self.stream.write_buf(&mut self.buffer).await?;
+            total_written += written;
+            log::trace!(
+                "[WRITER] encode: wrote {} bytes to stream (total={}/{}, remaining={})",
+                written,
+                total_written,
+                encoded_len,
+                self.buffer.len()
+            );
         }
+
+        log::debug!(
+            "[WRITER] encode: finished sending {} ({} bytes total)",
+            std::any::type_name::<T>(),
+            total_written
+        );
 
         Ok(())
     }
 
     pub async fn write(&mut self, buf: &[u8]) -> Result<(), SessionError> {
+        log::trace!("[WRITER] write: writing {} bytes to stream", buf.len());
+
         let mut cursor = io::Cursor::new(buf);
+        let total_len = buf.len();
+        let mut total_written = 0;
 
         while cursor.has_remaining() {
             let size = self.stream.write_buf(&mut cursor).await?;
             if size == 0 {
+                log::error!(
+                    "[WRITER] write: ERROR - wrote 0 bytes with {} bytes remaining",
+                    cursor.remaining()
+                );
                 return Err(EncodeError::More(cursor.remaining()).into());
             }
+            total_written += size;
+            log::trace!(
+                "[WRITER] write: wrote {} bytes (total={}/{}, remaining={})",
+                size,
+                total_written,
+                total_len,
+                cursor.remaining()
+            );
         }
+
+        log::debug!("[WRITER] write: finished writing {} bytes", total_written);
 
         Ok(())
     }


### PR DESCRIPTION
Adds basic support for qlog logging on a per CID basis and the option to serve these logs over over HTTPS for improved testing / troubleshooting.

Also adds some additional detailed logging around subgroup headers to help troubleshoot remaining draft-14 interop issues.