### PR TITLE
Add note about example applications in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ An implementation of the Media over QUIC Transport (MoQT) protocol for live medi
 
 This codebase was originally created by [Luke Curley (@kixelated)](https://github.com/kixelated). [Mike English (@englishm)](https://github.com/englishm) contributed to early design and has maintained this IETF-aligned fork. The project is now maintained by Cloudflare. The implementation targets [draft-ietf-moq-transport-14](https://datatracker.ietf.org/doc/draft-ietf-moq-transport/14/).
 
+> **Note:** This repository includes example client and server applications (moq-pub, moq-sub, moq-clock-ietf, moq-relay-ietf) intended to demonstrate usage of the moq-transport library. These are meant for testing and development purposes and have not been optimized for production use.
+
 ## Protocol Support
 
 The `main` branch targets **draft-14** of the MoQT specification. For draft-07 compatibility (used in [Cloudflare's current production deployment](https://developers.cloudflare.com/moq/)), see the [`draft-ietf-moq-transport-07`](https://github.com/cloudflare/moq-rs/tree/draft-ietf-moq-transport-07) branch.


### PR DESCRIPTION
## Summary
- Adds a note clarifying that bundled client/server apps are examples for testing and development, not production use.