### PR TITLE
relay: propagate downstream interest loss with warm-cache linger + upstream UNSUBSCRIBE

### DIFF
--- a/moq-relay-ietf/src/consumer.rs
+++ b/moq-relay-ietf/src/consumer.rs
@@ -6,11 +6,11 @@ use std::sync::Arc;
 use anyhow::Context;
 use futures::{stream::FuturesUnordered, FutureExt, StreamExt};
 use moq_transport::{
-    serve::Tracks,
+    serve::{ServeError, TrackLease, TrackRequest, Tracks, TrackWriter},
     session::{Announced, SessionError, Subscriber},
 };
 
-use crate::{metrics::GaugeGuard, Coordinator, Locals, Producer};
+use crate::{metrics::GaugeGuard, Coordinator, Locals, Producer, WARM_CACHE_LINGER};
 
 /// Consumer of tracks from a remote Publisher
 #[derive(Clone)]
@@ -158,18 +158,21 @@ impl Consumer {
                 },
 
                 // Wait for the next subscriber and serve the track.
-                Some(track) = request.next() => {
-                    let mut subscriber = self.subscriber.clone();
+                Some(req) = request.next() => {
+                    let subscriber = self.subscriber.clone();
 
                     // Spawn a new task to handle the subscribe
                     tasks.push(async move {
-                        let info = track.clone();
+                        let TrackRequest { writer, lease } = req;
+                        let info = writer.clone();
                         let namespace = info.namespace.to_utf8_path();
                         let track_name = info.name.clone();
                         tracing::info!(namespace = %namespace, track = %track_name, "forwarding subscribe: {:?}", info);
 
-                        // Forward the subscribe request
-                        if let Err(err) = subscriber.subscribe(track).await {
+                        // Forward the subscribe request, dropping the upstream
+                        // subscription (which emits UNSUBSCRIBE) once the last
+                        // downstream subscriber leaves and the linger expires.
+                        if let Err(err) = Self::serve_track_subscribe(subscriber, writer, lease).await {
                             tracing::warn!(namespace = %namespace, track = %track_name, error = %err, "failed forwarding subscribe: {:?}, error: {}", info, err)
                         }
 
@@ -178,6 +181,55 @@ impl Consumer {
                 },
                 res = tasks.next(), if !tasks.is_empty() => res.unwrap()?,
                 else => return Ok(()),
+            }
+        }
+    }
+
+    /// Forward a single deduplicated subscribe upstream and keep it alive only
+    /// while downstream subscribers are interested.
+    ///
+    /// Sending the SUBSCRIBE and awaiting SUBSCRIBE_OK is done by
+    /// [`Subscriber::subscribe_open`]. We then hold the resulting `Subscribe`
+    /// handle until one of:
+    ///  - the upstream subscription ends on its own (error / PUBLISH_DONE / teardown), or
+    ///  - the last downstream subscriber leaves and stays gone for [`WARM_CACHE_LINGER`].
+    ///
+    /// In the latter case we evict the dedup cache entry and return, dropping the
+    /// `Subscribe` — whose `Drop` emits the upstream UNSUBSCRIBE (the only place
+    /// the transport crate does so). Previously nothing propagated downstream
+    /// interest loss upstream, so the relay kept pulling from the publisher until
+    /// the whole session died.
+    async fn serve_track_subscribe(
+        mut subscriber: Subscriber,
+        writer: TrackWriter,
+        lease: TrackLease,
+    ) -> Result<(), ServeError> {
+        let subscribe = subscriber.subscribe_open(writer).await?;
+
+        loop {
+            // Wait until either the upstream subscription ends, or the last
+            // downstream subscriber goes away (interest drops to zero).
+            tokio::select! {
+                biased;
+                res = subscribe.closed() => return res,
+                _ = lease.interest().idle() => {}
+            }
+
+            // Warm-cache linger: keep the upstream subscription alive briefly so an
+            // instant late-joiner can reattach without a fresh upstream SUBSCRIBE.
+            tokio::select! {
+                biased;
+                res = subscribe.closed() => return res,
+                // A new subscriber arrived during the linger — keep serving.
+                _ = lease.interest().busy() => continue,
+                _ = tokio::time::sleep(WARM_CACHE_LINGER) => {
+                    // Linger elapsed. Evict the dedup entry iff still idle. On
+                    // success, returning drops `subscribe`, sending UNSUBSCRIBE.
+                    if lease.evict_if_idle() {
+                        return Ok(());
+                    }
+                    // Raced with a late joiner right at expiry; re-arm the linger.
+                }
             }
         }
     }

--- a/moq-relay-ietf/src/lib.rs
+++ b/moq-relay-ietf/src/lib.rs
@@ -42,6 +42,26 @@ mod remote;
 mod session;
 mod web;
 
+/// How long the relay keeps a warm upstream subscription alive after its last
+/// downstream subscriber leaves, before tearing it down.
+///
+/// A relay deduplicates many downstream subscribers onto a single upstream
+/// subscription. When the last downstream subscriber unsubscribes we do NOT tear
+/// the upstream subscription down immediately: a brief linger lets an instant
+/// late-joiner (a page reload, a player reconnect, a channel flip back) reattach
+/// to the still-warm subscription instead of paying for a fresh upstream
+/// SUBSCRIBE and the startup latency that comes with it (waiting for the next
+/// group / keyframe).
+///
+/// Once the linger elapses with no downstream interest, the upstream `Subscribe`
+/// handle is dropped — which is the only place the transport crate emits an
+/// UNSUBSCRIBE — and the dedup cache entry is evicted so a future subscriber
+/// starts a fresh upstream subscription.
+///
+/// Chosen at 3s: long enough to absorb brief gaps and reconnects, short enough
+/// that a publisher isn't served (and billed) for long after nobody is watching.
+pub const WARM_CACHE_LINGER: std::time::Duration = std::time::Duration::from_secs(3);
+
 pub use api::*;
 pub use consumer::*;
 pub use coordinator::*;

--- a/moq-relay-ietf/src/remote.rs
+++ b/moq-relay-ietf/src/remote.rs
@@ -8,12 +8,12 @@ use std::sync::{Arc, Weak};
 
 use moq_native_ietf::quic;
 use moq_transport::coding::TrackNamespace;
-use moq_transport::serve::{Track, TrackReader};
+use moq_transport::serve::{Track, TrackInterest, TrackReader};
 use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
 use url::Url;
 
-use crate::{metrics::GaugeGuard, Coordinator, CoordinatorError};
+use crate::{metrics::GaugeGuard, Coordinator, CoordinatorError, WARM_CACHE_LINGER};
 
 /// Cache key for upstream relay-to-relay connections.
 ///
@@ -22,7 +22,20 @@ use crate::{metrics::GaugeGuard, Coordinator, CoordinatorError};
 type RemoteCacheKey = (Url, Option<SocketAddr>);
 type RemoteSlot = Arc<Mutex<Option<Remote>>>;
 type TrackCacheKey = (TrackNamespace, String);
-type TrackSlot = Arc<Mutex<Option<TrackReader>>>;
+type TrackSlot = Arc<Mutex<Option<CachedTrack>>>;
+
+/// A deduplicated cross-relay track subscription.
+///
+/// Mirrors the local dedup cache in `moq-transport`'s `serve::tracks`: many
+/// downstream subscribers share one upstream subscription to a remote relay. The
+/// pinned `reader` clone keeps the track warm; `interest` counts how many
+/// downstream readers are currently live so the subscription task can tear the
+/// upstream subscription down (emitting UNSUBSCRIBE) once the last one leaves.
+#[derive(Clone)]
+struct CachedTrack {
+    reader: TrackReader,
+    interest: TrackInterest,
+}
 
 /// Manages connections to remote relays.
 ///
@@ -234,6 +247,48 @@ async fn remove_empty_track_slot(
     }
 }
 
+/// Log the outcome of a cross-relay track subscription ending.
+fn log_remote_subscription_ended(
+    url: &Url,
+    key: &TrackCacheKey,
+    result: Result<(), moq_transport::serve::ServeError>,
+) {
+    match result {
+        Ok(()) => {
+            tracing::debug!(remote_url = %url, namespace = %key.0, track = %key.1, "remote track subscription ended");
+        }
+        Err(err) => {
+            tracing::warn!(remote_url = %url, namespace = %key.0, track = %key.1, error = %err, "remote track subscription ended with error: {}", err);
+        }
+    }
+}
+
+/// Evict a cross-relay track from its cache slot, but only if the slot still
+/// holds the given reader AND no downstream interest remains.
+///
+/// The interest check runs under the same slot lock that `Remote::subscribe`
+/// holds when handing out readers, so a subscriber that arrives concurrently is
+/// never stranded on a torn-down upstream subscription: it either wins the lock
+/// (interest becomes non-zero and eviction is skipped) or takes the cache-miss
+/// path afterwards and creates a fresh upstream subscription. Returns true if the
+/// entry was evicted.
+async fn evict_remote_track_if_idle(
+    slot: &TrackSlot,
+    reader: &TrackReader,
+    interest: &TrackInterest,
+) -> bool {
+    let mut cached = slot.lock().await;
+    match cached.as_ref() {
+        Some(current)
+            if Arc::ptr_eq(&current.reader.info, &reader.info) && interest.count() == 0 =>
+        {
+            cached.take();
+            true
+        }
+        _ => false,
+    }
+}
+
 /// A connection to a single remote relay with its own QUIC client.
 #[derive(Clone)]
 struct Remote {
@@ -378,9 +433,15 @@ impl Remote {
                 continue;
             }
 
-            if let Some(reader) = cached.as_ref() {
-                if !reader.is_closed() {
-                    return Ok(Some(reader.clone()));
+            if let Some(entry) = cached.as_ref() {
+                if !entry.reader.is_closed() {
+                    // Deduplicate onto the warm upstream subscription. Hand out a
+                    // clone carrying a fresh interest guard (incremented under the
+                    // slot lock, serialized with eviction) so the subscription
+                    // task knows a downstream subscriber is present.
+                    return Ok(Some(
+                        entry.reader.clone().with_interest(entry.interest.guard()),
+                    ));
                 }
 
                 tracing::debug!(remote_url = %self.url, namespace = %key.0, track = %key.1, "removing closed remote track from cache");
@@ -420,32 +481,76 @@ impl Remote {
                 anyhow::bail!("remote connection to {} is closed", self.url);
             }
 
-            *cached = Some(reader.clone());
+            // Per-track interest counter, shared between the pinned cache clone,
+            // the handed-out reader's guard, and the subscription task below.
+            let interest = TrackInterest::new();
+
+            // Attach the first interest guard (count -> 1) BEFORE spawning the
+            // subscription task, so it never observes a spurious idle() at startup.
+            let handed = reader.clone().with_interest(interest.guard());
+
+            *cached = Some(CachedTrack {
+                reader: reader.clone(),
+                interest: interest.clone(),
+            });
             drop(cached);
 
             let cleanup_key = key.clone();
-            let cleanup_reader = reader.clone();
+            let cleanup_reader = reader;
             let cleanup_slot = slot.clone();
+            let cleanup_interest = interest.clone();
             tokio::spawn(async move {
-                tokio::select! {
-                    result = subscribe.closed() => {
-                        match result {
-                            Ok(()) => {
-                                tracing::debug!(remote_url = %url, namespace = %cleanup_key.0, track = %cleanup_key.1, "remote track subscription ended");
-                            }
-                            Err(err) => {
-                                tracing::warn!(remote_url = %url, namespace = %cleanup_key.0, track = %cleanup_key.1, error = %err, "remote track subscription ended with error: {}", err);
+                // Hold the upstream subscription until it ends on its own, the
+                // connection is cancelled, or downstream interest stays idle
+                // through the linger window.
+                loop {
+                    tokio::select! {
+                        biased;
+                        result = subscribe.closed() => {
+                            log_remote_subscription_ended(&url, &cleanup_key, result);
+                            break;
+                        }
+                        _ = cancel.cancelled() => {
+                            tracing::debug!(remote_url = %url, namespace = %cleanup_key.0, track = %cleanup_key.1, "remote track subscription cancelled");
+                            break;
+                        }
+                        _ = cleanup_interest.idle() => {
+                            // Last downstream subscriber left; linger briefly so an
+                            // instant late-joiner can reattach to the warm upstream
+                            // subscription instead of forcing a fresh SUBSCRIBE.
+                            tokio::select! {
+                                biased;
+                                result = subscribe.closed() => {
+                                    log_remote_subscription_ended(&url, &cleanup_key, result);
+                                    break;
+                                }
+                                _ = cancel.cancelled() => {
+                                    tracing::debug!(remote_url = %url, namespace = %cleanup_key.0, track = %cleanup_key.1, "remote track subscription cancelled");
+                                    break;
+                                }
+                                // A new subscriber arrived during the linger; keep serving.
+                                _ = cleanup_interest.busy() => {}
+                                _ = tokio::time::sleep(WARM_CACHE_LINGER) => {
+                                    // Linger elapsed. Evict iff still idle, then tear
+                                    // down (dropping `subscribe` emits UNSUBSCRIBE).
+                                    if evict_remote_track_if_idle(&cleanup_slot, &cleanup_reader, &cleanup_interest).await {
+                                        tracing::info!(remote_url = %url, namespace = %cleanup_key.0, track = %cleanup_key.1, "remote track idle; unsubscribing upstream");
+                                        break;
+                                    }
+                                    // Raced with a late joiner right at expiry; re-arm.
+                                }
                             }
                         }
                     }
-                    _ = cancel.cancelled() => {
-                        tracing::debug!(remote_url = %url, namespace = %cleanup_key.0, track = %cleanup_key.1, "remote track subscription cancelled");
-                    }
                 }
+
+                // Dropping the upstream subscription emits UNSUBSCRIBE (unless it
+                // already ended). Done explicitly for clarity before slot cleanup.
+                drop(subscribe);
 
                 if let Some(tracks) = tracks.upgrade() {
                     let mut cached = cleanup_slot.lock().await;
-                    if matches!(cached.as_ref(), Some(current) if Arc::ptr_eq(&current.info, &cleanup_reader.info))
+                    if matches!(cached.as_ref(), Some(current) if Arc::ptr_eq(&current.reader.info, &cleanup_reader.info))
                     {
                         cached.take();
                     }
@@ -455,7 +560,7 @@ impl Remote {
                 }
             });
 
-            return Ok(Some(reader));
+            return Ok(Some(handed));
         }
     }
 }

--- a/moq-transport/src/serve/interest.rs
+++ b/moq-transport/src/serve/interest.rs
@@ -1,0 +1,181 @@
+// SPDX-FileCopyrightText: 2024-2026 Cloudflare Inc., Luke Curley, Mike English and contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Downstream-interest tracking for deduplicated tracks.
+//!
+//! A relay deduplicates many downstream subscribers onto a single upstream
+//! subscription. Nothing in the plain [`Track`](super::Track) machinery counts
+//! how many downstream subscribers are currently interested, because the dedup
+//! cache pins a reader clone that keeps the track alive indefinitely. Without a
+//! separate count the upstream-subscribe task can never tell when the last
+//! downstream subscriber has left, so it never drops the upstream subscription
+//! (and therefore never emits an UNSUBSCRIBE).
+//!
+//! [`TrackInterest`] is that missing count. Each reader handed to a downstream
+//! subscriber carries a [`TrackInterestGuard`] that increments the count while it
+//! lives and decrements on drop. The pinned cache clone deliberately does not
+//! hold a guard, so it is not counted as interest.
+
+use crate::watch::State;
+
+/// A shared counter of live downstream reader handles for a single deduplicated track.
+///
+/// Cheap to clone; all clones observe the same count. See the module docs for how
+/// this plugs into the relay's dedup + upstream-unsubscribe logic.
+#[derive(Clone, Default)]
+pub struct TrackInterest {
+    // Number of live downstream reader handles, wrapped in a watchable State so
+    // tasks can await the count reaching (or leaving) zero.
+    count: State<usize>,
+}
+
+impl TrackInterest {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a new interested reader, returning a guard that decrements the
+    /// count when dropped.
+    pub fn guard(&self) -> TrackInterestGuard {
+        if let Some(mut count) = self.count.lock_mut() {
+            *count += 1;
+        }
+        TrackInterestGuard {
+            count: self.count.clone(),
+        }
+    }
+
+    /// The current number of live interested readers.
+    pub fn count(&self) -> usize {
+        *self.count.lock()
+    }
+
+    /// Wait until there are no interested readers (the count reaches zero).
+    /// Returns immediately if already idle.
+    pub async fn idle(&self) {
+        loop {
+            let notify = {
+                let count = self.count.lock();
+                if *count == 0 {
+                    return;
+                }
+                count.modified()
+            };
+
+            match notify {
+                Some(notify) => notify.await,
+                None => return,
+            }
+        }
+    }
+
+    /// Wait until there is at least one interested reader.
+    /// Returns immediately if already busy.
+    pub async fn busy(&self) {
+        loop {
+            let notify = {
+                let count = self.count.lock();
+                if *count > 0 {
+                    return;
+                }
+                count.modified()
+            };
+
+            match notify {
+                Some(notify) => notify.await,
+                None => return,
+            }
+        }
+    }
+}
+
+/// A guard representing a single downstream subscriber's interest in a track.
+///
+/// Held by the [`TrackReader`](super::TrackReader) handed to a downstream
+/// subscriber. Cloning increments the interest count; dropping decrements it.
+pub struct TrackInterestGuard {
+    count: State<usize>,
+}
+
+impl Clone for TrackInterestGuard {
+    fn clone(&self) -> Self {
+        if let Some(mut count) = self.count.lock_mut() {
+            *count += 1;
+        }
+        Self {
+            count: self.count.clone(),
+        }
+    }
+}
+
+impl Drop for TrackInterestGuard {
+    fn drop(&mut self) {
+        if let Some(mut count) = self.count.lock_mut() {
+            *count -= 1;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn guard_increments_and_decrements() {
+        let interest = TrackInterest::new();
+        assert_eq!(interest.count(), 0);
+
+        let a = interest.guard();
+        assert_eq!(interest.count(), 1);
+
+        let b = interest.guard();
+        assert_eq!(interest.count(), 2);
+
+        // Cloning a handed-out reader (and therefore its guard) also counts.
+        let b2 = b.clone();
+        assert_eq!(interest.count(), 3);
+
+        drop(b2);
+        assert_eq!(interest.count(), 2);
+
+        drop(a);
+        drop(b);
+        assert_eq!(interest.count(), 0);
+    }
+
+    #[tokio::test]
+    async fn idle_completes_when_count_reaches_zero() {
+        let interest = TrackInterest::new();
+        let guard = interest.guard();
+
+        // idle() must not complete while a guard is alive.
+        tokio::select! {
+            _ = interest.idle() => panic!("idle() completed while interest was held"),
+            _ = tokio::time::sleep(std::time::Duration::from_millis(20)) => {}
+        }
+
+        drop(guard);
+
+        // idle() must complete promptly once the last guard is dropped.
+        tokio::time::timeout(std::time::Duration::from_millis(100), interest.idle())
+            .await
+            .expect("idle() should complete after the last guard is dropped");
+    }
+
+    #[tokio::test]
+    async fn busy_completes_when_a_guard_is_created() {
+        let interest = TrackInterest::new();
+
+        // busy() must not complete while there is no interest.
+        tokio::select! {
+            _ = interest.busy() => panic!("busy() completed with no interest"),
+            _ = tokio::time::sleep(std::time::Duration::from_millis(20)) => {}
+        }
+
+        let _guard = interest.guard();
+
+        tokio::time::timeout(std::time::Duration::from_millis(100), interest.busy())
+            .await
+            .expect("busy() should complete once a guard exists");
+    }
+}

--- a/moq-transport/src/serve/mod.rs
+++ b/moq-transport/src/serve/mod.rs
@@ -4,6 +4,7 @@
 
 mod datagram;
 mod error;
+mod interest;
 mod object;
 mod stream;
 mod subgroup;
@@ -12,6 +13,7 @@ mod tracks;
 
 pub use datagram::*;
 pub use error::*;
+pub use interest::*;
 pub use object::*;
 pub use stream::*;
 pub use subgroup::*;

--- a/moq-transport/src/serve/track.rs
+++ b/moq-transport/src/serve/track.rs
@@ -20,7 +20,7 @@ use crate::watch::State;
 
 use super::{
     Datagrams, DatagramsReader, DatagramsWriter, ObjectsWriter, ServeError, Stream, StreamReader,
-    StreamWriter, Subgroups, SubgroupsReader, SubgroupsWriter,
+    StreamWriter, Subgroups, SubgroupsReader, SubgroupsWriter, TrackInterestGuard,
 };
 use crate::coding::{Location, TrackNamespace};
 use paste::paste;
@@ -184,11 +184,34 @@ impl Deref for TrackWriter {
 pub struct TrackReader {
     state: State<TrackState>,
     pub info: Arc<Track>,
+
+    /// Optional downstream-interest guard.
+    ///
+    /// Set by the relay dedup layer (via [`TrackReader::with_interest`]) on the
+    /// reader handed to each downstream subscriber, so the upstream-subscribe
+    /// task can tell when the last subscriber for a deduplicated track goes away.
+    /// It is `None` for the raw reader produced by [`Track::produce`] and for the
+    /// clone the dedup cache pins (which must not count as interest).
+    interest: Option<TrackInterestGuard>,
 }
 
 impl TrackReader {
     fn new(state: State<TrackState>, info: Arc<Track>) -> Self {
-        Self { state, info }
+        Self {
+            state,
+            info,
+            interest: None,
+        }
+    }
+
+    /// Attach a downstream-interest guard to this reader handle.
+    ///
+    /// Used by the relay dedup layer to count live downstream subscribers for a
+    /// deduplicated track. The guard increments the shared interest counter on
+    /// creation/clone and decrements it on drop.
+    pub fn with_interest(mut self, interest: TrackInterestGuard) -> Self {
+        self.interest = Some(interest);
+        self
     }
 
     /// Get the current mode of the track, waiting if necessary.

--- a/moq-transport/src/serve/tracks.rs
+++ b/moq-transport/src/serve/tracks.rs
@@ -16,9 +16,9 @@
 //! The broadcast is automatically closed with [ServeError::Done] when [Writer] is dropped, or all [Reader]s are dropped.
 use std::{collections::HashMap, ops::Deref, sync::Arc};
 
-use super::{ServeError, Track, TrackReader, TrackWriter};
+use super::{ServeError, Track, TrackInterest, TrackReader, TrackWriter};
 use crate::coding::TrackNamespace;
-use crate::watch::{Queue, State};
+use crate::watch::{Queue, State, StateWeak};
 
 /// Full track identifier: namespace + track name
 #[derive(Hash, Eq, PartialEq, Clone, Debug)]
@@ -51,9 +51,24 @@ impl Tracks {
     }
 }
 
+/// A deduplicated track cache entry.
+struct CachedTrack {
+    /// The pinned reader clone that keeps the track warm for late joiners.
+    ///
+    /// This clone deliberately does NOT carry a [`super::TrackInterestGuard`], so
+    /// it is not counted as downstream interest.
+    reader: TrackReader,
+
+    /// Shared counter of live downstream reader handles for this track.
+    ///
+    /// Incremented for every reader handed to a downstream subscriber (see
+    /// [`TracksReader::subscribe`]) and decremented when that reader is dropped.
+    interest: TrackInterest,
+}
+
 #[derive(Default)]
 pub struct TracksState {
-    tracks: HashMap<FullTrackName, TrackReader>,
+    tracks: HashMap<FullTrackName, CachedTrack>,
 }
 
 /// Publish new tracks for a broadcast by name.
@@ -82,7 +97,13 @@ impl TracksWriter {
             namespace: self.namespace.clone(),
             name: track.to_owned(),
         };
-        self.state.lock_mut()?.tracks.insert(full_name, reader);
+        self.state.lock_mut()?.tracks.insert(
+            full_name,
+            CachedTrack {
+                reader,
+                interest: TrackInterest::new(),
+            },
+        );
 
         Some(writer)
     }
@@ -93,7 +114,11 @@ impl TracksWriter {
             namespace: namespace.clone(),
             name: track_name.to_owned(),
         };
-        self.state.lock_mut()?.tracks.remove(&full_name)
+        self.state
+            .lock_mut()?
+            .tracks
+            .remove(&full_name)
+            .map(|cached| cached.reader)
     }
 }
 
@@ -105,15 +130,81 @@ impl Deref for TracksWriter {
     }
 }
 
+/// A request to create and serve a single track, delivered to the
+/// upstream-subscribe task via [`TracksRequest::next`].
+///
+/// It bundles the [`TrackWriter`] that upstream data is written into with a
+/// [`TrackLease`] the task uses to notice when the last downstream subscriber
+/// has gone away (so it can tear down the upstream subscription and evict the
+/// dedup cache entry).
+pub struct TrackRequest {
+    /// The writer that upstream (relayed) data is fed into.
+    pub writer: TrackWriter,
+
+    /// Downstream-interest lease for this deduplicated track.
+    pub lease: TrackLease,
+}
+
+/// Tracks downstream interest in a deduplicated track, and lets the
+/// upstream-subscribe task evict the shared dedup cache entry once interest is
+/// idle.
+pub struct TrackLease {
+    interest: TrackInterest,
+    state: StateWeak<TracksState>,
+    full_name: FullTrackName,
+}
+
+impl TrackLease {
+    /// The shared downstream-interest counter for this track.
+    ///
+    /// The upstream-subscribe task awaits [`TrackInterest::idle`] /
+    /// [`TrackInterest::busy`] on this to drive the warm-cache linger.
+    pub fn interest(&self) -> &TrackInterest {
+        &self.interest
+    }
+
+    /// Evict this track from the dedup cache, but only if no downstream interest
+    /// remains.
+    ///
+    /// The check and removal happen under the same broadcast lock that
+    /// [`TracksReader::subscribe`] uses to hand out readers, so a subscriber that
+    /// arrives concurrently is never stranded on a torn-down upstream: either it
+    /// wins the lock (interest becomes non-zero and eviction is skipped) or we do
+    /// (the entry is removed and the late subscriber takes the cache-miss path,
+    /// creating a fresh upstream subscription).
+    ///
+    /// Returns true if the entry was evicted (or the broadcast is already gone),
+    /// signalling the caller that it is safe to drop the upstream subscription.
+    pub fn evict_if_idle(&self) -> bool {
+        let state = match self.state.upgrade() {
+            Some(state) => state,
+            // The broadcast is gone; there is nothing left to serve.
+            None => return true,
+        };
+
+        let mut state = match state.lock_mut() {
+            Some(state) => state,
+            None => return true,
+        };
+
+        if self.interest.count() != 0 {
+            return false;
+        }
+
+        state.tracks.remove(&self.full_name);
+        true
+    }
+}
+
 pub struct TracksRequest {
     #[allow(dead_code)] // Avoid dropping the write side
     state: State<TracksState>,
-    incoming: Option<Queue<TrackWriter>>,
+    incoming: Option<Queue<TrackRequest>>,
     pub info: Arc<Tracks>,
 }
 
 impl TracksRequest {
-    fn new(state: State<TracksState>, incoming: Queue<TrackWriter>, info: Arc<Tracks>) -> Self {
+    fn new(state: State<TracksState>, incoming: Queue<TrackRequest>, info: Arc<Tracks>) -> Self {
         Self {
             state,
             incoming: Some(incoming),
@@ -123,7 +214,7 @@ impl TracksRequest {
 
     /// Wait for a request to create a new track.
     /// None is returned if all [TracksReader]s have been dropped.
-    pub async fn next(&mut self) -> Option<TrackWriter> {
+    pub async fn next(&mut self) -> Option<TrackRequest> {
         self.incoming.as_mut()?.pop().await
     }
 }
@@ -148,8 +239,8 @@ impl Drop for TracksRequest {
                 "TracksRequest dropped with pending track requests"
             );
         }
-        for track in pending_tracks {
-            let _ = track.close(ServeError::not_found_ctx(
+        for request in pending_tracks {
+            let _ = request.writer.close(ServeError::not_found_ctx(
                 "tracks request dropped before track handled",
             ));
         }
@@ -162,12 +253,12 @@ impl Drop for TracksRequest {
 #[derive(Clone)]
 pub struct TracksReader {
     state: State<TracksState>,
-    queue: Queue<TrackWriter>,
+    queue: Queue<TrackRequest>,
     pub info: Arc<Tracks>,
 }
 
 impl TracksReader {
-    fn new(state: State<TracksState>, queue: Queue<TrackWriter>, info: Arc<Tracks>) -> Self {
+    fn new(state: State<TracksState>, queue: Queue<TrackRequest>, info: Arc<Tracks>) -> Self {
         Self { state, queue, info }
     }
 
@@ -184,9 +275,11 @@ impl TracksReader {
             name: track_name.to_owned(),
         };
 
-        if let Some(track_reader) = state.tracks.get(&full_name) {
-            if !track_reader.is_closed() {
-                return Some(track_reader.clone());
+        if let Some(cached) = state.tracks.get(&full_name) {
+            if !cached.reader.is_closed() {
+                // NOTE: no interest guard is attached — a track-status probe is
+                // not a real subscription and must not keep the track warm.
+                return Some(cached.reader.clone());
             }
             // Track exists but is closed/stale - don't return it
         }
@@ -201,6 +294,10 @@ impl TracksReader {
         namespace: TrackNamespace,
         track_name: &str,
     ) -> Option<TrackReader> {
+        // A weak handle to the broadcast state, used by the delivered lease to
+        // evict this entry once downstream interest goes idle.
+        let state_weak = self.state.downgrade();
+
         let state = self.state.lock();
         let full_name = FullTrackName {
             namespace: namespace.clone(),
@@ -208,16 +305,19 @@ impl TracksReader {
         };
 
         // Check if we have a cached track that is still alive
-        if let Some(track_reader) = state.tracks.get(&full_name) {
-            if !track_reader.is_closed() {
-                // Track is still active, return the cached reader
+        if let Some(cached) = state.tracks.get(&full_name) {
+            if !cached.reader.is_closed() {
+                // Track is still active, deduplicate onto the warm upstream
+                // subscription. Hand out a clone carrying a fresh interest guard
+                // (incremented under this lock, serialized with eviction) so the
+                // upstream-subscribe task knows a subscriber is present.
                 tracing::debug!(
                     target: "moq_transport::tracks",
                     namespace = %namespace.to_utf8_path(),
                     track = %track_name,
                     "track cache hit (active)"
                 );
-                return Some(track_reader.clone());
+                return Some(cached.reader.clone().with_interest(cached.interest.guard()));
             }
             // Track is closed/stale, fall through to create a new one
             tracing::debug!(
@@ -233,13 +333,29 @@ impl TracksReader {
         // Remove the stale track if it exists (it was closed)
         state.tracks.remove(&full_name);
         // Use the full requested namespace, not self.namespace
-        let track_writer_reader = Track {
+        let (writer, reader) = Track {
             namespace: namespace.clone(),
             name: track_name.to_owned(),
         }
         .produce();
 
-        if self.queue.push(track_writer_reader.0).is_err() {
+        // Per-track interest counter, shared between the pinned cache clone, the
+        // handed-out reader's guard, and the lease delivered to the upstream task.
+        let interest = TrackInterest::new();
+
+        // Attach the first interest guard (count -> 1) BEFORE queueing the request,
+        // so the upstream-subscribe task never observes a spurious idle() before
+        // the caller has started serving. The increment happens under this lock,
+        // serialized with eviction.
+        let handed = reader.clone().with_interest(interest.guard());
+
+        let lease = TrackLease {
+            interest: interest.clone(),
+            state: state_weak,
+            full_name: full_name.clone(),
+        };
+
+        if self.queue.push(TrackRequest { writer, lease }).is_err() {
             tracing::debug!(
                 target: "moq_transport::tracks",
                 namespace = %namespace.to_utf8_path(),
@@ -250,9 +366,14 @@ impl TracksReader {
         }
 
         // We requested the track successfully so we can deduplicate it by full name.
-        state
-            .tracks
-            .insert(full_name, track_writer_reader.1.clone());
+        // The pinned cache clone deliberately carries NO interest guard.
+        state.tracks.insert(
+            full_name,
+            CachedTrack {
+                reader,
+                interest: interest.clone(),
+            },
+        );
 
         tracing::debug!(
             target: "moq_transport::tracks",
@@ -261,7 +382,7 @@ impl TracksReader {
             "track cache miss, requested from upstream"
         );
 
-        Some(track_writer_reader.1)
+        Some(handed)
     }
 }
 
@@ -305,7 +426,8 @@ mod tests {
         let track_writer_1 = request
             .next()
             .await
-            .expect("publisher should receive first track request");
+            .expect("publisher should receive first track request")
+            .writer;
 
         assert_eq!(track_writer_1.name, track_name);
 
@@ -344,7 +466,8 @@ mod tests {
 
         let track_writer_2 = maybe_track_writer_2
             .unwrap()
-            .expect("publisher should receive second track request");
+            .expect("publisher should receive second track request")
+            .writer;
 
         assert_eq!(track_writer_2.name, track_name);
 
@@ -377,8 +500,9 @@ mod tests {
             .subscribe(namespace.clone(), track_name)
             .expect("first subscribe should succeed");
 
-        // Publisher receives request
-        let _track_writer = request
+        // Publisher receives request. Hold the whole request (writer + lease) so
+        // the track stays alive for the dedup check below.
+        let _request = request
             .next()
             .await
             .expect("publisher should receive track request");
@@ -420,7 +544,8 @@ mod tests {
         let track_writer = request
             .next()
             .await
-            .expect("publisher should receive track request");
+            .expect("publisher should receive track request")
+            .writer;
 
         let _subgroups_writer = track_writer
             .subgroups()
@@ -455,7 +580,8 @@ mod tests {
         let track_writer = request
             .next()
             .await
-            .expect("publisher should receive track request");
+            .expect("publisher should receive track request")
+            .writer;
 
         let subgroups_writer = track_writer
             .subgroups()
@@ -477,5 +603,167 @@ mod tests {
         let _second_request = maybe_second_request
             .unwrap()
             .expect("publisher should receive second track request");
+    }
+
+    /// (a) When the last downstream subscriber leaves, the per-track interest
+    /// counter reaches zero, `idle()` fires, and — after the linger — the dedup
+    /// cache entry can be evicted so a future subscriber re-requests upstream.
+    ///
+    /// This is the core of the fix: without interest tracking the pinned cache
+    /// clone kept the track alive forever, so the upstream subscription (and its
+    /// UNSUBSCRIBE) was never released.
+    #[tokio::test]
+    async fn test_interest_idle_allows_eviction_and_resubscribe() {
+        let namespace = TrackNamespace::from_utf8_path("test/namespace");
+        let track_name = "test-track";
+        let (_writer, mut request, mut reader) = Tracks::new(namespace.clone()).produce();
+
+        // A subscriber arrives: cache miss, an upstream request is queued.
+        let track_reader = reader
+            .subscribe(namespace.clone(), track_name)
+            .expect("subscribe should succeed");
+
+        let TrackRequest {
+            writer: _upstream_writer,
+            lease,
+        } = request
+            .next()
+            .await
+            .expect("publisher should receive a track request");
+
+        // The pinned cache clone must NOT count as interest — only the one
+        // handed-out reader does.
+        assert_eq!(lease.interest().count(), 1);
+        assert!(
+            !lease.evict_if_idle(),
+            "must not evict while a subscriber is present"
+        );
+
+        // Last subscriber leaves.
+        drop(track_reader);
+
+        // Interest becomes idle (this is what the linger loop awaits before it
+        // drops the upstream Subscribe).
+        tokio::time::timeout(
+            std::time::Duration::from_millis(100),
+            lease.interest().idle(),
+        )
+        .await
+        .expect("interest should become idle after the last reader drops");
+        assert_eq!(lease.interest().count(), 0);
+
+        // After the linger, still idle: the entry is evicted (the caller would
+        // then drop its Subscribe, emitting the upstream UNSUBSCRIBE).
+        assert!(lease.evict_if_idle(), "idle track should be evictable");
+
+        // The dedup cache no longer pins the track, so a fresh subscribe takes the
+        // cache-miss path and re-requests from upstream.
+        let _track_reader_2 = reader
+            .subscribe(namespace.clone(), track_name)
+            .expect("re-subscribe should succeed");
+        let maybe_new =
+            tokio::time::timeout(std::time::Duration::from_millis(100), request.next()).await;
+        assert!(
+            maybe_new.is_ok(),
+            "a new upstream request should be issued after eviction"
+        );
+    }
+
+    /// (b) A late joiner that arrives during the linger window (a cache hit)
+    /// re-arms interest, so the eviction check refuses and the warm upstream
+    /// subscription is kept — no new upstream request is issued.
+    #[tokio::test]
+    async fn test_resubscribe_during_linger_keeps_subscription() {
+        let namespace = TrackNamespace::from_utf8_path("test/namespace");
+        let track_name = "test-track";
+        let (_writer, mut request, mut reader) = Tracks::new(namespace.clone()).produce();
+
+        let track_reader_1 = reader
+            .subscribe(namespace.clone(), track_name)
+            .expect("subscribe should succeed");
+        let TrackRequest {
+            writer: _upstream_writer,
+            lease,
+        } = request
+            .next()
+            .await
+            .expect("publisher should receive a track request");
+
+        // Subscriber leaves -> interest idle -> linger begins.
+        drop(track_reader_1);
+        tokio::time::timeout(
+            std::time::Duration::from_millis(100),
+            lease.interest().idle(),
+        )
+        .await
+        .expect("interest should become idle");
+        assert_eq!(lease.interest().count(), 0);
+
+        // A late joiner arrives DURING the linger: cache hit, interest re-armed.
+        let _track_reader_2 = reader
+            .subscribe(namespace.clone(), track_name)
+            .expect("re-subscribe should succeed");
+        assert_eq!(lease.interest().count(), 1);
+
+        // The linger's eviction check now refuses: the warm subscription is kept.
+        assert!(
+            !lease.evict_if_idle(),
+            "must not evict while a late joiner is present"
+        );
+
+        // No new upstream request was issued (still deduped onto the warm subscription).
+        let maybe_new =
+            tokio::time::timeout(std::time::Duration::from_millis(100), request.next()).await;
+        assert!(
+            maybe_new.is_err(),
+            "no new upstream request should be issued for a cache hit during linger"
+        );
+    }
+
+    /// (c) After the entry is evicted, a brand-new subscriber creates a genuinely
+    /// fresh upstream subscription (new writer + new interest counter).
+    #[tokio::test]
+    async fn test_resubscribe_after_eviction_creates_new_upstream() {
+        let namespace = TrackNamespace::from_utf8_path("test/namespace");
+        let track_name = "test-track";
+        let (_writer, mut request, mut reader) = Tracks::new(namespace.clone()).produce();
+
+        let track_reader = reader
+            .subscribe(namespace.clone(), track_name)
+            .expect("subscribe should succeed");
+        let TrackRequest {
+            writer: upstream_writer_1,
+            lease,
+        } = request
+            .next()
+            .await
+            .expect("publisher should receive a track request");
+
+        drop(track_reader);
+        tokio::time::timeout(
+            std::time::Duration::from_millis(100),
+            lease.interest().idle(),
+        )
+        .await
+        .expect("interest should become idle");
+        assert!(lease.evict_if_idle(), "idle track should be evictable");
+        // Simulate the upstream-subscribe task tearing down after eviction.
+        drop(upstream_writer_1);
+        drop(lease);
+
+        // A brand-new subscriber triggers a fresh upstream subscription.
+        let track_reader_2 = reader
+            .subscribe(namespace.clone(), track_name)
+            .expect("re-subscribe should succeed");
+        let request_2 = tokio::time::timeout(std::time::Duration::from_millis(100), request.next())
+            .await
+            .expect("publisher should receive a request")
+            .expect("a new upstream request should be issued after eviction");
+
+        assert_eq!(request_2.writer.name, track_name);
+        // The new request carries its own, independent interest counter, already
+        // reflecting the single live downstream reader.
+        assert_eq!(request_2.lease.interest().count(), 1);
+        drop(track_reader_2);
     }
 }


### PR DESCRIPTION
Observed bug
------------
When a relay deduplicates several downstream subscribers onto a single upstream subscription, it never propagates interest loss back upstream. After the LAST downstream subscriber for a track unsubscribes or disconnects, the relay sends NO upstream UNSUBSCRIBE: the upstream publisher keeps producing and the relay keeps pulling the track until the whole session dies. Measured live against Cloudflare's deployment: the upstream subscription stayed active for >80s after the last subscriber left, with no UNSUBSCRIBE ever emitted.

Root cause
----------
Three things combined:

  * No interest tracking. `TracksReader::subscribe` (the dedup point) hands each downstream subscriber a clone of a cached `TrackReader`, but nothing counts how many are alive.
  * A pinned cache reader. On a cache miss the dedup cache stores a strong `TrackReader` clone, so the track's reader side never fully drops even after every real subscriber is gone. There was no TTL/eviction sweep (`TracksWriter::remove` was dead code).
  * `Subscribe::drop` is the ONLY place the transport crate emits an upstream UNSUBSCRIBE. The upstream-subscribe holders in the relay (`consumer.rs` locals path and `remote.rs` cross-relay path) hold that `Subscribe` and await only `subscribe.closed()`, which resolves solely on upstream events (SUBSCRIBE_ERROR / PUBLISH_DONE / stream error) or session teardown. Downstream UNSUBSCRIBE / disconnect merely dropped per-viewer `TrackReader` clones while the cache kept one pinned, so the `Subscribe` was never dropped and no UNSUBSCRIBE was sent.

Fix design
----------
Add explicit downstream-interest tracking at both dedup points and react to it at both upstream-subscribe sites:

  * Interest refcount. New `serve::TrackInterest` / `TrackInterestGuard` (moq-transport). Every `TrackReader` handed to a downstream subscriber carries a guard that increments the per-track count on creation/clone and decrements on drop. The dedup cache's own pinned reader clone deliberately carries NO guard, so it is not counted as interest. The reader flows through `Subscribed::serve`, which holds it for the whole downstream subscription, so the guard's lifetime exactly matches real interest.

  * Warm-cache linger. When interest reaches zero the upstream-subscribe task does NOT tear down immediately; it waits `WARM_CACHE_LINGER` (3s, see moq-relay-ietf/src/lib.rs). If a new subscriber arrives during the linger it is cancelled and serving continues from the still-warm upstream subscription, preserving the intentional instant-late-joiner caching behavior (page reloads, reconnects, channel flips) without a fresh upstream SUBSCRIBE and its startup latency.

  * Eviction + UNSUBSCRIBE. If the linger elapses still idle, the task evicts the dedup-cache entry and returns, dropping the `Subscribe` handle so `Subscribe::drop` emits the upstream UNSUBSCRIBE. The eviction check is serialized with `subscribe()` under the shared cache lock, so a subscriber arriving at the same instant is never stranded on a torn-down upstream: it either keeps the entry warm or takes the cache-miss path and starts a fresh upstream subscription.

  * Both paths. The same select-on-interest-idle + linger + eviction logic is applied to the locals path (`consumer.rs`, via `TracksReader`'s new `TrackRequest`/`TrackLease`) and the cross-relay path (`remote.rs`, whose own per-track cache now stores the interest alongside the reader).

Existing deduplication-while-alive behavior is preserved (multiple concurrent subscribers still share one upstream subscription; `test_track_deduplication_while_alive` still passes).

Tests
-----
moq-transport gains unit tests for: interest guard increment/decrement and idle/busy signalling; refcount reaching zero + linger allowing eviction + re-subscribe re-requesting upstream; re-subscribe during the linger keeping the warm subscription (no new upstream request); and re-subscribe after eviction creating a genuinely fresh upstream subscription.

cargo build + cargo test pass for moq-transport and moq-relay-ietf, and `cargo build --workspace` is clean.