### PR TITLE
fix(moq-transport): compute correct `object_id_delta` in `serve_subgroup`

### DIFF
--- a/moq-transport/src/session/subscribed.rs
+++ b/moq-transport/src/session/subscribed.rs
@@ -272,9 +272,10 @@ impl Subscribed {
         }
 
         let mut object_count = 0;
+        let mut current_object_id: u64 = 0;
         while let Some(mut subgroup_object_reader) = subgroup_reader.next().await? {
             let subgroup_object = data::SubgroupObjectExt {
-                object_id_delta: 0, // before delta logic, used to be subgroup_object_reader.object_id,
+                object_id_delta: subgroup_object_reader.object_id - current_object_id,
                 extension_headers: subgroup_object_reader.extension_headers.clone(), // Pass through extension headers
                 payload_length: subgroup_object_reader.size,
                 status: if subgroup_object_reader.size == 0 {
@@ -342,6 +343,7 @@ impl Subscribed {
                 chunks_sent,
                 bytes_sent
             );
+            current_object_id = subgroup_object_reader.object_id;
             object_count += 1;
         }
 


### PR DESCRIPTION
In [moq-transport/src/session/subscribed.rs](https://github.com/cloudflare/moq-rs/blob/3803121716190ed1360bc93ad2c676505219c56a/moq-transport/src/session/subscribed.rs), the `serve_subgroup` method hardcodes `object_id_delta: 0` for every object when re-serving subgroup data to downstream subscribers. Every object in a subgroup is received by downstream subscribers with `object_id=0`.

In draft-14, object IDs within a subgroup are delta-encoded (the receiver accumulates deltas to reconstruct absolute IDs - `current_object_id += delta`). With delta always `0`, the accumulator never advances and this corrupts object ordering for any client subscribing through the relay, causing playback failures. Direct publisher-to-client connections are unaffected - only relayed subscriptions are broken.

To fix, track a running `current_object_id` accumulator (starting at `0`) in the serving loop, then compute each delta as `object_id - current_object_id` (matching the inverse of the decode logic in subscriber.rs:543).