### PR TITLE
Publish message support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1378,6 +1378,7 @@ name = "moq-test-client"
 version = "0.1.8"
 dependencies = [
  "anyhow",
+ "bytes",
  "clap",
  "moq-native-ietf",
  "moq-transport",

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ This repository provides:
 **Supported:**
 - CLIENT_SETUP / SERVER_SETUP
 - PUBLISH_NAMESPACE
+- PUBLISH / PUBLISH_OK / PUBLISH_DONE
 - SUBSCRIBE
 - WebTransport and raw QUIC transport layers
 - Both stream ("subgroup") and datagram delivery modes

--- a/moq-api/CHANGELOG.md
+++ b/moq-api/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 
 - update Cargo.lock dependencies
+- Refresh locked dependencies for the draft-16 release train; no moq-api behavior changes.
 
 ## [0.2.10](https://github.com/cloudflare/moq-rs/compare/moq-api-v0.2.9...moq-api-v0.2.10) - 2026-03-31
 

--- a/moq-clock-ietf/CHANGELOG.md
+++ b/moq-clock-ietf/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 
 - Merge pull request #170 from itzmanish/draft-16-rewrite
+- Update the clock example to run on the draft-16 transport/native stack.
 
 ## [0.6.15](https://github.com/cloudflare/moq-rs/compare/moq-clock-ietf-v0.6.14...moq-clock-ietf-v0.6.15) - 2026-06-10
 

--- a/moq-native-ietf/CHANGELOG.md
+++ b/moq-native-ietf/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 
 - Merge pull request #170 from itzmanish/draft-16-rewrite
+- Update native QUIC/WebTransport helpers to use the moq-transport 0.15 draft-16 session stack.
 
 ## [0.9.0](https://github.com/cloudflare/moq-rs/compare/moq-native-ietf-v0.8.0...moq-native-ietf-v0.9.0) - 2026-06-10
 

--- a/moq-pub/CHANGELOG.md
+++ b/moq-pub/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.8.16](https://github.com/cloudflare/moq-rs/compare/moq-pub-v0.8.15...moq-pub-v0.8.16) - 2026-07-08
 
+### Added
+
+- add `--publish` mode to push newly created tracks with PUBLISH after announcing the namespace
+
 ### Other
 
 - Merge pull request #170 from itzmanish/draft-16-rewrite

--- a/moq-pub/CHANGELOG.md
+++ b/moq-pub/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 
 - Merge pull request #170 from itzmanish/draft-16-rewrite
+- Update publisher CLI dependencies for the draft-16 transport/native stack.
 
 ## [0.8.15](https://github.com/cloudflare/moq-rs/compare/moq-pub-v0.8.14...moq-pub-v0.8.15) - 2026-06-10
 

--- a/moq-pub/README.md
+++ b/moq-pub/README.md
@@ -5,7 +5,7 @@ A command line tool for publishing media via Media over QUIC (MoQ).
 Expects to receive fragmented MP4 via standard input and connect to a MOQT relay.
 
 ```
-ffmpeg ... - | moq-pub https://localhost:4443
+ffmpeg ... - | moq-pub --name bbb https://localhost:4443
 ```
 
 ### Invoking `moq-pub`:
@@ -13,10 +13,16 @@ ffmpeg ... - | moq-pub https://localhost:4443
 Here's how I'm currently testing things, with a local copy of Big Buck Bunny named `bbb_source.mp4`:
 
 ```
-$ ffmpeg -hide_banner -v quiet -stream_loop -1 -re -i bbb_source.mp4 -an -f mp4 -movflags empty_moov+frag_every_frame+separate_moof+omit_tfhd_offset - | RUST_LOG=moq_pub=info moq-pub https://localhost:4443
+$ ffmpeg -hide_banner -v quiet -stream_loop -1 -re -i bbb_source.mp4 -an -f mp4 -movflags empty_moov+frag_every_frame+separate_moof+omit_tfhd_offset - | RUST_LOG=moq_pub=info moq-pub --name bbb https://localhost:4443
 ```
 
 This relies on having `moq-relay` (the relay server) already running locally in another shell.
+
+Add `--publish` to push each created track with PUBLISH after announcing the namespace:
+
+```
+$ ffmpeg -hide_banner -v quiet -stream_loop -1 -re -i bbb_source.mp4 -an -f mp4 -movflags empty_moov+frag_every_frame+separate_moof+omit_tfhd_offset - | RUST_LOG=moq_pub=info moq-pub --name bbb --publish https://localhost:4443
+```
 
 Note also that we're dropping the audio track (`-an`) above until audio playback is stabilized on the `moq-js` side.
 

--- a/moq-pub/src/main.rs
+++ b/moq-pub/src/main.rs
@@ -9,10 +9,16 @@ use url::Url;
 use anyhow::Context;
 use clap::Parser;
 use tokio::io::AsyncReadExt;
+use tokio::sync::mpsc;
+use tokio::task::JoinSet;
 
 use moq_native_ietf::quic;
 use moq_pub::Media;
-use moq_transport::{coding::TrackNamespace, serve, session::Publisher};
+use moq_transport::{
+    coding::{KeyValuePairs, TrackName, TrackNamespace},
+    serve,
+    session::Publisher,
+};
 
 #[derive(Parser, Clone)]
 pub struct Cli {
@@ -41,6 +47,10 @@ pub struct Cli {
     /// The TLS configuration.
     #[command(flatten)]
     pub tls: moq_native_ietf::tls::Args,
+
+    /// Push tracks with PUBLISH after sending PUBLISH_NAMESPACE.
+    #[arg(long)]
+    pub publish: bool,
 }
 
 #[tokio::main]
@@ -58,7 +68,14 @@ async fn main() -> anyhow::Result<()> {
 
     let (writer, _, reader) =
         serve::Tracks::new(TrackNamespace::from_utf8_path(&cli.name)).produce();
-    let media = Media::new(writer)?;
+
+    let (track_tx, track_rx) = if cli.publish {
+        let (tx, rx) = mpsc::unbounded_channel();
+        (Some(tx), Some(rx))
+    } else {
+        (None, None)
+    };
+    let media = Media::new(writer, track_tx)?;
 
     let tls = cli.tls.load()?;
 
@@ -76,19 +93,92 @@ async fn main() -> anyhow::Result<()> {
         connection_id
     );
 
-    let (session, mut publisher) = Publisher::connect(session, transport)
+    let (session, publisher) = Publisher::connect(session, transport)
         .await
         .context("failed to create MoQ Transport publisher")?;
+
+    let mut namespace_publisher = publisher.clone();
+    let publish_publisher = publisher;
+    let namespace_reader = reader.clone();
+    let publish_reader = reader.clone();
 
     tokio::select! {
         res = session.run() => res.context("session error")?,
         res = run_media(media) => {
             res.context("media error")?
         },
-        res = publisher.publish_namespace(reader) => res.context("publisher error")?,
+        res = namespace_publisher.publish_namespace(namespace_reader) => res.context("publisher error")?,
+        res = async {
+            if let Some(track_rx) = track_rx {
+                publish_created_tracks(publish_publisher, publish_reader, track_rx).await?;
+            }
+            Ok::<_, anyhow::Error>(())
+        }, if cli.publish => res.context("publish tracks error")?,
     }
 
     Ok(())
+}
+
+async fn publish_created_tracks(
+    mut publisher: Publisher,
+    mut tracks: serve::TracksReader,
+    mut track_rx: mpsc::UnboundedReceiver<TrackName>,
+) -> anyhow::Result<()> {
+    let mut tasks = JoinSet::new();
+
+    loop {
+        tokio::select! {
+            Some(track_name) = track_rx.recv() => {
+                let namespace = tracks.namespace.clone();
+                let Some(track) = tracks.get_track_reader(&namespace, track_name.clone()) else {
+                    tracing::warn!(namespace = %namespace, track = %track_name, "created track was not found in TracksReader");
+                    continue;
+                };
+
+                tracing::info!(namespace = %namespace, track = %track_name, "sending PUBLISH for track");
+                let published = publisher
+                    .publish(track, KeyValuePairs::default())
+                    .await
+                    .with_context(|| format!("failed to send PUBLISH for track {}/{}", namespace, track_name))?;
+
+                tasks.spawn(async move {
+                    published
+                        .serve()
+                        .await
+                        .context("failed serving PUBLISH track")
+                });
+            },
+            Some(res) = tasks.join_next(), if !tasks.is_empty() => {
+                res.context("PUBLISH track task panicked")??;
+            },
+            else => return Ok(()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn publish_flag_defaults_false() {
+        let cli = Cli::try_parse_from(["moq-pub", "https://example.com/watch", "--name", "test"])
+            .unwrap();
+        assert!(!cli.publish);
+    }
+
+    #[test]
+    fn publish_flag_sets_true() {
+        let cli = Cli::try_parse_from([
+            "moq-pub",
+            "https://example.com/watch",
+            "--name",
+            "test",
+            "--publish",
+        ])
+        .unwrap();
+        assert!(cli.publish);
+    }
 }
 
 async fn run_media(mut media: Media) -> anyhow::Result<()> {

--- a/moq-pub/src/media.rs
+++ b/moq-pub/src/media.rs
@@ -4,12 +4,16 @@
 
 use anyhow::{self, Context};
 use bytes::{Buf, BufMut, Bytes, BytesMut};
-use moq_transport::serve::{SubgroupWriter, SubgroupsWriter, TrackWriter, TracksWriter};
+use moq_transport::{
+    coding::TrackName,
+    serve::{SubgroupWriter, SubgroupsWriter, TrackWriter, TracksWriter},
+};
 use mp4::{self, ReadBox, TrackType};
 use std::cmp::max;
 use std::collections::HashMap;
 use std::io::Cursor;
 use std::time;
+use tokio::sync::mpsc;
 
 pub struct Media {
     // Tracks based on their track ID.
@@ -28,10 +32,16 @@ pub struct Media {
 
     // The current track name
     current: Option<u32>,
+
+    // Optional notification for tracks as they become available.
+    track_tx: Option<mpsc::UnboundedSender<TrackName>>,
 }
 
 impl Media {
-    pub fn new(mut broadcast: TracksWriter) -> anyhow::Result<Self> {
+    pub fn new(
+        mut broadcast: TracksWriter,
+        track_tx: Option<mpsc::UnboundedSender<TrackName>>,
+    ) -> anyhow::Result<Self> {
         let catalog = broadcast
             .create(".catalog")
             .context("broadcast closed")?
@@ -41,6 +51,11 @@ impl Media {
             .context("broadcast closed")?
             .subgroups()?;
 
+        if let Some(tx) = &track_tx {
+            let _ = tx.send(TrackName::from(".catalog"));
+            let _ = tx.send(TrackName::from("0.mp4"));
+        }
+
         Ok(Media {
             tracks: Default::default(),
             broadcast,
@@ -49,6 +64,7 @@ impl Media {
             ftyp: None,
             moov: None,
             current: None,
+            track_tx,
         })
     }
 
@@ -251,6 +267,9 @@ impl Media {
 
             // Store the track publisher in a map so we can update it later.
             let track = self.broadcast.create(&name).context("broadcast closed")?;
+            if let Some(tx) = &self.track_tx {
+                let _ = tx.send(TrackName::from(name.clone()));
+            }
             let track = Track::new(track, handler, timescale);
             self.tracks.insert(id, track);
         }

--- a/moq-relay-ietf/CHANGELOG.md
+++ b/moq-relay-ietf/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.7.20](https://github.com/cloudflare/moq-rs/compare/moq-relay-ietf-v0.7.19...moq-relay-ietf-v0.7.20) - 2026-07-08
 
+### Added
+
+- route track-level PUBLISH registrations so relays can serve exact pushed tracks before falling back to namespace routing
+
 ### Other
 
 - Merge pull request #170 from itzmanish/draft-16-rewrite

--- a/moq-relay-ietf/CHANGELOG.md
+++ b/moq-relay-ietf/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 
 - Merge pull request #170 from itzmanish/draft-16-rewrite
+- Update relay dependencies for the draft-16 transport/native stack.
 
 ## [0.7.19](https://github.com/cloudflare/moq-rs/compare/moq-relay-ietf-v0.7.18...moq-relay-ietf-v0.7.19) - 2026-06-10
 

--- a/moq-relay-ietf/src/bin/moq-relay-ietf/file_coordinator.rs
+++ b/moq-relay-ietf/src/bin/moq-relay-ietf/file_coordinator.rs
@@ -32,7 +32,7 @@ struct CoordinatorData {
     #[serde(default)]
     namespaces: HashMap<String, HashMap<String, String>>,
     /// Maps connection scope to exact full-track map.
-    /// Key format: `<namespace utf8 path>--<track utf8/lossy>`.
+    /// Key format: `<namespace utf8 byte len>:<namespace utf8 path><track utf8/lossy>`.
     #[serde(default)]
     tracks: HashMap<String, HashMap<String, String>>,
 }
@@ -47,7 +47,8 @@ impl CoordinatorData {
     }
 
     fn track_key(namespace: &TrackNamespace, track: &str) -> String {
-        format!("{}--{}", namespace.to_utf8_path(), track)
+        let namespace = namespace.to_utf8_path();
+        format!("{}:{}{}", namespace.len(), namespace, track)
     }
 }
 
@@ -512,6 +513,40 @@ mod tests {
         assert_eq!(origin.namespace(), &namespace);
         assert_eq!(origin.url(), relay_url);
         assert!(client.is_none());
+
+        let _ = std::fs::remove_file(file);
+    }
+
+    #[tokio::test]
+    async fn lookup_track_distinguishes_separator_text_in_namespace_and_track() {
+        let file = temp_file_path("track-key-collision");
+        let relay_a = Url::parse("https://relay-a.example.com").unwrap();
+        let relay_b = Url::parse("https://relay-b.example.com").unwrap();
+        let coordinator_a = FileCoordinator::new(&file, relay_a.clone());
+        let coordinator_b = FileCoordinator::new(&file, relay_b.clone());
+        let namespace_a = TrackNamespace::from_utf8_path("room--audio");
+        let namespace_b = TrackNamespace::from_utf8_path("room");
+
+        let _track_a = coordinator_a
+            .register_track(Some("scope-a"), &namespace_a, "main")
+            .await
+            .expect("first track should register");
+        let _track_b = coordinator_b
+            .register_track(Some("scope-a"), &namespace_b, "audio--main")
+            .await
+            .expect("second track should register");
+
+        let (origin_a, _) = coordinator_a
+            .lookup_track(Some("scope-a"), &namespace_a, "main")
+            .await
+            .expect("first track lookup should find original relay");
+        let (origin_b, _) = coordinator_a
+            .lookup_track(Some("scope-a"), &namespace_b, "audio--main")
+            .await
+            .expect("second track lookup should find original relay");
+
+        assert_eq!(origin_a.url(), relay_a);
+        assert_eq!(origin_b.url(), relay_b);
 
         let _ = std::fs::remove_file(file);
     }

--- a/moq-relay-ietf/src/bin/moq-relay-ietf/file_coordinator.rs
+++ b/moq-relay-ietf/src/bin/moq-relay-ietf/file_coordinator.rs
@@ -22,13 +22,19 @@ use url::Url;
 
 use moq_relay_ietf::{
     Coordinator, CoordinatorError, CoordinatorResult, NamespaceOrigin, NamespaceRegistration,
+    TrackRegistration,
 };
 
 /// Data stored in the shared file
 #[derive(Debug, Default, Serialize, Deserialize)]
 struct CoordinatorData {
     /// Maps connection scope to namespace map
+    #[serde(default)]
     namespaces: HashMap<String, HashMap<String, String>>,
+    /// Maps connection scope to exact full-track map.
+    /// Key format: `<namespace utf8 path>--<track utf8/lossy>`.
+    #[serde(default)]
+    tracks: HashMap<String, HashMap<String, String>>,
 }
 
 impl CoordinatorData {
@@ -39,6 +45,10 @@ impl CoordinatorData {
     fn namespace_key(namespace: &TrackNamespace) -> String {
         namespace.to_utf8_path()
     }
+
+    fn track_key(namespace: &TrackNamespace, track: &str) -> String {
+        format!("{}--{}", namespace.to_utf8_path(), track)
+    }
 }
 
 /// Handle that unregisters a namespace when dropped
@@ -46,6 +56,21 @@ struct NamespaceUnregisterHandle {
     scope_key: String,
     namespace_key: String,
     file_path: PathBuf,
+}
+
+/// Handle that unregisters a track when dropped.
+struct TrackUnregisterHandle {
+    scope_key: String,
+    track_key: String,
+    file_path: PathBuf,
+}
+
+impl Drop for TrackUnregisterHandle {
+    fn drop(&mut self) {
+        if let Err(err) = unregister_track_sync(&self.file_path, &self.scope_key, &self.track_key) {
+            tracing::warn!(track = %self.track_key, error = %err, "failed to unregister track on drop: {}", err);
+        }
+    }
 }
 
 impl Drop for NamespaceUnregisterHandle {
@@ -75,6 +100,31 @@ fn unregister_namespace_sync(file_path: &Path, scope_key: &str, namespace_key: &
         bucket.remove(namespace_key);
         if bucket.is_empty() {
             data.namespaces.remove(scope_key);
+        }
+    }
+
+    write_data(&file, &data)?;
+    file.unlock()?;
+
+    Ok(())
+}
+
+fn unregister_track_sync(file_path: &Path, scope_key: &str, track_key: &str) -> Result<()> {
+    let file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(file_path)?;
+
+    file.lock_exclusive()?;
+
+    let mut data = read_data(&file)?;
+    tracing::debug!(track = %track_key, scope = %scope_key, "unregistering track: {}", track_key);
+    if let Some(bucket) = data.tracks.get_mut(scope_key) {
+        bucket.remove(track_key);
+        if bucket.is_empty() {
+            data.tracks.remove(scope_key);
         }
     }
 
@@ -279,8 +329,214 @@ impl Coordinator for FileCoordinator {
         result.ok_or(CoordinatorError::NamespaceNotFound)
     }
 
+    async fn register_track(
+        &self,
+        scope: Option<&str>,
+        namespace: &TrackNamespace,
+        track: &str,
+    ) -> CoordinatorResult<TrackRegistration> {
+        let scope_key = CoordinatorData::scope_key(scope);
+        let track_key = CoordinatorData::track_key(namespace, track);
+        let relay_url = self.relay_url.to_string();
+        let file_path = self.file_path.clone();
+
+        let scope_clone = scope_key.clone();
+        let key_clone = track_key.clone();
+        tokio::task::spawn_blocking(move || {
+            let file = OpenOptions::new()
+                .read(true)
+                .write(true)
+                .create(true)
+                .truncate(false)
+                .open(&file_path)?;
+
+            file.lock_exclusive()?;
+
+            let mut data = read_data(&file)?;
+            tracing::info!(track = %key_clone, scope = %scope_clone, relay_url = %relay_url, "registering track: {} -> {}", key_clone, relay_url);
+            data.tracks
+                .entry(scope_clone)
+                .or_default()
+                .insert(key_clone, relay_url);
+
+            write_data(&file, &data)?;
+            file.unlock()?;
+
+            Ok::<_, anyhow::Error>(())
+        })
+        .await??;
+
+        let handle = TrackUnregisterHandle {
+            scope_key,
+            track_key,
+            file_path: self.file_path.clone(),
+        };
+
+        Ok(TrackRegistration::new(handle))
+    }
+
+    async fn unregister_track(
+        &self,
+        scope: Option<&str>,
+        namespace: &TrackNamespace,
+        track: &str,
+    ) -> CoordinatorResult<()> {
+        let scope_key = CoordinatorData::scope_key(scope);
+        let track_key = CoordinatorData::track_key(namespace, track);
+        let file_path = self.file_path.clone();
+
+        tokio::task::spawn_blocking(move || {
+            unregister_track_sync(&file_path, &scope_key, &track_key)
+        })
+        .await??;
+
+        Ok(())
+    }
+
+    async fn lookup_track(
+        &self,
+        scope: Option<&str>,
+        namespace: &TrackNamespace,
+        track: &str,
+    ) -> CoordinatorResult<(NamespaceOrigin, Option<Client>)> {
+        let namespace = namespace.clone();
+        let scope_key = CoordinatorData::scope_key(scope);
+        let namespace_key = CoordinatorData::namespace_key(&namespace);
+        let track_key = CoordinatorData::track_key(&namespace, track);
+        let file_path = self.file_path.clone();
+
+        let result = tokio::task::spawn_blocking(
+            move || -> Result<Option<(NamespaceOrigin, Option<Client>)>> {
+                let file = OpenOptions::new()
+                    .read(true)
+                    .write(true)
+                    .create(true)
+                    .truncate(false)
+                    .open(&file_path)?;
+
+                file.lock_shared()?;
+
+                let data = read_data(&file)?;
+                tracing::debug!(track = %track_key, scope = %scope_key, "looking up track: {}", track_key);
+
+                if let Some(relay_url) = data
+                    .tracks
+                    .get(&scope_key)
+                    .and_then(|bucket| bucket.get(&track_key))
+                {
+                    let url = Url::parse(relay_url)?;
+                    file.unlock()?;
+                    return Ok(Some((NamespaceOrigin::new(namespace.clone(), url, None), None)));
+                }
+
+                let Some(bucket) = data.namespaces.get(&scope_key) else {
+                    file.unlock()?;
+                    return Ok(None);
+                };
+
+                if let Some(relay_url) = bucket.get(&namespace_key) {
+                    let url = Url::parse(relay_url)?;
+                    file.unlock()?;
+                    return Ok(Some((NamespaceOrigin::new(namespace.clone(), url, None), None)));
+                }
+
+                let mut best_match: Option<(String, String)> = None;
+                for (registered_key, url) in bucket {
+                    let is_prefix = registered_key
+                        .split('/')
+                        .zip(namespace_key.split('/'))
+                        .all(|(a, b)| a == b);
+                    match best_match {
+                        Some((ns, _)) if is_prefix && ns.len() < registered_key.len() => {
+                            best_match = Some((registered_key.clone(), url.clone()));
+                        }
+                        None if is_prefix => {
+                            best_match = Some((registered_key.clone(), url.clone()));
+                        }
+                        _ => {}
+                    }
+                }
+
+                file.unlock()?;
+
+                if let Some((matched_key, relay_url)) = best_match {
+                    let matched_ns = TrackNamespace::from_utf8_path(&matched_key);
+                    let url = Url::parse(&relay_url)?;
+                    return Ok(Some((NamespaceOrigin::new(matched_ns, url, None), None)));
+                }
+
+                Ok(None)
+            },
+        )
+        .await??;
+
+        result.ok_or(CoordinatorError::NamespaceNotFound)
+    }
+
     async fn shutdown(&self) -> CoordinatorResult<()> {
         // Nothing to clean up - file will be unlocked automatically
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_file_path(name: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!("moq-file-coordinator-{name}-{nanos}.json"))
+    }
+
+    #[tokio::test]
+    async fn lookup_track_finds_registered_track() {
+        let file = temp_file_path("track-lookup");
+        let relay_url = Url::parse("https://relay.example.com").unwrap();
+        let coordinator = FileCoordinator::new(&file, relay_url.clone());
+        let namespace = TrackNamespace::from_utf8_path("room/123");
+
+        let _track = coordinator
+            .register_track(Some("scope-a"), &namespace, "audio")
+            .await
+            .expect("track should register");
+
+        let (origin, client) = coordinator
+            .lookup_track(Some("scope-a"), &namespace, "audio")
+            .await
+            .expect("track lookup should find registration");
+
+        assert_eq!(origin.namespace(), &namespace);
+        assert_eq!(origin.url(), relay_url);
+        assert!(client.is_none());
+
+        let _ = std::fs::remove_file(file);
+    }
+
+    #[tokio::test]
+    async fn lookup_track_falls_back_to_namespace() {
+        let file = temp_file_path("track-namespace-fallback");
+        let relay_url = Url::parse("https://relay.example.com").unwrap();
+        let coordinator = FileCoordinator::new(&file, relay_url.clone());
+        let namespace = TrackNamespace::from_utf8_path("room/123");
+
+        let _namespace = coordinator
+            .register_namespace(Some("scope-a"), &namespace)
+            .await
+            .expect("namespace should register");
+
+        let (origin, client) = coordinator
+            .lookup_track(Some("scope-a"), &namespace, "audio")
+            .await
+            .expect("track lookup should fall back to namespace");
+
+        assert_eq!(origin.namespace(), &namespace);
+        assert_eq!(origin.url(), relay_url);
+        assert!(client.is_none());
+
+        let _ = std::fs::remove_file(file);
     }
 }

--- a/moq-relay-ietf/src/consumer.rs
+++ b/moq-relay-ietf/src/consumer.rs
@@ -6,8 +6,9 @@ use std::sync::Arc;
 use anyhow::Context;
 use futures::{stream::FuturesUnordered, FutureExt, StreamExt};
 use moq_transport::{
-    serve::Tracks,
-    session::{PublishedNamespace, SessionError, Subscriber},
+    message::RequestErrorCode,
+    serve::{FullTrackName, ServeError, Tracks},
+    session::{PublishReceived, PublishedNamespace, SessionError, Subscriber},
 };
 
 use crate::{metrics::GaugeGuard, Coordinator, Locals, Producer};
@@ -42,13 +43,16 @@ impl Consumer {
         }
     }
 
-    /// Run the consumer to handle inbound PUBLISH_NAMESPACE requests.
-    pub async fn run(mut self) -> Result<(), SessionError> {
-        let mut tasks = FuturesUnordered::new();
+    /// Run the consumer to handle inbound PUBLISH_NAMESPACE and PUBLISH requests.
+    pub async fn run(self) -> Result<(), SessionError> {
+        let mut tasks: FuturesUnordered<futures::future::BoxFuture<'static, ()>> =
+            FuturesUnordered::new();
 
         loop {
+            let mut namespace_subscriber = self.subscriber.clone();
+            let mut publish_subscriber = self.subscriber.clone();
             tokio::select! {
-                Some(published_ns) = self.subscriber.published_namespace() => {
+                Some(published_ns) = namespace_subscriber.published_namespace() => {
                     metrics::counter!("moq_relay_publishers_total").increment(1);
 
                     let this = self.clone();
@@ -68,7 +72,21 @@ impl Consumer {
                                 "failed serving PUBLISH_NAMESPACE: {:?}", info
                             );
                         }
-                    });
+                    }.boxed());
+                },
+                Some(publish) = publish_subscriber.publish_received() => {
+                    metrics::counter!("moq_relay_published_tracks_total").increment(1);
+
+                    let this = self.clone();
+                    tasks.push(async move {
+                        let namespace = publish.namespace().to_utf8_path();
+                        let track_name = publish.name().clone();
+                        tracing::info!(namespace = %namespace, track = %track_name, "serving PUBLISH");
+
+                        if let Err(err) = this.serve_track(publish).await {
+                            tracing::warn!(namespace = %namespace, track = %track_name, error = %err, "failed serving PUBLISH");
+                        }
+                    }.boxed());
                 },
                 _ = tasks.next(), if !tasks.is_empty() => {},
                 else => return Ok(()),
@@ -82,16 +100,15 @@ impl Consumer {
         let _publisher_guard = GaugeGuard::new("moq_relay_active_publishers");
 
         let mut tasks = FuturesUnordered::new();
+        let ns = published_ns.namespace.to_utf8_path();
 
-        let (_, mut request, reader) = Tracks::new(published_ns.namespace.clone()).produce();
-
-        let ns = reader.namespace.to_utf8_path();
-
-        // Register the namespace locally so downstream subscribers can be served.
-        tracing::debug!(namespace = %ns, "registering namespace in locals");
-        let _register = match self
+        // Register namespace routing metadata locally. This does not register
+        // any media tracks; it only creates a request queue used when a
+        // downstream SUBSCRIBE asks for a missing track under this namespace.
+        tracing::debug!(namespace = %ns, "registering namespace route source in locals");
+        let (_register, mut requests) = match self
             .locals
-            .register(self.scope.as_deref(), reader.clone())
+            .register_namespace(self.scope.as_deref(), published_ns.namespace.clone())
             .await
         {
             Ok(reg) => reg,
@@ -101,13 +118,13 @@ impl Consumer {
                 return Err(err);
             }
         };
-        tracing::debug!(namespace = %ns, "namespace registered in locals");
+        tracing::debug!(namespace = %ns, "namespace route source registered in locals");
 
         // Register namespace with the coordinator so other relay nodes can route to us.
         tracing::debug!(namespace = %ns, "registering namespace with coordinator");
         let _namespace_registration = match self
             .coordinator
-            .register_namespace(self.scope.as_deref(), &reader.namespace)
+            .register_namespace(self.scope.as_deref(), &published_ns.namespace)
             .await
         {
             Ok(reg) => reg,
@@ -129,15 +146,20 @@ impl Consumer {
 
         // Forward the namespace upstream, if configured.
         if let Some(mut forward) = self.forward {
+            // The forwarding API still uses the moq-transport Tracks helper.
+            // This helper is not the relay-local registry; it is only an
+            // adapter for the outgoing publish_namespace API.
+            let (_, _forward_request, forward_reader) =
+                Tracks::new(published_ns.namespace.clone()).produce();
             tasks.push(
                 async move {
-                    let namespace = reader.namespace.to_utf8_path();
+                    let namespace = forward_reader.namespace.to_utf8_path();
                     tracing::info!(
                         namespace = %namespace,
-                        "forwarding PUBLISH_NAMESPACE: {:?}", reader.info
+                        "forwarding PUBLISH_NAMESPACE: {:?}", forward_reader.info
                     );
                     forward
-                        .publish_namespace(reader)
+                        .publish_namespace(forward_reader)
                         .await
                         .context("failed forwarding PUBLISH_NAMESPACE")
                 }
@@ -153,7 +175,7 @@ impl Consumer {
                     tracing::info!(namespace = %ns, "PUBLISH_NAMESPACE closed");
                     return Ok(());
                 },
-                Some(track) = request.next() => {
+                Some(track) = requests.recv() => {
                     let mut subscriber = self.subscriber.clone();
 
                     tasks.push(async move {
@@ -182,5 +204,82 @@ impl Consumer {
                 else => return Ok(()),
             }
         }
+    }
+
+    /// Serve an inbound PUBLISH for one exact track.
+    async fn serve_track(mut self, mut publish: PublishReceived) -> Result<(), anyhow::Error> {
+        let namespace = publish.namespace().clone();
+        let track_name = publish.name().clone();
+        let full_name = FullTrackName {
+            namespace: namespace.clone(),
+            name: track_name.clone(),
+        };
+
+        // First-cut multi-publisher policy: reject a second publisher for the
+        // same exact scoped Full Track Name. draft-16 §8.3 allows multiple
+        // publishers, but deduplication is follow-up work.
+        if self
+            .locals
+            .retrieve_track(self.scope.as_deref(), &full_name)
+            .is_some()
+        {
+            publish.close(ServeError::Closed(RequestErrorCode::Uninterested as u64));
+            return Err(ServeError::Duplicate.into());
+        }
+
+        // Take the reader first, then follow the same order as PUBLISH_NAMESPACE:
+        // local registration → coordinator registration → PUBLISH_OK.
+        let reader = match publish.take_reader() {
+            Ok(reader) => reader,
+            Err(err) => {
+                metrics::counter!("moq_relay_publish_errors_total", "phase" => "take_reader")
+                    .increment(1);
+                return Err(err.into());
+            }
+        };
+
+        let _registration = match self
+            .locals
+            .register_track(self.scope.as_deref(), reader)
+            .await
+        {
+            Ok(registration) => registration,
+            Err(err) => {
+                metrics::counter!("moq_relay_publish_errors_total", "phase" => "local_register")
+                    .increment(1);
+                return Err(err);
+            }
+        };
+
+        let track_string = track_name.to_string();
+        let _track_registration = match self
+            .coordinator
+            .register_track(self.scope.as_deref(), &namespace, &track_string)
+            .await
+        {
+            Ok(registration) => registration,
+            Err(err) => {
+                metrics::counter!("moq_relay_publish_errors_total", "phase" => "coordinator_register")
+                    .increment(1);
+                publish.close(ServeError::Closed(RequestErrorCode::InternalError as u64));
+                return Err(err.into());
+            }
+        };
+
+        if let Err(err) = publish.accept(true) {
+            metrics::counter!("moq_relay_publish_errors_total", "phase" => "send_ok").increment(1);
+            return Err(err.into());
+        }
+
+        tracing::debug!(
+            namespace = %namespace.to_utf8_path(),
+            track = %track_name,
+            "PUBLISH registered as exact local track"
+        );
+
+        publish.closed().await?;
+        tracing::info!(namespace = %namespace.to_utf8_path(), track = %track_name, "PUBLISH closed");
+
+        Ok(())
     }
 }

--- a/moq-relay-ietf/src/consumer.rs
+++ b/moq-relay-ietf/src/consumer.rs
@@ -218,7 +218,7 @@ impl Consumer {
             Err(_) => {
                 metrics::counter!("moq_relay_publish_errors_total", "phase" => "session_limit")
                     .increment(1);
-                publish.close(ServeError::Closed(RequestErrorCode::Uninterested as u64));
+                publish.close(ServeError::Closed(RequestErrorCode::InternalError as u64));
                 return Err(ServeError::Cancel.into());
             }
         };

--- a/moq-relay-ietf/src/consumer.rs
+++ b/moq-relay-ietf/src/consumer.rs
@@ -7,11 +7,14 @@ use anyhow::Context;
 use futures::{stream::FuturesUnordered, FutureExt, StreamExt};
 use moq_transport::{
     message::RequestErrorCode,
-    serve::{FullTrackName, ServeError, Tracks},
+    serve::{ServeError, Tracks},
     session::{PublishReceived, PublishedNamespace, SessionError, Subscriber},
 };
+use tokio::sync::Semaphore;
 
 use crate::{metrics::GaugeGuard, Coordinator, Locals, Producer};
+
+const MAX_INBOUND_PUBLISH_TRACKS_PER_SESSION: usize = 1024;
 
 /// Consumer of tracks from a remote Publisher
 #[derive(Clone)]
@@ -24,6 +27,7 @@ pub struct Consumer {
     /// Produced by `Coordinator::resolve_scope()` from the connection path.
     /// Passed to coordinator register/lookup calls to isolate namespaces.
     scope: Option<String>,
+    publish_track_permits: Arc<Semaphore>,
 }
 
 impl Consumer {
@@ -40,6 +44,7 @@ impl Consumer {
             coordinator,
             forward,
             scope,
+            publish_track_permits: Arc::new(Semaphore::new(MAX_INBOUND_PUBLISH_TRACKS_PER_SESSION)),
         }
     }
 
@@ -47,10 +52,10 @@ impl Consumer {
     pub async fn run(self) -> Result<(), SessionError> {
         let mut tasks: FuturesUnordered<futures::future::BoxFuture<'static, ()>> =
             FuturesUnordered::new();
+        let mut namespace_subscriber = self.subscriber.clone();
+        let mut publish_subscriber = self.subscriber.clone();
 
         loop {
-            let mut namespace_subscriber = self.subscriber.clone();
-            let mut publish_subscriber = self.subscriber.clone();
             tokio::select! {
                 Some(published_ns) = namespace_subscriber.published_namespace() => {
                     metrics::counter!("moq_relay_publishers_total").increment(1);
@@ -208,24 +213,18 @@ impl Consumer {
 
     /// Serve an inbound PUBLISH for one exact track.
     async fn serve_track(mut self, mut publish: PublishReceived) -> Result<(), anyhow::Error> {
-        let namespace = publish.namespace().clone();
-        let track_name = publish.name().clone();
-        let full_name = FullTrackName {
-            namespace: namespace.clone(),
-            name: track_name.clone(),
+        let _publish_permit = match self.publish_track_permits.clone().try_acquire_owned() {
+            Ok(permit) => permit,
+            Err(_) => {
+                metrics::counter!("moq_relay_publish_errors_total", "phase" => "session_limit")
+                    .increment(1);
+                publish.close(ServeError::Closed(RequestErrorCode::Uninterested as u64));
+                return Err(ServeError::Cancel.into());
+            }
         };
 
-        // First-cut multi-publisher policy: reject a second publisher for the
-        // same exact scoped Full Track Name. draft-16 §8.3 allows multiple
-        // publishers, but deduplication is follow-up work.
-        if self
-            .locals
-            .retrieve_track(self.scope.as_deref(), &full_name)
-            .is_some()
-        {
-            publish.close(ServeError::Closed(RequestErrorCode::Uninterested as u64));
-            return Err(ServeError::Duplicate.into());
-        }
+        let namespace = publish.namespace().clone();
+        let track_name = publish.name().clone();
 
         // Take the reader first, then follow the same order as PUBLISH_NAMESPACE:
         // local registration → coordinator registration → PUBLISH_OK.
@@ -247,6 +246,13 @@ impl Consumer {
             Err(err) => {
                 metrics::counter!("moq_relay_publish_errors_total", "phase" => "local_register")
                     .increment(1);
+                if err
+                    .downcast_ref::<ServeError>()
+                    .is_some_and(|err| matches!(err, ServeError::Duplicate))
+                {
+                    publish.close(ServeError::Duplicate);
+                    return Err(ServeError::Duplicate.into());
+                }
                 return Err(err);
             }
         };

--- a/moq-relay-ietf/src/coordinator.rs
+++ b/moq-relay-ietf/src/coordinator.rs
@@ -502,6 +502,27 @@ pub trait Coordinator: Send + Sync {
         namespace: &TrackNamespace,
     ) -> CoordinatorResult<(NamespaceOrigin, Option<quic::Client>)>;
 
+    /// Lookup where a specific track is served from.
+    ///
+    /// Called when a subscriber requests a full track name. Implementations
+    /// should prefer exact track registrations created by PUBLISH, then fall
+    /// back to namespace routing created by PUBLISH_NAMESPACE. This keeps the
+    /// common caller ergonomic while still allowing a single PUBLISH track to be
+    /// routed without pretending the whole namespace was published.
+    ///
+    /// # Default Implementation
+    ///
+    /// Falls back to [`lookup`], so existing coordinators that only implement
+    /// namespace-level routing retain their current behavior.
+    async fn lookup_track(
+        &self,
+        scope: Option<&str>,
+        namespace: &TrackNamespace,
+        _track: &str,
+    ) -> CoordinatorResult<(NamespaceOrigin, Option<quic::Client>)> {
+        self.lookup(scope, namespace).await
+    }
+
     /// Graceful shutdown of the coordinator.
     ///
     /// Called when the relay is shutting down. Implementations should:
@@ -1101,6 +1122,30 @@ mod tests {
                 }
                 None => Err(CoordinatorError::NamespaceNotFound),
             }
+        }
+
+        async fn lookup_track(
+            &self,
+            scope: Option<&str>,
+            namespace: &TrackNamespace,
+            track: &str,
+        ) -> CoordinatorResult<(NamespaceOrigin, Option<quic::Client>)> {
+            let scope_key = MockState::scope_key(scope);
+            let track_key = MockState::track_key(namespace, track);
+
+            {
+                let state = self.state.lock().unwrap();
+                if let Some(relay_url) = state
+                    .tracks
+                    .get(&scope_key)
+                    .and_then(|bucket| bucket.get(&track_key))
+                {
+                    let url = Url::parse(relay_url).unwrap();
+                    return Ok((NamespaceOrigin::new(namespace.clone(), url, None), None));
+                }
+            }
+
+            self.lookup(scope, namespace).await
         }
 
         async fn get_scope_config(&self, scope: Option<&str>) -> CoordinatorResult<ScopeConfig> {
@@ -1748,6 +1793,44 @@ mod tests {
         assert!(names.contains(&"video-1080p"));
         assert!(names.contains(&"video-480p"));
         assert!(names.contains(&"audio-en"));
+    }
+
+    #[tokio::test]
+    async fn lookup_track_finds_exact_registered_track() {
+        let coord = MockCoordinator::new("https://relay-1.example.com");
+        let scope = Some("content-provider-123");
+        let match_ns = ns("sports/football/match-42");
+
+        let _reg = coord
+            .register_track(scope, &match_ns, "video-1080p")
+            .await
+            .unwrap();
+
+        let (origin, client) = coord
+            .lookup_track(scope, &match_ns, "video-1080p")
+            .await
+            .unwrap();
+
+        assert_eq!(origin.namespace(), &match_ns);
+        assert_eq!(origin.url().as_str(), "https://relay-1.example.com/");
+        assert!(client.is_none());
+    }
+
+    #[tokio::test]
+    async fn lookup_track_falls_back_to_namespace_registration() {
+        let coord = MockCoordinator::new("https://relay-1.example.com");
+        let scope = Some("content-provider-123");
+        let match_ns = ns("sports/football/match-42");
+
+        let _namespace = coord.register_namespace(scope, &match_ns).await.unwrap();
+
+        let (origin, client) = coord
+            .lookup_track(scope, &match_ns, "video-1080p")
+            .await
+            .unwrap();
+        assert_eq!(origin.namespace(), &match_ns);
+        assert_eq!(origin.url().as_str(), "https://relay-1.example.com/");
+        assert!(client.is_none());
     }
 
     #[tokio::test]

--- a/moq-relay-ietf/src/local.rs
+++ b/moq-relay-ietf/src/local.rs
@@ -3,13 +3,13 @@
 
 use std::collections::hash_map;
 use std::collections::HashMap;
-
 use std::sync::{Arc, Mutex};
 
 use moq_transport::{
     coding::TrackNamespace,
-    serve::{ServeError, TracksReader},
+    serve::{FullTrackName, ServeError, Track, TrackReader, TrackWriter},
 };
+use tokio::sync::mpsc;
 
 use crate::metrics::GaugeGuard;
 
@@ -19,22 +19,29 @@ use crate::metrics::GaugeGuard;
 /// connections share this bucket — any publisher without a scope can be reached
 /// by any subscriber without a scope. This is the default behavior for backward
 /// compatibility with pre-scope deployments.
-///
-/// We use `String` rather than `Option<String>` so that `HashMap::get` can
-/// accept a `&str` via the `Borrow` trait, avoiding a heap allocation on
-/// every lookup in `retrieve()`.
 type ScopeKey = String;
 
 /// The scope key used for unscoped (global) registrations.
 const UNSCOPED: &str = "";
 
-/// Registry of local tracks, indexed by (scope, namespace).
+#[derive(Clone)]
+struct NamespaceSource {
+    requests: mpsc::UnboundedSender<TrackWriter>,
+}
+
+/// Relay-local registry.
 ///
-/// Uses a two-level map so that `retrieve()` only scans namespaces within
-/// the matching scope, rather than iterating all namespaces across all scopes.
+/// Actual media tracks are always stored by exact Full Track Name. Namespace
+/// entries are only routing metadata from PUBLISH_NAMESPACE: they tell the
+/// relay which upstream publisher can be asked for a missing track.
 #[derive(Clone)]
 pub struct Locals {
-    lookup: Arc<Mutex<HashMap<ScopeKey, HashMap<TrackNamespace, TracksReader>>>>,
+    /// Actual media tracks, indexed by (scope, full track name).
+    tracks: Arc<Mutex<HashMap<ScopeKey, HashMap<FullTrackName, TrackReader>>>>,
+
+    /// Namespace route sources from PUBLISH_NAMESPACE, indexed by (scope,
+    /// namespace) and matched by prefix.
+    namespaces: Arc<Mutex<HashMap<ScopeKey, HashMap<TrackNamespace, NamespaceSource>>>>,
 }
 
 impl Default for Locals {
@@ -43,68 +50,141 @@ impl Default for Locals {
     }
 }
 
-/// Local tracks registry.
 impl Locals {
     pub fn new() -> Self {
         Self {
-            lookup: Default::default(),
+            tracks: Default::default(),
+            namespaces: Default::default(),
         }
     }
 
-    /// Register new local tracks.
+    /// Register namespace routing metadata from PUBLISH_NAMESPACE.
     ///
-    /// `scope` is the resolved scope identity from `Coordinator::resolve_scope()`,
-    /// or `None` for unscoped sessions. Registrations are keyed by `(scope, namespace)`,
-    /// so the same namespace in different scopes routes independently.
-    pub async fn register(
+    /// This does not register any media tracks. It only creates a request queue
+    /// used when a downstream SUBSCRIBE asks for a missing track under this
+    /// namespace.
+    pub async fn register_namespace(
         &mut self,
         scope: Option<&str>,
-        tracks: TracksReader,
-    ) -> anyhow::Result<Registration> {
-        let namespace = tracks.namespace.clone();
+        namespace: TrackNamespace,
+    ) -> anyhow::Result<(
+        LocalNamespaceRegistration,
+        mpsc::UnboundedReceiver<TrackWriter>,
+    )> {
         let scope_key = scope.unwrap_or(UNSCOPED).to_string();
+        let (tx, rx) = mpsc::unbounded_channel();
 
-        // Insert the tracks into the scope bucket
-        let mut lookup = self.lookup.lock().unwrap();
-        let bucket = lookup.entry(scope_key.clone()).or_default();
+        let mut namespaces = self
+            .namespaces
+            .lock()
+            .map_err(|_| ServeError::internal_ctx("locals namespace registry lock poisoned"))?;
+        let bucket = namespaces.entry(scope_key.clone()).or_default();
         match bucket.entry(namespace.clone()) {
-            hash_map::Entry::Vacant(entry) => entry.insert(tracks),
+            hash_map::Entry::Vacant(entry) => {
+                entry.insert(NamespaceSource { requests: tx });
+            }
             hash_map::Entry::Occupied(_) => return Err(ServeError::Duplicate.into()),
-        };
+        }
 
-        let registration = Registration {
+        let registration = LocalNamespaceRegistration {
             locals: self.clone(),
             scope_key,
             namespace,
             _gauge_guard: GaugeGuard::new("moq_relay_announced_namespaces"),
         };
 
-        Ok(registration)
+        Ok((registration, rx))
     }
 
-    /// Retrieve local tracks by namespace using hierarchical prefix matching.
-    /// Returns the TracksReader for the longest matching namespace prefix.
-    ///
-    /// `scope` is the resolved scope identity from `Coordinator::resolve_scope()`,
-    /// or `None` for unscoped sessions. When `scope` is `None`, only tracks
-    /// registered without a scope (the global/unscoped bucket) are searched.
-    pub fn retrieve(
+    /// Register one exact track received via PUBLISH.
+    pub async fn register_track(
+        &mut self,
+        scope: Option<&str>,
+        track: TrackReader,
+    ) -> anyhow::Result<LocalTrackRegistration> {
+        let full_name = FullTrackName {
+            namespace: track.namespace.clone(),
+            name: track.name.clone(),
+        };
+        self.insert_track_with_registration(scope, full_name, track)
+            .await
+    }
+
+    async fn insert_track_with_registration(
+        &mut self,
+        scope: Option<&str>,
+        full_name: FullTrackName,
+        track: TrackReader,
+    ) -> anyhow::Result<LocalTrackRegistration> {
+        let scope_key = scope.unwrap_or(UNSCOPED).to_string();
+
+        let mut tracks = self
+            .tracks
+            .lock()
+            .map_err(|_| ServeError::internal_ctx("locals track registry lock poisoned"))?;
+        let bucket = tracks.entry(scope_key.clone()).or_default();
+        match bucket.entry(full_name.clone()) {
+            hash_map::Entry::Vacant(entry) => entry.insert(track),
+            hash_map::Entry::Occupied(_) => return Err(ServeError::Duplicate.into()),
+        };
+
+        Ok(LocalTrackRegistration {
+            locals: self.clone(),
+            scope_key,
+            full_name,
+            _gauge_guard: GaugeGuard::new("moq_relay_active_published_tracks"),
+        })
+    }
+
+    async fn insert_track(
+        &mut self,
+        scope: Option<&str>,
+        full_name: FullTrackName,
+        track: TrackReader,
+    ) -> anyhow::Result<()> {
+        let scope_key = scope.unwrap_or(UNSCOPED).to_string();
+        let mut tracks = self
+            .tracks
+            .lock()
+            .map_err(|_| ServeError::internal_ctx("locals track registry lock poisoned"))?;
+        let bucket = tracks.entry(scope_key).or_default();
+        match bucket.entry(full_name) {
+            hash_map::Entry::Vacant(entry) => {
+                entry.insert(track);
+                Ok(())
+            }
+            hash_map::Entry::Occupied(_) => Err(ServeError::Duplicate.into()),
+        }
+    }
+
+    /// Retrieve one actual media track by exact Full Track Name.
+    pub fn retrieve_track(
+        &self,
+        scope: Option<&str>,
+        full_name: &FullTrackName,
+    ) -> Option<TrackReader> {
+        let mut tracks = self.tracks.lock().ok()?;
+        let bucket = tracks.get_mut(scope.unwrap_or(UNSCOPED))?;
+        if bucket.get(full_name).is_some_and(|track| track.is_closed()) {
+            bucket.remove(full_name);
+            return None;
+        }
+        bucket.get(full_name).cloned()
+    }
+
+    /// Return the best namespace route source for a requested namespace.
+    fn route_namespace(
         &self,
         scope: Option<&str>,
         namespace: &TrackNamespace,
-    ) -> Option<TracksReader> {
-        let lookup = self.lookup.lock().unwrap();
+    ) -> Option<NamespaceSource> {
+        let namespaces = self.namespaces.lock().ok()?;
+        let bucket = namespaces.get(scope.unwrap_or(UNSCOPED))?;
 
-        // Look up the scope bucket directly — O(1), zero allocation.
-        // HashMap<String, V>::get accepts &str via Borrow<str>.
-        let bucket = lookup.get(scope.unwrap_or(UNSCOPED))?;
-
-        // Find the longest matching prefix within this scope
-        let mut best_match: Option<TracksReader> = None;
+        let mut best_match: Option<NamespaceSource> = None;
         let mut best_len = 0;
 
-        for (registered_ns, tracks) in bucket.iter() {
-            // Check if registered_ns is a prefix of namespace
+        for (registered_ns, source) in bucket.iter() {
             if namespace.fields.len() >= registered_ns.fields.len() {
                 let is_prefix = registered_ns
                     .fields
@@ -113,7 +193,7 @@ impl Locals {
                     .all(|(a, b)| a == b);
 
                 if is_prefix && registered_ns.fields.len() > best_len {
-                    best_match = Some(tracks.clone());
+                    best_match = Some(source.clone());
                     best_len = registered_ns.fields.len();
                 }
             }
@@ -121,18 +201,56 @@ impl Locals {
 
         best_match
     }
+
+    /// Get an existing exact track or request it from a matching namespace source.
+    ///
+    /// This replaces the old `TracksReader::subscribe` relay registry behavior:
+    /// the actual track reader is stored in `tracks`, while PUBLISH_NAMESPACE is
+    /// only a source to ask when a track is missing.
+    pub async fn get_or_request_track(
+        &mut self,
+        scope: Option<&str>,
+        namespace: TrackNamespace,
+        track_name: impl Into<moq_transport::coding::TrackName>,
+    ) -> Option<TrackReader> {
+        let track_name = track_name.into();
+        let full_name = FullTrackName {
+            namespace: namespace.clone(),
+            name: track_name.clone(),
+        };
+
+        if let Some(track) = self.retrieve_track(scope, &full_name) {
+            return Some(track);
+        }
+
+        let source = self.route_namespace(scope, &namespace)?;
+
+        let (writer, reader) = Track::new(namespace.clone(), track_name.clone()).produce();
+        self.insert_track(scope, full_name.clone(), reader.clone())
+            .await
+            .ok()?;
+
+        if source.requests.send(writer).is_err() {
+            if let Ok(mut tracks) = self.tracks.lock() {
+                if let Some(bucket) = tracks.get_mut(scope.unwrap_or(UNSCOPED)) {
+                    bucket.remove(&full_name);
+                }
+            }
+            return None;
+        }
+
+        Some(reader)
+    }
 }
 
-pub struct Registration {
+pub struct LocalNamespaceRegistration {
     locals: Locals,
     scope_key: ScopeKey,
     namespace: TrackNamespace,
-    /// Gauge guard for tracking announced namespaces - decrements on drop
     _gauge_guard: GaugeGuard,
 }
 
-/// Deregister local tracks on drop.
-impl Drop for Registration {
+impl Drop for LocalNamespaceRegistration {
     fn drop(&mut self) {
         let ns = self.namespace.to_utf8_path();
         let scope = if self.scope_key.is_empty() {
@@ -140,15 +258,167 @@ impl Drop for Registration {
         } else {
             &self.scope_key
         };
-        tracing::debug!(namespace = %ns, scope = %scope, "deregistering namespace from locals");
+        tracing::debug!(namespace = %ns, scope = %scope, "deregistering namespace route source from locals");
 
-        let mut lookup = self.locals.lookup.lock().unwrap();
-        if let Some(bucket) = lookup.get_mut(self.scope_key.as_str()) {
-            bucket.remove(&self.namespace);
-            // Clean up empty scope buckets to avoid memory leaks
-            if bucket.is_empty() {
-                lookup.remove(self.scope_key.as_str());
+        if let Ok(mut namespaces) = self.locals.namespaces.lock() {
+            if let Some(bucket) = namespaces.get_mut(self.scope_key.as_str()) {
+                bucket.remove(&self.namespace);
+                if bucket.is_empty() {
+                    namespaces.remove(self.scope_key.as_str());
+                }
             }
         }
+    }
+}
+
+pub struct LocalTrackRegistration {
+    locals: Locals,
+    scope_key: ScopeKey,
+    full_name: FullTrackName,
+    _gauge_guard: GaugeGuard,
+}
+
+impl Drop for LocalTrackRegistration {
+    fn drop(&mut self) {
+        let namespace = self.full_name.namespace.to_utf8_path();
+        let track = self.full_name.name.to_string();
+        let scope = if self.scope_key.is_empty() {
+            "<unscoped>"
+        } else {
+            &self.scope_key
+        };
+        tracing::debug!(namespace = %namespace, track = %track, scope = %scope, "deregistering track from locals");
+
+        if let Ok(mut tracks) = self.locals.tracks.lock() {
+            if let Some(bucket) = tracks.get_mut(self.scope_key.as_str()) {
+                bucket.remove(&self.full_name);
+                if bucket.is_empty() {
+                    tracks.remove(self.scope_key.as_str());
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use moq_transport::coding::TrackName;
+
+    fn ns(path: &str) -> TrackNamespace {
+        TrackNamespace::from_utf8_path(path)
+    }
+
+    fn full(namespace: &TrackNamespace, name: &str) -> FullTrackName {
+        FullTrackName {
+            namespace: namespace.clone(),
+            name: TrackName::from(name),
+        }
+    }
+
+    #[tokio::test]
+    async fn register_track_makes_exact_track_retrievable_until_drop() {
+        let mut locals = Locals::new();
+        let namespace = ns("room/123");
+        let (writer, reader) = Track::new(namespace.clone(), "audio").produce();
+        let key = full(&namespace, "audio");
+
+        let registration = locals
+            .register_track(None, reader.clone())
+            .await
+            .expect("track registration should succeed");
+
+        assert!(locals.retrieve_track(None, &key).is_some());
+
+        drop(registration);
+        assert!(locals.retrieve_track(None, &key).is_none());
+
+        drop(writer);
+    }
+
+    #[tokio::test]
+    async fn get_or_request_track_uses_namespace_source_and_caches_reader() {
+        let mut locals = Locals::new();
+        let namespace = ns("room/123");
+        let (_registration, mut requests) = locals
+            .register_namespace(None, namespace.clone())
+            .await
+            .expect("namespace source should register");
+
+        let reader = locals
+            .get_or_request_track(None, namespace.clone(), "video")
+            .await
+            .expect("missing track should be requested from namespace source");
+
+        let requested = requests
+            .recv()
+            .await
+            .expect("source should get TrackWriter");
+        assert_eq!(requested.namespace, namespace);
+        assert_eq!(requested.name, TrackName::from("video"));
+
+        let key = full(&namespace, "video");
+        let cached = locals
+            .retrieve_track(None, &key)
+            .expect("requested track should be cached");
+        assert_eq!(cached.namespace, reader.namespace);
+        assert_eq!(cached.name, reader.name);
+
+        let reader_again = locals
+            .get_or_request_track(None, namespace.clone(), "video")
+            .await
+            .expect("cached track should be returned");
+        assert_eq!(reader_again.namespace, namespace);
+        assert_eq!(reader_again.name, TrackName::from("video"));
+
+        let no_second_request =
+            tokio::time::timeout(std::time::Duration::from_millis(50), requests.recv()).await;
+        assert!(
+            no_second_request.is_err(),
+            "cache hit should not request again"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_or_request_track_uses_longest_namespace_prefix() {
+        let mut locals = Locals::new();
+        let (_short_registration, mut short_requests) = locals
+            .register_namespace(None, ns("room"))
+            .await
+            .expect("short prefix should register");
+        let (_long_registration, mut long_requests) = locals
+            .register_namespace(None, ns("room/123"))
+            .await
+            .expect("long prefix should register");
+
+        let requested_ns = ns("room/123/camera");
+        let reader = locals
+            .get_or_request_track(None, requested_ns.clone(), "video")
+            .await
+            .expect("track should be requested from longest prefix");
+        assert_eq!(reader.namespace, requested_ns);
+
+        let long_request = long_requests
+            .recv()
+            .await
+            .expect("longest prefix should receive the request");
+        assert_eq!(long_request.namespace, ns("room/123/camera"));
+        assert_eq!(long_request.name, TrackName::from("video"));
+
+        let no_short_request =
+            tokio::time::timeout(std::time::Duration::from_millis(50), short_requests.recv()).await;
+        assert!(
+            no_short_request.is_err(),
+            "shorter prefix should not receive request"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_or_request_track_returns_none_without_track_or_namespace_source() {
+        let mut locals = Locals::new();
+        let result = locals
+            .get_or_request_track(None, ns("unknown"), "video")
+            .await;
+        assert!(result.is_none());
     }
 }

--- a/moq-relay-ietf/src/local.rs
+++ b/moq-relay-ietf/src/local.rs
@@ -24,9 +24,11 @@ type ScopeKey = String;
 /// The scope key used for unscoped (global) registrations.
 const UNSCOPED: &str = "";
 
+const NAMESPACE_REQUEST_CHANNEL_CAPACITY: usize = 1024;
+
 #[derive(Clone)]
 struct NamespaceSource {
-    requests: mpsc::UnboundedSender<TrackWriter>,
+    requests: mpsc::Sender<TrackWriter>,
 }
 
 /// Relay-local registry.
@@ -67,12 +69,9 @@ impl Locals {
         &mut self,
         scope: Option<&str>,
         namespace: TrackNamespace,
-    ) -> anyhow::Result<(
-        LocalNamespaceRegistration,
-        mpsc::UnboundedReceiver<TrackWriter>,
-    )> {
+    ) -> anyhow::Result<(LocalNamespaceRegistration, mpsc::Receiver<TrackWriter>)> {
         let scope_key = scope.unwrap_or(UNSCOPED).to_string();
-        let (tx, rx) = mpsc::unbounded_channel();
+        let (tx, rx) = mpsc::channel(NAMESPACE_REQUEST_CHANNEL_CAPACITY);
 
         let mut namespaces = self
             .namespaces
@@ -134,27 +133,6 @@ impl Locals {
             full_name,
             _gauge_guard: GaugeGuard::new("moq_relay_active_published_tracks"),
         })
-    }
-
-    async fn insert_track(
-        &mut self,
-        scope: Option<&str>,
-        full_name: FullTrackName,
-        track: TrackReader,
-    ) -> anyhow::Result<()> {
-        let scope_key = scope.unwrap_or(UNSCOPED).to_string();
-        let mut tracks = self
-            .tracks
-            .lock()
-            .map_err(|_| ServeError::internal_ctx("locals track registry lock poisoned"))?;
-        let bucket = tracks.entry(scope_key).or_default();
-        match bucket.entry(full_name) {
-            hash_map::Entry::Vacant(entry) => {
-                entry.insert(track);
-                Ok(())
-            }
-            hash_map::Entry::Occupied(_) => Err(ServeError::Duplicate.into()),
-        }
     }
 
     /// Retrieve one actual media track by exact Full Track Name.
@@ -226,11 +204,26 @@ impl Locals {
         let source = self.route_namespace(scope, &namespace)?;
 
         let (writer, reader) = Track::new(namespace.clone(), track_name.clone()).produce();
-        self.insert_track(scope, full_name.clone(), reader.clone())
-            .await
-            .ok()?;
+        let reader = {
+            let scope_key = scope.unwrap_or(UNSCOPED).to_string();
+            let mut tracks = self.tracks.lock().ok()?;
+            let bucket = tracks.entry(scope_key).or_default();
+            match bucket.entry(full_name.clone()) {
+                hash_map::Entry::Vacant(entry) => {
+                    entry.insert(reader.clone());
+                    reader
+                }
+                hash_map::Entry::Occupied(mut entry) => {
+                    if !entry.get().is_closed() {
+                        return Some(entry.get().clone());
+                    }
+                    entry.insert(reader.clone());
+                    reader
+                }
+            }
+        };
 
-        if source.requests.send(writer).is_err() {
+        if source.requests.send(writer).await.is_err() {
             if let Ok(mut tracks) = self.tracks.lock() {
                 if let Some(bucket) = tracks.get_mut(scope.unwrap_or(UNSCOPED)) {
                     bucket.remove(&full_name);
@@ -376,6 +369,41 @@ mod tests {
         assert!(
             no_second_request.is_err(),
             "cache hit should not request again"
+        );
+    }
+
+    #[tokio::test]
+    async fn concurrent_get_or_request_track_deduplicates_request() {
+        let mut locals = Locals::new();
+        let namespace = ns("room/123");
+        let (_registration, mut requests) = locals
+            .register_namespace(None, namespace.clone())
+            .await
+            .expect("namespace source should register");
+
+        let mut first = locals.clone();
+        let mut second = locals.clone();
+        let (first_reader, second_reader) = tokio::join!(
+            first.get_or_request_track(None, namespace.clone(), "video"),
+            second.get_or_request_track(None, namespace.clone(), "video"),
+        );
+
+        let first_reader = first_reader.expect("first request should get a reader");
+        let second_reader = second_reader.expect("second request should get cached reader");
+        assert_eq!(first_reader.namespace, namespace);
+        assert_eq!(second_reader.namespace, namespace);
+        assert_eq!(first_reader.name, TrackName::from("video"));
+        assert_eq!(second_reader.name, TrackName::from("video"));
+
+        requests
+            .recv()
+            .await
+            .expect("source should receive one TrackWriter");
+        let no_second_request =
+            tokio::time::timeout(std::time::Duration::from_millis(50), requests.recv()).await;
+        assert!(
+            no_second_request.is_err(),
+            "concurrent misses should be deduplicated"
         );
     }
 

--- a/moq-relay-ietf/src/metrics.rs
+++ b/moq-relay-ietf/src/metrics.rs
@@ -77,6 +77,14 @@ pub fn describe_metrics() {
         "Total publishers (PUBLISH_NAMESPACE requests) received"
     );
     describe_counter!(
+        "moq_relay_published_tracks_total",
+        "Total publisher-initiated PUBLISH track requests received"
+    );
+    describe_counter!(
+        "moq_relay_publish_errors_total",
+        "Publisher-initiated PUBLISH failures by phase (take_reader, local_register, coordinator_register, send_ok)"
+    );
+    describe_counter!(
         "moq_relay_announce_ok_total",
         "Successful REQUEST_OK responses sent for PUBLISH_NAMESPACE"
     );
@@ -117,6 +125,10 @@ pub fn describe_metrics() {
     describe_gauge!(
         "moq_relay_active_tracks",
         "Current number of tracks being served"
+    );
+    describe_gauge!(
+        "moq_relay_active_published_tracks",
+        "Current number of exact tracks registered from PUBLISH"
     );
     describe_gauge!(
         "moq_relay_announced_namespaces",

--- a/moq-relay-ietf/src/producer.rs
+++ b/moq-relay-ietf/src/producer.rs
@@ -3,7 +3,7 @@
 
 use futures::{stream::FuturesUnordered, FutureExt, StreamExt};
 use moq_transport::{
-    serve::{ServeError, TracksReader},
+    serve::{FullTrackName, ServeError, TracksReader},
     session::{Publisher, SessionError, Subscribed, TrackStatusRequested},
 };
 
@@ -111,21 +111,22 @@ impl Producer {
         let namespace = subscribed.track_namespace.clone();
         let track_name = subscribed.track_name.clone();
 
-        // Check local tracks first, and serve from local if possible
-        if let Some(mut local) = self.locals.retrieve(self.scope.as_deref(), &namespace) {
-            // Pass the full requested namespace, not the announced prefix
-            if let Some(track) = local.subscribe(namespace.clone(), &track_name) {
-                let ns = namespace.to_utf8_path();
-                tracing::info!(namespace = %ns, track = %track_name, source = "local", "serving subscribe from local: {:?}", track.info);
-                // Update label to indicate local source, timing recorded on drop
-                timing_guard.set_label("source", "local");
-                // Track active tracks - decrements when serve completes
-                let _track_guard = GaugeGuard::new("moq_relay_active_tracks");
-                return Ok(subscribed.serve(track).await?);
-            }
+        // Local lookup order inside Locals:
+        // 1. actual FullTrackName -> TrackReader media cache
+        // 2. PUBLISH_NAMESPACE route source, which triggers upstream SUBSCRIBE
+        let mut locals = self.locals.clone();
+        if let Some(track) = locals
+            .get_or_request_track(self.scope.as_deref(), namespace.clone(), &track_name)
+            .await
+        {
+            let ns = namespace.to_utf8_path();
+            tracing::info!(namespace = %ns, track = %track_name, source = "local", "serving subscribe from local: {:?}", track.info);
+            timing_guard.set_label("source", "local");
+            let _track_guard = GaugeGuard::new("moq_relay_active_tracks");
+            return Ok(subscribed.serve(track).await?);
         }
 
-        // Check remote tracks second, and serve from remote if possible
+        // Check remote tracks after local exact tracks and namespace route sources.
         match self
             .remotes
             .subscribe(self.scope.as_deref(), &namespace, &track_name)
@@ -188,23 +189,20 @@ impl Producer {
         self,
         mut track_status_requested: TrackStatusRequested,
     ) -> Result<(), anyhow::Error> {
-        // Check local tracks first, and serve from local if possible
-        if let Some(mut local_tracks) = self.locals.retrieve(
-            self.scope.as_deref(),
-            &track_status_requested.request_msg.track_namespace,
-        ) {
-            if let Some(track) = local_tracks.get_track_reader(
-                &track_status_requested.request_msg.track_namespace,
-                &track_status_requested.request_msg.track_name,
-            ) {
-                let namespace = track_status_requested
-                    .request_msg
-                    .track_namespace
-                    .to_utf8_path();
-                let track_name = &track_status_requested.request_msg.track_name;
-                tracing::info!(namespace = %namespace, track = %track_name, source = "local", "serving track_status from local: {:?}", track.info);
-                return Ok(track_status_requested.respond_ok(&track)?);
-            }
+        let full_name = FullTrackName {
+            namespace: track_status_requested.request_msg.track_namespace.clone(),
+            name: track_status_requested.request_msg.track_name.clone(),
+        };
+
+        // Check actual local tracks first.
+        if let Some(track) = self
+            .locals
+            .retrieve_track(self.scope.as_deref(), &full_name)
+        {
+            let namespace = full_name.namespace.to_utf8_path();
+            let track_name = &full_name.name;
+            tracing::info!(namespace = %namespace, track = %track_name, source = "local", "serving track_status from local: {:?}", track.info);
+            return Ok(track_status_requested.respond_ok(&track)?);
         }
 
         // TODO - forward track status to remotes?

--- a/moq-relay-ietf/src/remote.rs
+++ b/moq-relay-ietf/src/remote.rs
@@ -121,7 +121,15 @@ impl RemoteManager {
         track_name: impl Into<TrackName>,
     ) -> anyhow::Result<Option<TrackReader>> {
         let track_name = track_name.into();
-        let (origin, client) = match self.coordinator.lookup(scope, namespace).await {
+
+        // Coordinator::lookup_track is the ergonomic routing entry point: it
+        // tries exact PUBLISH track registrations first, then falls back to
+        // PUBLISH_NAMESPACE namespace routing.
+        let (origin, client) = match self
+            .coordinator
+            .lookup_track(scope, namespace, &track_name.to_string())
+            .await
+        {
             Ok(result) => result,
             Err(CoordinatorError::NamespaceNotFound) => return Ok(None),
             Err(err) => return Err(err.into()),

--- a/moq-relay-ietf/src/session.rs
+++ b/moq-relay-ietf/src/session.rs
@@ -59,9 +59,10 @@ impl Session {
     /// Dropping a `PublishedNamespace` without calling `ok()` triggers its
     /// `Drop` impl, which sends REQUEST_ERROR back to the peer.
     async fn drain_and_reject_publishes(subscriber: Subscriber) -> Result<(), SessionError> {
+        let mut namespace_subscriber = subscriber.clone();
+        let mut publish_subscriber = subscriber;
+
         loop {
-            let mut namespace_subscriber = subscriber.clone();
-            let mut publish_subscriber = subscriber.clone();
             tokio::select! {
                 Some(published_ns) = namespace_subscriber.published_namespace() => {
                     tracing::debug!(

--- a/moq-relay-ietf/src/session.rs
+++ b/moq-relay-ietf/src/session.rs
@@ -54,19 +54,33 @@ impl Session {
         tasks.select_next_some().await
     }
 
-    /// Drain incoming PUBLISH_NAMESPACEs and reject each one.
+    /// Drain incoming PUBLISH_NAMESPACE and PUBLISH requests and reject each one.
     ///
     /// Dropping a `PublishedNamespace` without calling `ok()` triggers its
     /// `Drop` impl, which sends REQUEST_ERROR back to the peer.
-    async fn drain_and_reject_publishes(mut subscriber: Subscriber) -> Result<(), SessionError> {
-        while let Some(published_ns) = subscriber.published_namespace().await {
-            tracing::debug!(
-                namespace = %published_ns.namespace,
-                "rejecting PUBLISH_NAMESPACE: publish not permitted for this session"
-            );
-            drop(published_ns);
+    async fn drain_and_reject_publishes(subscriber: Subscriber) -> Result<(), SessionError> {
+        loop {
+            let mut namespace_subscriber = subscriber.clone();
+            let mut publish_subscriber = subscriber.clone();
+            tokio::select! {
+                Some(published_ns) = namespace_subscriber.published_namespace() => {
+                    tracing::debug!(
+                        namespace = %published_ns.namespace,
+                        "rejecting PUBLISH_NAMESPACE: publish not permitted for this session"
+                    );
+                    drop(published_ns);
+                },
+                Some(publish) = publish_subscriber.publish_received() => {
+                    tracing::debug!(
+                        namespace = %publish.namespace(),
+                        track = %publish.name(),
+                        "rejecting PUBLISH: publish not permitted for this session"
+                    );
+                    drop(publish);
+                },
+                else => return Ok(()),
+            }
         }
-        Ok(())
     }
 
     /// Drain incoming SUBSCRIBEs and reject each one.

--- a/moq-sub/CHANGELOG.md
+++ b/moq-sub/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 
 - update Cargo.lock dependencies
+- Update subscriber CLI dependencies for the draft-16 transport/native stack.
 
 ## [0.4.9](https://github.com/cloudflare/moq-rs/compare/moq-sub-v0.4.8...moq-sub-v0.4.9) - 2026-06-10
 

--- a/moq-test-client/CHANGELOG.md
+++ b/moq-test-client/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add direct PUBLISH interop scenarios for publisher-only completion and exact-track subscriber routing.
+
 ## [0.1.8](https://github.com/cloudflare/moq-rs/compare/moq-test-client-v0.1.7...moq-test-client-v0.1.8) - 2026-07-08
 
 ### Other

--- a/moq-test-client/CHANGELOG.md
+++ b/moq-test-client/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 
 - Merge pull request #170 from itzmanish/draft-16-rewrite
+- Update the interoperability test client for the draft-16 transport/native stack.
 
 ## [0.1.7](https://github.com/cloudflare/moq-rs/compare/moq-test-client-v0.1.6...moq-test-client-v0.1.7) - 2026-06-10
 

--- a/moq-test-client/Cargo.toml
+++ b/moq-test-client/Cargo.toml
@@ -23,6 +23,7 @@ moq-transport = { path = "../moq-transport", version = "0.15" }
 moq-native-ietf = { path = "../moq-native-ietf", version = "0.9" }
 web-transport = { workspace = true }
 
+bytes = "1"
 url = "2"
 
 # Async stuff

--- a/moq-test-client/README.md
+++ b/moq-test-client/README.md
@@ -50,6 +50,8 @@ moq-test-client --relay https://localhost:4443 --tls-disable-verify
 | `publish-namespace-subscribe` | Publisher sends PUBLISH_NAMESPACE, subscriber subscribes, verify handshake |
 | `subscribe-before-publish-namespace` | Subscriber subscribes before publisher sends PUBLISH_NAMESPACE |
 | `publish-namespace-done` | Send PUBLISH_NAMESPACE, then send PUBLISH_NAMESPACE_DONE |
+| `publish-track-only` | Publisher sends direct PUBLISH, receives PUBLISH_OK, then sends PUBLISH_DONE |
+| `publish-track-subscribe` | Publisher sends direct PUBLISH, subscriber subscribes to the exact track |
 
 ## Running with moq-relay
 
@@ -83,8 +85,10 @@ Relay: https://localhost:4443
 ✓ publish-namespace-subscribe (127 ms)
 ✓ subscribe-before-publish-namespace (89 ms)
 ✓ publish-namespace-done (45 ms)
+✓ publish-track-only (42 ms)
+✓ publish-track-subscribe (76 ms)
 
-Results: 6 passed, 0 failed
+Results: 8 passed, 0 failed
 
 MOQT_TEST_RESULT: SUCCESS
 ```
@@ -114,6 +118,8 @@ The test cases implemented here correspond to the specifications in [moq-interop
 | `setup-only` | MoQT §3.3, §9.3 |
 | `publish-namespace-only` | MoQT §6.2, §9.23-9.24 |
 | `publish-namespace-done` | MoQT §6.2, §9.26 |
+| `publish-track-only` | MoQT §9.13-9.15 |
+| `publish-track-subscribe` | MoQT §5.1, §9.9-9.15 |
 | `subscribe-error` | MoQT §5.1, §9.7, §9.9 |
 | `publish-namespace-subscribe` | MoQT §5.1, §6.2, §9.7-9.8, §9.23-9.24 |
 | `subscribe-before-publish-namespace` | MoQT §5.1, §6.2 |

--- a/moq-test-client/src/main.rs
+++ b/moq-test-client/src/main.rs
@@ -79,6 +79,10 @@ pub enum TestCase {
     SubscribeBeforePublishNamespace,
     /// T0.6: Send PUBLISH_NAMESPACE, receive REQUEST_OK, send PUBLISH_NAMESPACE_DONE
     PublishNamespaceDone,
+    /// T0.7: Publisher sends PUBLISH for one track, receives PUBLISH_OK, then completes
+    PublishTrackOnly,
+    /// T0.8: Publisher sends PUBLISH for one track, subscriber receives it through relay routing
+    PublishTrackSubscribe,
 }
 
 impl TestCase {
@@ -90,6 +94,8 @@ impl TestCase {
             TestCase::PublishNamespaceSubscribe,
             TestCase::SubscribeBeforePublishNamespace,
             TestCase::PublishNamespaceDone,
+            TestCase::PublishTrackOnly,
+            TestCase::PublishTrackSubscribe,
         ]
     }
 
@@ -101,6 +107,8 @@ impl TestCase {
             TestCase::PublishNamespaceSubscribe => "publish-namespace-subscribe",
             TestCase::SubscribeBeforePublishNamespace => "subscribe-before-publish-namespace",
             TestCase::PublishNamespaceDone => "publish-namespace-done",
+            TestCase::PublishTrackOnly => "publish-track-only",
+            TestCase::PublishTrackSubscribe => "publish-track-subscribe",
         }
     }
 }
@@ -152,6 +160,8 @@ async fn run_test(args: &Args, test_case: TestCase) -> TestResult {
             scenarios::test_subscribe_before_publish_namespace(args).await
         }
         TestCase::PublishNamespaceDone => scenarios::test_publish_namespace_done(args).await,
+        TestCase::PublishTrackOnly => scenarios::test_publish_track_only(args).await,
+        TestCase::PublishTrackSubscribe => scenarios::test_publish_track_subscribe(args).await,
     };
 
     let duration = start.elapsed();

--- a/moq-test-client/src/scenarios.rs
+++ b/moq-test-client/src/scenarios.rs
@@ -10,10 +10,15 @@
 //! for correlation with relay-side mlog files.
 
 use anyhow::{Context, Result};
+use bytes::Bytes;
 use tokio::time::{timeout, Duration};
 
 use moq_native_ietf::quic;
-use moq_transport::{coding::TrackNamespace, serve::Tracks, session::Session};
+use moq_transport::{
+    coding::{KeyValuePairs, TrackNamespace},
+    serve::{Track, TrackReaderMode, TrackWriter, Tracks},
+    session::Session,
+};
 
 use crate::Args;
 
@@ -25,6 +30,12 @@ const TEST_NAMESPACE: &str = "moq-test/interop";
 
 /// Track name used for test operations
 const TEST_TRACK: &str = "test-track";
+
+/// Namespace used for direct PUBLISH test operations
+const PUBLISH_NAMESPACE: &str = "moq-test/publish";
+
+/// Track name used for direct PUBLISH test operations
+const PUBLISH_TRACK: &str = "published-track";
 
 /// Helper to connect to a relay and establish a session
 /// Returns (session, connection_id, transport) so we can report CIDs for mlog correlation
@@ -52,6 +63,17 @@ impl TestConnectionIds {
     pub fn add(&mut self, cid: String) {
         self.cids.push(cid);
     }
+}
+
+fn write_test_subgroup(track: TrackWriter, payload: &'static [u8]) -> Result<()> {
+    let mut subgroups = track.subgroups().context("failed to enter subgroup mode")?;
+    let mut subgroup = subgroups.append(128).context("failed to create subgroup")?;
+    subgroup
+        .write(Bytes::from_static(payload))
+        .context("failed to write subgroup object")?;
+    drop(subgroup);
+    drop(subgroups);
+    Ok(())
 }
 
 /// T0.1: Setup Only
@@ -294,6 +316,158 @@ pub async fn test_publish_namespace_done(args: &Args) -> Result<TestConnectionId
 
         tokio::time::sleep(Duration::from_millis(100)).await;
         tracing::info!("PUBLISH_NAMESPACE_DONE sent successfully");
+        Ok(cids)
+    })
+    .await
+    .context("test timed out")?
+}
+
+/// T0.7: Publish Track Only
+///
+/// Publisher sends direct PUBLISH for one track, receives PUBLISH_OK, serves one
+/// object, and completes with PUBLISH_DONE.
+pub async fn test_publish_track_only(args: &Args) -> Result<TestConnectionIds> {
+    timeout(TEST_TIMEOUT, async {
+        let (session, cid, transport) = connect(args)
+            .await
+            .context("publisher failed to connect to relay")?;
+        let mut cids = TestConnectionIds::default();
+        cids.add(cid);
+
+        let (session, mut publisher, _subscriber) = Session::connect(session, None, transport)
+            .await
+            .context("publisher SETUP failed")?;
+
+        let namespace = TrackNamespace::from_utf8_path(PUBLISH_NAMESPACE);
+        let (track_writer, track_reader) = Track::new(namespace.clone(), PUBLISH_TRACK).produce();
+
+        tracing::info!(
+            namespace = %namespace,
+            track = PUBLISH_TRACK,
+            "Publisher sending direct PUBLISH"
+        );
+
+        let result: Result<()> = tokio::select! {
+            res = async {
+                let mut published = publisher
+                    .publish(track_reader, KeyValuePairs::default())
+                    .await
+                    .context("failed to send PUBLISH")?;
+                published.ok().await.context("PUBLISH was rejected")?;
+                tracing::info!(namespace = %namespace, track = PUBLISH_TRACK, "PUBLISH accepted");
+
+                write_test_subgroup(track_writer, b"publish-track-only")?;
+                published.serve().await.context("failed serving PUBLISH track")?;
+                tracing::info!(namespace = %namespace, track = PUBLISH_TRACK, "PUBLISH completed");
+                Ok(())
+            } => res,
+            res = session.run() => {
+                res.context("publisher session error")?;
+                anyhow::bail!("publisher session ended before PUBLISH completed");
+            }
+        };
+
+        result?;
+        Ok(cids)
+    })
+    .await
+    .context("test timed out")?
+}
+
+/// T0.8: Publish Track + Subscribe
+///
+/// Publisher sends direct PUBLISH for one track; after PUBLISH_OK, a subscriber
+/// subscribes to the exact track and receives the relayed object stream.
+pub async fn test_publish_track_subscribe(args: &Args) -> Result<TestConnectionIds> {
+    timeout(TEST_TIMEOUT, async {
+        let mut cids = TestConnectionIds::default();
+
+        let (pub_session, pub_cid, pub_transport) = connect(args)
+            .await
+            .context("publisher failed to connect")?;
+        cids.add(pub_cid);
+        let (pub_session, mut publisher, _pub_subscriber) =
+            Session::connect(pub_session, None, pub_transport)
+                .await
+                .context("publisher SETUP failed")?;
+
+        let (sub_session, sub_cid, sub_transport) = connect(args)
+            .await
+            .context("subscriber failed to connect")?;
+        cids.add(sub_cid);
+        let (sub_session, _sub_publisher, mut subscriber) =
+            Session::connect(sub_session, None, sub_transport)
+                .await
+                .context("subscriber SETUP failed")?;
+
+        let namespace = TrackNamespace::from_utf8_path(PUBLISH_NAMESPACE);
+        let (track_writer, track_reader) = Track::new(namespace.clone(), PUBLISH_TRACK).produce();
+        let (mut sub_tracks, _, mut sub_reader) = Tracks::new(namespace.clone()).produce();
+        let sub_track = sub_tracks
+            .create(PUBLISH_TRACK)
+            .ok_or_else(|| anyhow::anyhow!("failed to create subscriber track"))?;
+        let received_track = sub_reader
+            .get_track_reader(&namespace, PUBLISH_TRACK)
+            .ok_or_else(|| anyhow::anyhow!("failed to read subscriber track"))?;
+
+        tracing::info!(
+            namespace = %namespace,
+            track = PUBLISH_TRACK,
+            "Publisher sending direct PUBLISH before subscriber subscribes"
+        );
+
+        let result: Result<()> = tokio::select! {
+            res = async {
+                let mut published = publisher
+                    .publish(track_reader, KeyValuePairs::default())
+                    .await
+                    .context("failed to send PUBLISH")?;
+                published.ok().await.context("PUBLISH was rejected")?;
+                tracing::info!(namespace = %namespace, track = PUBLISH_TRACK, "PUBLISH accepted; starting subscriber");
+
+                let subscribe = async {
+                    subscriber
+                        .subscribe(sub_track)
+                        .await
+                        .context("subscriber failed to receive direct PUBLISH track")
+                };
+
+                let receive = async {
+                    let mut subgroups = match received_track.mode().await.context("subscriber track mode failed")? {
+                        TrackReaderMode::Subgroups(subgroups) => subgroups,
+                        _ => anyhow::bail!("subscriber track used non-subgroup delivery"),
+                    };
+                    let mut subgroup = subgroups.next().await.context("subscriber subgroup failed")?
+                        .ok_or_else(|| anyhow::anyhow!("subscriber did not receive a subgroup"))?;
+                    let payload = subgroup.read_next().await.context("subscriber object failed")?
+                        .ok_or_else(|| anyhow::anyhow!("subscriber did not receive an object"))?;
+                    if payload.as_ref() != b"publish-track-subscribe" {
+                        anyhow::bail!("subscriber received unexpected payload");
+                    }
+                    Ok(())
+                };
+
+                let publish = async {
+                    tokio::time::sleep(Duration::from_millis(100)).await;
+                    write_test_subgroup(track_writer, b"publish-track-subscribe")?;
+                    published.serve().await.context("failed serving PUBLISH track")
+                };
+
+                tokio::try_join!(subscribe, receive, publish)?;
+                tracing::info!(namespace = %namespace, track = PUBLISH_TRACK, "Subscriber received direct PUBLISH track");
+                Ok(())
+            } => res,
+            res = pub_session.run() => {
+                res.context("publisher session error")?;
+                anyhow::bail!("publisher session ended before PUBLISH/subscriber flow completed");
+            },
+            res = sub_session.run() => {
+                res.context("subscriber session error")?;
+                anyhow::bail!("subscriber session ended before PUBLISH/subscriber flow completed");
+            }
+        };
+
+        result?;
         Ok(cids)
     })
     .await

--- a/moq-transport/CHANGELOG.md
+++ b/moq-transport/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.15.0](https://github.com/cloudflare/moq-rs/compare/moq-transport-v0.14.2...moq-transport-v0.15.0) - 2026-07-08
 
+### Added
+
+- add draft-16 PUBLISH, PUBLISH_OK, and PUBLISH_DONE support for publisher-initiated track delivery
+
 ### Fixed
 
 - ignore stale unsubscribe ids

--- a/moq-transport/src/session/mod.rs
+++ b/moq-transport/src/session/mod.rs
@@ -1007,10 +1007,14 @@ impl Session {
                 "SUBSCRIBE_OK completed unexpected {:?} request {}",
                 request, msg.id
             ))),
-            None => subscriber
-                .as_mut()
-                .ok_or(SessionError::RoleViolation)?
-                .recv_subscribe_ok(&msg),
+            None => {
+                tracing::debug!(
+                    target: "moq_transport::control",
+                    request_id = msg.id,
+                    "received SUBSCRIBE_OK for unknown outbound request — ignoring"
+                );
+                Ok(())
+            }
         }
     }
 
@@ -1165,5 +1169,23 @@ mod tests {
         // Exactly at the limit (1024 total including leading slash)
         let path = format!("/{}", "a".repeat(Session::MAX_CONNECTION_PATH_LEN - 1));
         assert!(Session::normalize_connection_path(&path).is_ok());
+    }
+
+    #[test]
+    fn subscribe_ok_for_unknown_request_id_is_ignored() {
+        let pending_requests = PendingRequests::default();
+        let mut subscriber = None;
+
+        Session::recv_subscribe_ok(
+            &pending_requests,
+            &mut subscriber,
+            message::SubscribeOk {
+                id: 42,
+                track_alias: 7,
+                params: Default::default(),
+                track_extensions: Default::default(),
+            },
+        )
+        .unwrap();
     }
 }

--- a/moq-transport/src/session/mod.rs
+++ b/moq-transport/src/session/mod.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 mod error;
+mod pending_requests;
 mod publish_namespace;
 mod publish_received;
 mod published;
@@ -17,6 +18,7 @@ mod track_status_requested;
 mod writer;
 
 pub use error::*;
+pub(crate) use pending_requests::{PendingRequest, PendingRequests, PendingResponse};
 pub use publish_namespace::*;
 pub use publish_received::PublishReceived;
 pub(crate) use publish_received::PublishReceivedRecv;
@@ -98,6 +100,9 @@ pub struct Session {
     /// Session-level request ID manager.
     /// Publisher and Subscriber share one outbound request ID sequence.
     request_id: RequestId,
+
+    /// Outbound requests that are waiting for a terminal response.
+    pending_requests: PendingRequests,
 
     /// Optional mlog writer for MoQ Transport events
     /// Wrapped in Arc<Mutex<>> to share across send/recv tasks when enabled
@@ -456,6 +461,7 @@ impl Session {
         request_id: RequestId,
     ) -> (Self, Option<Publisher>, Option<Subscriber>) {
         let outgoing = Queue::default().split();
+        let pending_requests = PendingRequests::default();
 
         // Wrap mlog in Arc<Mutex<>> for sharing across tasks
         let mlog_shared = mlog.map(|m| Arc::new(Mutex::new(m)));
@@ -465,11 +471,13 @@ impl Session {
             webtransport.clone(),
             mlog_shared.clone(),
             request_id.clone(),
+            pending_requests.clone(),
         ));
         let subscriber = Some(Subscriber::new(
             outgoing.0,
             mlog_shared.clone(),
             request_id.clone(),
+            pending_requests.clone(),
         ));
 
         let session = Self {
@@ -480,6 +488,7 @@ impl Session {
             subscriber: subscriber.clone(),
             outgoing: outgoing.1,
             request_id,
+            pending_requests,
             mlog: mlog_shared,
             transport,
             connection_path,
@@ -699,10 +708,11 @@ impl Session {
     /// and receiving and processing QUIC datagrams received
     pub async fn run(self) -> Result<(), SessionError> {
         tokio::select! {
-            res = Self::run_recv(self.recver, self.publisher, self.subscriber.clone(), self.mlog.clone(), self.request_id.clone(), self.outgoing.clone()) => res,
+            res = Self::run_recv(self.recver, self.publisher.clone(), self.subscriber.clone(), self.mlog.clone(), self.request_id.clone(), self.pending_requests.clone()) => res,
             res = Self::run_send(self.sender, self.outgoing, self.mlog.clone()) => res,
             res = Self::run_streams(self.webtransport.clone(), self.subscriber.clone()) => res,
-            res = Self::run_datagrams(self.webtransport, self.subscriber) => res,
+            res = Self::run_datagrams(self.webtransport, self.subscriber.clone()) => res,
+            res = Self::run_pending_timeouts(self.publisher, self.subscriber, self.pending_requests) => res,
         }
     }
 
@@ -766,7 +776,7 @@ impl Session {
         mut subscriber: Option<Subscriber>,
         mlog: Option<Arc<Mutex<mlog::MlogWriter>>>,
         request_id: RequestId,
-        _outgoing: Queue<Message>,
+        pending_requests: PendingRequests,
     ) -> Result<(), SessionError> {
         let mut goaway_received = false;
 
@@ -811,6 +821,31 @@ impl Session {
             if let Some(id) = msg.sequenced_request_id() {
                 request_id.validate_incoming(id)?;
             }
+
+            let msg = match msg {
+                Message::RequestOk(msg) => {
+                    Self::recv_request_ok(&pending_requests, &mut publisher, msg)?;
+                    continue;
+                }
+                Message::RequestError(msg) => {
+                    Self::recv_request_error(
+                        &pending_requests,
+                        &mut publisher,
+                        &mut subscriber,
+                        msg,
+                    )?;
+                    continue;
+                }
+                Message::PublishOk(msg) => {
+                    Self::recv_publish_ok(&pending_requests, &mut publisher, msg)?;
+                    continue;
+                }
+                Message::SubscribeOk(msg) => {
+                    Self::recv_subscribe_ok(&pending_requests, &mut subscriber, msg)?;
+                    continue;
+                }
+                msg => msg,
+            };
 
             let msg = match TryInto::<message::Publisher>::try_into(msg) {
                 Ok(msg) => {
@@ -874,6 +909,143 @@ impl Session {
                         "message type {}",
                         other.name()
                     )));
+                }
+            }
+        }
+    }
+
+    fn recv_request_ok(
+        pending_requests: &PendingRequests,
+        publisher: &mut Option<Publisher>,
+        msg: message::RequestOk,
+    ) -> Result<(), SessionError> {
+        match pending_requests.complete(msg.id, PendingResponse::RequestOk)? {
+            Some(PendingRequest::PublishNamespace) => publisher
+                .as_mut()
+                .ok_or(SessionError::RoleViolation)?
+                .recv_request_ok(msg),
+            Some(request) => Err(SessionError::ProtocolViolation(format!(
+                "REQUEST_OK completed unexpected {:?} request {}",
+                request, msg.id
+            ))),
+            None => {
+                tracing::debug!(
+                    target: "moq_transport::control",
+                    request_id = msg.id,
+                    "received REQUEST_OK for unknown outbound request — ignoring"
+                );
+                Ok(())
+            }
+        }
+    }
+
+    fn recv_request_error(
+        pending_requests: &PendingRequests,
+        publisher: &mut Option<Publisher>,
+        subscriber: &mut Option<Subscriber>,
+        msg: message::RequestError,
+    ) -> Result<(), SessionError> {
+        match pending_requests.complete(msg.id, PendingResponse::RequestError)? {
+            Some(PendingRequest::PublishNamespace | PendingRequest::Publish) => publisher
+                .as_mut()
+                .ok_or(SessionError::RoleViolation)?
+                .recv_request_error(msg),
+            Some(PendingRequest::Subscribe) => subscriber
+                .as_mut()
+                .ok_or(SessionError::RoleViolation)?
+                .recv_request_error(&msg),
+            None => {
+                tracing::debug!(
+                    target: "moq_transport::control",
+                    request_id = msg.id,
+                    error_code = msg.error_code,
+                    retry_interval = msg.retry_interval,
+                    reason = %msg.reason.0,
+                    "received REQUEST_ERROR for unknown outbound request — ignoring"
+                );
+                Ok(())
+            }
+        }
+    }
+
+    fn recv_publish_ok(
+        pending_requests: &PendingRequests,
+        publisher: &mut Option<Publisher>,
+        msg: message::PublishOk,
+    ) -> Result<(), SessionError> {
+        match pending_requests.complete(msg.id, PendingResponse::PublishOk)? {
+            Some(PendingRequest::Publish) => publisher
+                .as_mut()
+                .ok_or(SessionError::RoleViolation)?
+                .recv_publish_ok(msg),
+            Some(request) => Err(SessionError::ProtocolViolation(format!(
+                "PUBLISH_OK completed unexpected {:?} request {}",
+                request, msg.id
+            ))),
+            None => {
+                tracing::debug!(
+                    target: "moq_transport::control",
+                    request_id = msg.id,
+                    "received PUBLISH_OK for unknown outbound request — ignoring"
+                );
+                Ok(())
+            }
+        }
+    }
+
+    fn recv_subscribe_ok(
+        pending_requests: &PendingRequests,
+        subscriber: &mut Option<Subscriber>,
+        msg: message::SubscribeOk,
+    ) -> Result<(), SessionError> {
+        match pending_requests.complete(msg.id, PendingResponse::SubscribeOk)? {
+            Some(PendingRequest::Subscribe) => subscriber
+                .as_mut()
+                .ok_or(SessionError::RoleViolation)?
+                .recv_subscribe_ok(&msg),
+            Some(request) => Err(SessionError::ProtocolViolation(format!(
+                "SUBSCRIBE_OK completed unexpected {:?} request {}",
+                request, msg.id
+            ))),
+            None => subscriber
+                .as_mut()
+                .ok_or(SessionError::RoleViolation)?
+                .recv_subscribe_ok(&msg),
+        }
+    }
+
+    async fn run_pending_timeouts(
+        mut publisher: Option<Publisher>,
+        mut subscriber: Option<Subscriber>,
+        pending_requests: PendingRequests,
+    ) -> Result<(), SessionError> {
+        loop {
+            let Some(deadline) = pending_requests.next_deadline()? else {
+                pending_requests.changed().await;
+                continue;
+            };
+
+            tokio::select! {
+                _ = tokio::time::sleep_until(deadline) => {},
+                _ = pending_requests.changed() => continue,
+            }
+
+            for (id, request) in pending_requests.expire()? {
+                tracing::warn!(
+                    target: "moq_transport::control",
+                    request_id = id,
+                    request = ?request,
+                    "outbound request timed out waiting for response"
+                );
+                match request {
+                    PendingRequest::PublishNamespace | PendingRequest::Publish => publisher
+                        .as_mut()
+                        .ok_or(SessionError::RoleViolation)?
+                        .recv_request_timeout(id, request)?,
+                    PendingRequest::Subscribe => subscriber
+                        .as_mut()
+                        .ok_or(SessionError::RoleViolation)?
+                        .recv_request_timeout(id, request)?,
                 }
             }
         }

--- a/moq-transport/src/session/mod.rs
+++ b/moq-transport/src/session/mod.rs
@@ -5,6 +5,7 @@
 mod error;
 mod publish_namespace;
 mod published_namespace;
+mod published_track;
 mod publisher;
 mod reader;
 mod request_id;
@@ -17,6 +18,8 @@ mod writer;
 pub use error::*;
 pub use publish_namespace::*;
 pub use published_namespace::*;
+pub use published_track::PublishedTrack;
+pub(crate) use published_track::{PendingPublishUpdate, PublishedTrackRecv};
 pub use publisher::*;
 pub use request_id::{RequestId, RequestIdAllocation};
 pub use subscribe::*;

--- a/moq-transport/src/session/mod.rs
+++ b/moq-transport/src/session/mod.rs
@@ -4,8 +4,9 @@
 
 mod error;
 mod publish_namespace;
+mod publish_received;
+mod published;
 mod published_namespace;
-mod published_track;
 mod publisher;
 mod reader;
 mod request_id;
@@ -17,9 +18,11 @@ mod writer;
 
 pub use error::*;
 pub use publish_namespace::*;
+pub use publish_received::PublishReceived;
+pub(crate) use publish_received::PublishReceivedRecv;
+pub(crate) use published::{split_published_state, PublishedRecv};
+pub use published::{Published, PublishedInfo};
 pub use published_namespace::*;
-pub use published_track::PublishedTrack;
-pub(crate) use published_track::{PendingPublishUpdate, PublishedTrackRecv};
 pub use publisher::*;
 pub use request_id::{RequestId, RequestIdAllocation};
 pub use subscribe::*;

--- a/moq-transport/src/session/pending_requests.rs
+++ b/moq-transport/src/session/pending_requests.rs
@@ -1,0 +1,135 @@
+// SPDX-FileCopyrightText: 2026 Cloudflare Inc.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
+
+use tokio::{
+    sync::Notify,
+    time::{Duration, Instant},
+};
+
+use super::SessionError;
+
+const RESPONSE_TIMEOUT: Duration = Duration::from_secs(30);
+
+#[derive(Clone, Default)]
+pub(crate) struct PendingRequests {
+    inner: Arc<Mutex<HashMap<u64, PendingRequestState>>>,
+    notify: Arc<Notify>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum PendingRequest {
+    PublishNamespace,
+    Publish,
+    Subscribe,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum PendingResponse {
+    RequestOk,
+    RequestError,
+    PublishOk,
+    SubscribeOk,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct PendingRequestState {
+    request: PendingRequest,
+    deadline: Instant,
+}
+
+impl PendingRequest {
+    fn accepts(self, response: PendingResponse) -> bool {
+        match (self, response) {
+            (
+                Self::PublishNamespace,
+                PendingResponse::RequestOk | PendingResponse::RequestError,
+            ) => true,
+            (Self::Publish, PendingResponse::PublishOk | PendingResponse::RequestError) => true,
+            (Self::Subscribe, PendingResponse::SubscribeOk | PendingResponse::RequestError) => true,
+            _ => false,
+        }
+    }
+}
+
+impl PendingRequests {
+    pub(crate) fn insert(&self, id: u64, request: PendingRequest) -> Result<(), SessionError> {
+        let mut pending = self.inner.lock().map_err(|_| SessionError::Internal)?;
+        if pending.contains_key(&id) {
+            return Err(SessionError::Duplicate);
+        }
+
+        pending.insert(
+            id,
+            PendingRequestState {
+                request,
+                deadline: Instant::now() + RESPONSE_TIMEOUT,
+            },
+        );
+        self.notify.notify_one();
+        Ok(())
+    }
+
+    pub(crate) fn remove(&self, id: u64) -> Result<Option<PendingRequest>, SessionError> {
+        Ok(self
+            .inner
+            .lock()
+            .map_err(|_| SessionError::Internal)?
+            .remove(&id)
+            .map(|state| state.request))
+    }
+
+    pub(crate) fn complete(
+        &self,
+        id: u64,
+        response: PendingResponse,
+    ) -> Result<Option<PendingRequest>, SessionError> {
+        let mut pending = self.inner.lock().map_err(|_| SessionError::Internal)?;
+        let Some(state) = pending.get(&id).copied() else {
+            return Ok(None);
+        };
+
+        if !state.request.accepts(response) {
+            return Err(SessionError::ProtocolViolation(format!(
+                "received {:?} for pending {:?} request {}",
+                response, state.request, id
+            )));
+        }
+
+        pending.remove(&id);
+        Ok(Some(state.request))
+    }
+
+    pub(crate) fn next_deadline(&self) -> Result<Option<Instant>, SessionError> {
+        Ok(self
+            .inner
+            .lock()
+            .map_err(|_| SessionError::Internal)?
+            .values()
+            .map(|state| state.deadline)
+            .min())
+    }
+
+    pub(crate) fn expire(&self) -> Result<Vec<(u64, PendingRequest)>, SessionError> {
+        let now = Instant::now();
+        let mut pending = self.inner.lock().map_err(|_| SessionError::Internal)?;
+        let expired = pending
+            .iter()
+            .filter_map(|(id, state)| (state.deadline <= now).then_some((*id, state.request)))
+            .collect::<Vec<_>>();
+
+        for (id, _) in &expired {
+            pending.remove(id);
+        }
+
+        Ok(expired)
+    }
+
+    pub(crate) async fn changed(&self) {
+        self.notify.notified().await;
+    }
+}

--- a/moq-transport/src/session/pending_requests.rs
+++ b/moq-transport/src/session/pending_requests.rs
@@ -44,15 +44,19 @@ struct PendingRequestState {
 
 impl PendingRequest {
     fn accepts(self, response: PendingResponse) -> bool {
-        match (self, response) {
+        matches!(
+            (self, response),
             (
                 Self::PublishNamespace,
                 PendingResponse::RequestOk | PendingResponse::RequestError,
-            ) => true,
-            (Self::Publish, PendingResponse::PublishOk | PendingResponse::RequestError) => true,
-            (Self::Subscribe, PendingResponse::SubscribeOk | PendingResponse::RequestError) => true,
-            _ => false,
-        }
+            ) | (
+                Self::Publish,
+                PendingResponse::PublishOk | PendingResponse::RequestError
+            ) | (
+                Self::Subscribe,
+                PendingResponse::SubscribeOk | PendingResponse::RequestError,
+            )
+        )
     }
 }
 

--- a/moq-transport/src/session/publish_namespace.rs
+++ b/moq-transport/src/session/publish_namespace.rs
@@ -60,7 +60,7 @@ pub struct PublishNamespace {
 
 impl PublishNamespace {
     pub(super) fn new(
-        mut publisher: Publisher,
+        publisher: Publisher,
         request_id: u64,
         namespace: TrackNamespace,
     ) -> (PublishNamespace, PublishNamespaceRecv) {
@@ -68,12 +68,6 @@ impl PublishNamespace {
             request_id,
             namespace: namespace.clone(),
         };
-
-        publisher.send_message(message::PublishNamespace {
-            id: request_id,
-            track_namespace: namespace.clone(),
-            params: Default::default(),
-        });
 
         let (send, recv) = State::default().split();
 
@@ -88,6 +82,14 @@ impl PublishNamespace {
         };
 
         (send, recv)
+    }
+
+    pub(super) fn send_request(&mut self) {
+        self.publisher.send_message(message::PublishNamespace {
+            id: self.info.request_id,
+            track_namespace: self.info.namespace.clone(),
+            params: Default::default(),
+        });
     }
 
     /// Wait until the namespace publish is closed (error or peer disconnect).

--- a/moq-transport/src/session/publish_received.rs
+++ b/moq-transport/src/session/publish_received.rs
@@ -58,6 +58,7 @@ impl Default for PublishReceivedState {
 pub struct PublishReceived {
     session: Subscriber,
     state: State<PublishReceivedState>,
+    reader: Option<TrackReader>,
 
     /// Request ID of the inbound PUBLISH (draft-16 §9.1).
     request_id: u64,
@@ -87,11 +88,13 @@ impl PublishReceived {
         name: TrackName,
         initial_forward: bool,
         largest_location: Option<Location>,
+        reader: TrackReader,
         state: State<PublishReceivedState>,
     ) -> Self {
         Self {
             session,
             state,
+            reader: Some(reader),
             request_id,
             track_alias,
             namespace,
@@ -103,9 +106,16 @@ impl PublishReceived {
         }
     }
 
-    /// Accept the PUBLISH by sending PUBLISH_OK (draft-16 §9.14).
+    /// Move out the `TrackReader` before sending PUBLISH_OK.
     ///
-    /// Returns the `TrackReader` the application should poll for Objects.
+    /// This lets relays register local/coordinator state before accepting the
+    /// PUBLISH. It does **not** send PUBLISH_OK; callers must still call
+    /// [`accept`](Self::accept) or drop this handle to reject.
+    pub fn take_reader(&mut self) -> Result<TrackReader, ServeError> {
+        self.reader.take().ok_or(ServeError::Done)
+    }
+
+    /// Accept the PUBLISH by sending PUBLISH_OK (draft-16 §9.14).
     ///
     /// `forward` sets the initial Forward State:
     ///   - `true`  — publisher may start transmitting Objects immediately.
@@ -118,7 +128,7 @@ impl PublishReceived {
     /// # Protocol note
     /// PUBLISH has a dedicated success response (§9.14, type 0x1E). Do not use
     /// REQUEST_OK (§9.7) here.
-    pub fn ok(&mut self, forward: bool) -> Result<TrackReader, ServeError> {
+    pub fn accept(&mut self, forward: bool) -> Result<(), ServeError> {
         if self.ok {
             return Err(ServeError::Duplicate);
         }
@@ -133,12 +143,13 @@ impl PublishReceived {
         });
         self.ok = true;
 
-        // Take the TrackReader that was pre-allocated in recv_publish.
-        let reader = self
-            .session
-            .take_publish_received_reader(self.request_id)
-            .ok_or(ServeError::Done)?;
+        Ok(())
+    }
 
+    /// Accept the PUBLISH and return the `TrackReader`.
+    pub fn ok(&mut self, forward: bool) -> Result<TrackReader, ServeError> {
+        let reader = self.take_reader()?;
+        self.accept(forward)?;
         Ok(reader)
     }
 
@@ -241,10 +252,6 @@ pub(crate) struct PublishReceivedRecv {
     /// Write half for inbound Objects. The transport owns this so it can push
     /// Objects without going through the application.
     writer: Option<TrackWriterMode>,
-
-    /// Read half returned to the application on `PublishReceived::ok`.
-    /// Wrapped in `Option` so it can be taken exactly once.
-    reader: Option<TrackReader>,
 }
 
 impl PublishReceivedRecv {
@@ -272,20 +279,15 @@ impl PublishReceivedRecv {
             name,
             initial_forward,
             largest_location,
+            reader,
             app_state,
         );
         let recv = Self {
             state: transport_state,
             writer: Some(writer.into()),
-            reader: Some(reader),
         };
 
         (app, recv)
-    }
-
-    /// Take the `TrackReader` out exactly once (for `PublishReceived::ok`).
-    pub fn take_reader(&mut self) -> Option<TrackReader> {
-        self.reader.take()
     }
 
     /// Open a subgroup writer for the given subgroup header.
@@ -404,10 +406,10 @@ mod tests {
 
     #[test]
     fn take_reader_returns_once() {
-        let (_pr, mut recv, _sub) = make_pair(0);
-        assert!(recv.take_reader().is_some());
+        let (mut pr, _recv, _sub) = make_pair(0);
+        assert!(pr.take_reader().is_ok());
         assert!(
-            recv.take_reader().is_none(),
+            pr.take_reader().is_err(),
             "reader must only be given out once"
         );
     }

--- a/moq-transport/src/session/publish_received.rs
+++ b/moq-transport/src/session/publish_received.rs
@@ -166,7 +166,11 @@ impl PublishReceived {
         loop {
             {
                 let state = self.state.lock();
-                state.closed.clone()?;
+                match state.closed.clone() {
+                    Ok(()) => {}
+                    Err(ServeError::Done) => return Ok(()),
+                    Err(err) => return Err(err),
+                }
                 match state.modified() {
                     Some(notify) => notify,
                     None => return Ok(()),
@@ -440,9 +444,30 @@ mod tests {
         assert!(recv.writer.is_none());
     }
 
+    #[tokio::test]
+    async fn closed_returns_ok_for_track_ended() {
+        let (pr, mut recv, _sub) = make_pair(3);
+
+        recv.recv_done(message::PublishDoneCode::TrackEnded as u64);
+
+        assert_eq!(pr.closed().await, Ok(()));
+    }
+
+    #[tokio::test]
+    async fn closed_returns_error_for_non_track_ended() {
+        let (pr, mut recv, _sub) = make_pair(4);
+
+        recv.recv_done(message::PublishDoneCode::Expired as u64);
+
+        assert!(matches!(
+            pr.closed().await,
+            Err(ServeError::Closed(code)) if code == message::PublishDoneCode::Expired as u64
+        ));
+    }
+
     #[test]
     fn publish_received_drop_without_ok_does_not_panic() {
-        let (pr, _recv, _sub) = make_pair(3);
+        let (pr, _recv, _sub) = make_pair(5);
         // Drop without calling ok() — should send REQUEST_ERROR, not panic.
         drop(pr);
     }

--- a/moq-transport/src/session/publish_received.rs
+++ b/moq-transport/src/session/publish_received.rs
@@ -387,7 +387,12 @@ mod tests {
         crate::session::Subscriber,
     ) {
         let rid = RequestId::new(0, 100, 100, 0);
-        let subscriber = crate::session::Subscriber::new(Queue::default(), None, rid);
+        let subscriber = crate::session::Subscriber::new(
+            Queue::default(),
+            None,
+            rid,
+            crate::session::PendingRequests::default(),
+        );
         let (writer, reader) =
             Track::new(TrackNamespace::from_utf8_path("test"), "0.mp4").produce();
         let (pr, recv) = PublishReceivedRecv::produce(

--- a/moq-transport/src/session/publish_received.rs
+++ b/moq-transport/src/session/publish_received.rs
@@ -1,19 +1,21 @@
 // SPDX-FileCopyrightText: 2026 Cloudflare Inc.
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! Inbound PUBLISH handling: a subscriber receives a PUBLISH from a publisher
-//! and can accept it with PUBLISH_OK, reject it with REQUEST_ERROR, and then
-//! receive Objects on the resulting subscription.
+//! Inbound PUBLISH handling: this endpoint, acting as subscriber, receives a
+//! PUBLISH from a publisher and can accept it with PUBLISH_OK, reject it with
+//! REQUEST_ERROR, and then receive Objects on the resulting subscription
+//! (draft-16 §9.13 / §9.14 / §9.15).
 //!
-//! # Ownership model (draft-16 §9.13 / §9.14)
+//! # Ownership model
 //!
-//! The transport layer retains the `TrackWriter` (stored inside
-//! `PublishedTrackRecv`) so that `recv_stream` and `recv_datagram` can write
-//! inbound Objects without application involvement.  The application receives
-//! the `TrackReader` by calling `PublishedTrack::ok`.
+//! The transport layer retains the `TrackWriter` (inside `PublishReceivedRecv`)
+//! so the stream/datagram receive paths can write inbound Objects without
+//! application involvement. The application receives the `TrackReader` from
+//! `PublishReceived::ok`. This mirrors the outbound-SUBSCRIBE receive path
+//! where `SubscribeRecv` owns the writer.
 //!
-//! This mirrors the existing outbound-SUBSCRIBE path where `SubscribeRecv`
-//! owns the writer and the stream/datagram handlers write into it.
+//! This is the inbound counterpart of `Published` (outbound PUBLISH). Both use
+//! the same `TrackOrigin` alias map in `Subscriber` for stream routing.
 
 use crate::{
     coding::{KeyValuePairs, Location, ReasonPhrase, TrackName, TrackNamespace},
@@ -27,16 +29,16 @@ use super::Subscriber;
 
 // ── Shared state ──────────────────────────────────────────────────────────────
 
-/// State shared between `PublishedTrack` (application handle) and
-/// `PublishedTrackRecv` (transport handle).
-pub(crate) struct PublishedTrackState {
+/// State shared between `PublishReceived` (application handle) and
+/// `PublishReceivedRecv` (transport handle).
+pub(crate) struct PublishReceivedState {
     /// True once PUBLISH_DONE has been received from the publisher.
     done: bool,
     /// Terminal result; set when `done` becomes true.
     closed: Result<(), ServeError>,
 }
 
-impl Default for PublishedTrackState {
+impl Default for PublishReceivedState {
     fn default() -> Self {
         Self {
             done: false,
@@ -50,12 +52,12 @@ impl Default for PublishedTrackState {
 /// An inbound PUBLISH received by this endpoint acting as subscriber
 /// (draft-16 §9.13).
 ///
-/// Call [`ok`] to accept the subscription and obtain the [`TrackReader`].
-/// Dropping without calling [`ok`] sends `REQUEST_ERROR UNINTERESTED` back to
-/// the publisher.
-pub struct PublishedTrack {
+/// Call [`ok`](Self::ok) to accept the subscription and obtain the
+/// [`TrackReader`]. Dropping without calling `ok` sends `REQUEST_ERROR
+/// UNINTERESTED` back to the publisher.
+pub struct PublishReceived {
     session: Subscriber,
-    state: State<PublishedTrackState>,
+    state: State<PublishReceivedState>,
 
     /// Request ID of the inbound PUBLISH (draft-16 §9.1).
     request_id: u64,
@@ -75,7 +77,7 @@ pub struct PublishedTrack {
     error: Option<ServeError>,
 }
 
-impl PublishedTrack {
+impl PublishReceived {
     #[allow(clippy::too_many_arguments)]
     pub(super) fn new(
         session: Subscriber,
@@ -85,7 +87,7 @@ impl PublishedTrack {
         name: TrackName,
         initial_forward: bool,
         largest_location: Option<Location>,
-        state: State<PublishedTrackState>,
+        state: State<PublishReceivedState>,
     ) -> Self {
         Self {
             session,
@@ -107,12 +109,15 @@ impl PublishedTrack {
     ///
     /// `forward` sets the initial Forward State:
     ///   - `true`  — publisher may start transmitting Objects immediately.
-    ///   - `false` — publisher pauses until the subscriber sends REQUEST_UPDATE
-    ///               with Forward=1.
+    ///   - `false` — publisher pauses until Forward is later set to 1.
+    ///
+    /// Note: post-establishment `REQUEST_UPDATE` is not supported yet, so
+    /// passing `false` keeps the publisher paused for the lifetime of the
+    /// subscription in this implementation.
     ///
     /// # Protocol note
-    /// PUBLISH has a dedicated success response (§9.14, type 0x1E).  Do not
-    /// use REQUEST_OK (§9.7) here.
+    /// PUBLISH has a dedicated success response (§9.14, type 0x1E). Do not use
+    /// REQUEST_OK (§9.7) here.
     pub fn ok(&mut self, forward: bool) -> Result<TrackReader, ServeError> {
         if self.ok {
             return Err(ServeError::Duplicate);
@@ -131,7 +136,7 @@ impl PublishedTrack {
         // Take the TrackReader that was pre-allocated in recv_publish.
         let reader = self
             .session
-            .take_published_track_reader(self.request_id)
+            .take_publish_received_reader(self.request_id)
             .ok_or(ServeError::Done)?;
 
         Ok(reader)
@@ -160,16 +165,6 @@ impl PublishedTrack {
         }
     }
 
-    /// Toggle Forward state by sending REQUEST_UPDATE (draft-16 §9.11).
-    ///
-    /// Waits for the publisher's REQUEST_OK or returns the error from
-    /// REQUEST_ERROR.
-    pub async fn set_forward(&mut self, forward: bool) -> Result<(), ServeError> {
-        self.session
-            .send_request_update_for_publish(self.request_id, forward)
-            .await
-    }
-
     pub fn namespace(&self) -> &TrackNamespace {
         &self.namespace
     }
@@ -191,7 +186,7 @@ impl PublishedTrack {
     }
 }
 
-impl Drop for PublishedTrack {
+impl Drop for PublishReceived {
     fn drop(&mut self) {
         if self.ok {
             // Already accepted; nothing to send — PUBLISH_DONE arrives from the
@@ -229,7 +224,7 @@ impl Drop for PublishedTrack {
         );
 
         // Clean up subscriber-side state for this PUBLISH.
-        self.session.remove_published_track(self.request_id);
+        self.session.remove_publish_received(self.request_id);
     }
 }
 
@@ -237,26 +232,24 @@ impl Drop for PublishedTrack {
 
 /// Transport-side bookkeeping for a single inbound PUBLISH.
 ///
-/// Stored in `Subscriber::published_tracks`.  Stream and datagram receive
+/// Stored in `Subscriber::publishes_received`. Stream and datagram receive
 /// paths write Objects directly into the `TrackWriterMode` here.
-pub(crate) struct PublishedTrackRecv {
+pub(crate) struct PublishReceivedRecv {
     /// Shared state so both the transport and app can observe PUBLISH_DONE.
-    state: State<PublishedTrackState>,
+    state: State<PublishReceivedState>,
 
-    /// Write half for inbound Objects.  The transport owns this so it can push
+    /// Write half for inbound Objects. The transport owns this so it can push
     /// Objects without going through the application.
     writer: Option<TrackWriterMode>,
 
-    /// Read half returned to the application on `PublishedTrack::ok`.
+    /// Read half returned to the application on `PublishReceived::ok`.
     /// Wrapped in `Option` so it can be taken exactly once.
     reader: Option<TrackReader>,
 }
 
-impl PublishedTrackRecv {
-    /// Create a `PublishedTrack` / `PublishedTrackRecv` pair from a PUBLISH message.
-    ///
-    /// Returns both the application-facing handle and the transport-facing recv,
-    /// pre-wired to the same shared state.
+impl PublishReceivedRecv {
+    /// Create a `PublishReceived` / `PublishReceivedRecv` pair from a PUBLISH
+    /// message. Both handles share the same state.
     #[allow(clippy::too_many_arguments)]
     pub(super) fn produce(
         session: Subscriber,
@@ -268,10 +261,10 @@ impl PublishedTrackRecv {
         largest_location: Option<Location>,
         writer: serve::TrackWriter,
         reader: TrackReader,
-    ) -> (PublishedTrack, PublishedTrackRecv) {
-        let (app_state, transport_state) = State::<PublishedTrackState>::default().split();
+    ) -> (PublishReceived, PublishReceivedRecv) {
+        let (app_state, transport_state) = State::<PublishReceivedState>::default().split();
 
-        let app = PublishedTrack::new(
+        let app = PublishReceived::new(
             session,
             request_id,
             track_alias,
@@ -290,15 +283,15 @@ impl PublishedTrackRecv {
         (app, recv)
     }
 
-    /// Take the `TrackReader` out exactly once (for `PublishedTrack::ok`).
+    /// Take the `TrackReader` out exactly once (for `PublishReceived::ok`).
     pub fn take_reader(&mut self) -> Option<TrackReader> {
         self.reader.take()
     }
 
     /// Open a subgroup writer for the given subgroup header.
     ///
-    /// Mirrors `SubscribeRecv::subgroup` so the same `recv_subgroup` code path
-    /// can serve both SUBSCRIBE-initiated and PUBLISH-initiated subscriptions.
+    /// Mirrors `SubscribeRecv::subgroup` so the same subgroup receive loop can
+    /// serve both SUBSCRIBE-initiated and PUBLISH-initiated subscriptions.
     pub fn subgroup(
         &mut self,
         header: data::SubgroupHeader,
@@ -375,18 +368,6 @@ impl PublishedTrackRecv {
     }
 }
 
-// ── Pending REQUEST_UPDATE for set_forward ────────────────────────────────────
-
-/// Bookkeeping for a pending REQUEST_UPDATE sent by `PublishedTrack::set_forward`.
-///
-/// Stored in `Subscriber::pending_publish_updates` keyed by the REQUEST_UPDATE
-/// request id.  When REQUEST_OK or REQUEST_ERROR arrives it is removed and the
-/// sender is notified.
-pub(crate) struct PendingPublishUpdate {
-    /// One-shot channel to wake the `set_forward` caller.
-    pub result_tx: tokio::sync::oneshot::Sender<Result<(), ServeError>>,
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -399,15 +380,15 @@ mod tests {
     fn make_pair(
         request_id: u64,
     ) -> (
-        PublishedTrack,
-        PublishedTrackRecv,
+        PublishReceived,
+        PublishReceivedRecv,
         crate::session::Subscriber,
     ) {
         let rid = RequestId::new(0, 100, 100, 0);
         let subscriber = crate::session::Subscriber::new(Queue::default(), None, rid);
         let (writer, reader) =
             Track::new(TrackNamespace::from_utf8_path("test"), "0.mp4").produce();
-        let (pt, recv) = PublishedTrackRecv::produce(
+        let (pr, recv) = PublishReceivedRecv::produce(
             subscriber.clone(),
             request_id,
             42,
@@ -418,12 +399,12 @@ mod tests {
             writer,
             reader,
         );
-        (pt, recv, subscriber)
+        (pr, recv, subscriber)
     }
 
     #[test]
     fn take_reader_returns_once() {
-        let (_pt, mut recv, _sub) = make_pair(0);
+        let (_pr, mut recv, _sub) = make_pair(0);
         assert!(recv.take_reader().is_some());
         assert!(
             recv.take_reader().is_none(),
@@ -433,7 +414,7 @@ mod tests {
 
     #[test]
     fn recv_done_closes_writer_and_sets_state() {
-        let (_pt, mut recv, _sub) = make_pair(1);
+        let (_pr, mut recv, _sub) = make_pair(1);
         assert!(recv.writer.is_some());
 
         recv.recv_done(message::PublishDoneCode::TrackEnded as u64);
@@ -446,16 +427,16 @@ mod tests {
 
     #[test]
     fn recv_done_non_track_ended_stores_code() {
-        let (_pt, mut recv, _sub) = make_pair(2);
+        let (_pr, mut recv, _sub) = make_pair(2);
         recv.recv_done(message::PublishDoneCode::Expired as u64);
         // No panic and writer is gone.
         assert!(recv.writer.is_none());
     }
 
     #[test]
-    fn published_track_drop_without_ok_does_not_panic() {
-        let (pt, _recv, _sub) = make_pair(3);
+    fn publish_received_drop_without_ok_does_not_panic() {
+        let (pr, _recv, _sub) = make_pair(3);
         // Drop without calling ok() — should send REQUEST_ERROR, not panic.
-        drop(pt);
+        drop(pr);
     }
 }

--- a/moq-transport/src/session/published.rs
+++ b/moq-transport/src/session/published.rs
@@ -4,9 +4,8 @@
 //! Outbound PUBLISH handling: a publisher sends PUBLISH, receives PUBLISH_OK
 //! or REQUEST_ERROR, serves Objects, and terminates with PUBLISH_DONE.
 //!
-//! The data-plane serving path is intentionally reused from `Subscribed` via
-//! `Subscribed::new_for_publish`; this keeps PUBLISH serving and SUBSCRIBE
-//! serving on the same subgroup/datagram implementation.
+//! The data-plane serving path is shared with SUBSCRIBE serving through
+//! `ObjectForwarder`; PUBLISH-specific state stays in `Published`.
 
 use std::ops;
 
@@ -17,7 +16,7 @@ use crate::{
     watch::State,
 };
 
-use super::{Publisher, SessionError, Subscribed};
+use super::{DeliveryFilter, ObjectForwarder, Publisher, SessionError};
 
 #[derive(Debug, Clone)]
 pub struct PublishedInfo {
@@ -49,8 +48,8 @@ impl PublishedState {
 /// Outbound PUBLISH created by [`Publisher::publish`].
 ///
 /// Dropping without calling [`serve`] sends PUBLISH_DONE with a generic
-/// terminal status. Calling [`serve`] delegates to `Subscribed::serve`, whose
-/// Drop sends PUBLISH_DONE after the data-plane loop has stopped.
+/// terminal status. Calling [`serve`] runs the shared object forwarder; dropping
+/// after the data-plane loop has stopped sends PUBLISH_DONE from this handle.
 #[must_use = "serve or drop to send PUBLISH_DONE"]
 pub struct Published {
     publisher: Publisher,
@@ -120,28 +119,40 @@ impl Published {
 
         let forward = self.state.lock().forward;
         if !forward {
-            self.closed().await?;
+            let res = self.closed().await;
             self.served = true;
-            return Ok(());
+            return match res {
+                Ok(()) | Err(ServeError::Cancel) => Ok(()),
+                Err(err) => Err(err.into()),
+            };
         }
 
         let track = self.track.take().ok_or(SessionError::Internal)?;
-        let (subscribed, _recv) = Subscribed::new_for_publish(
-            self.publisher.clone(),
-            self.info.id,
-            self.info.track_alias,
-            self.info.track_namespace.clone(),
-            self.info.track_name.clone(),
+        let (mut forwarder, recv) =
+            ObjectForwarder::new(self.publisher.clone(), self.info.track_alias, None);
+        self.publisher
+            .register_published_subscription(self.info.id, recv)?;
+
+        let largest_location = track.largest_location();
+        forwarder.set_largest_location(largest_location)?;
+        let delivery_filter = DeliveryFilter {
             forward,
-            None,
-        );
+            start_location: None,
+            end_group_id: None,
+        };
 
         self.served = true;
-        subscribed.serve(track).await
+        match forwarder.serve(track, delivery_filter).await {
+            Err(SessionError::Serve(ServeError::Cancel)) => Ok(()),
+            res => res,
+        }
     }
 
     pub fn close(self, err: ServeError) -> Result<(), ServeError> {
-        let state = self.state.lock();
+        let state = self
+            .state
+            .try_lock()
+            .map_err(|_| ServeError::internal_ctx("published state lock poisoned"))?;
         state.closed.clone()?;
 
         let mut state = state.into_mut().ok_or(ServeError::Done)?;
@@ -165,7 +176,16 @@ impl Drop for Published {
             return;
         }
 
-        let state = self.state.lock();
+        let state = match self.state.try_lock() {
+            Ok(state) => state,
+            Err(()) => {
+                tracing::error!(
+                    request_id = self.info.id,
+                    "published state lock poisoned while dropping PUBLISH"
+                );
+                return;
+            }
+        };
         // If the subscriber rejected the PUBLISH with REQUEST_ERROR before it
         // became established, the request is already terminal (§5.1). Do not
         // send a second terminal message.
@@ -181,12 +201,21 @@ impl Drop for Published {
             .unwrap_or(ServeError::Done);
         drop(state);
 
-        self.publisher.send_message(message::PublishDone {
-            id: self.info.id,
-            status_code: publish_done_code(&err),
-            stream_count: 0,
-            reason: ReasonPhrase("publish ended".to_string()),
-        });
+        if self
+            .publisher
+            .try_send_message(message::PublishDone {
+                id: self.info.id,
+                status_code: publish_done_code(&err),
+                stream_count: 0,
+                reason: ReasonPhrase("publish ended".to_string()),
+            })
+            .is_err()
+        {
+            tracing::error!(
+                request_id = self.info.id,
+                "failed to enqueue PUBLISH_DONE while dropping PUBLISH"
+            );
+        }
     }
 }
 
@@ -220,6 +249,10 @@ impl PublishedRecv {
             state.closed = Err(err);
         }
         Ok(())
+    }
+
+    pub fn recv_unsubscribe(&mut self) -> Result<(), ServeError> {
+        self.recv_error(ServeError::Cancel)
     }
 }
 

--- a/moq-transport/src/session/published.rs
+++ b/moq-transport/src/session/published.rs
@@ -32,6 +32,7 @@ pub struct PublishedInfo {
 pub(crate) struct PublishedState {
     ok: bool,
     forward: bool,
+    unsubscribed: bool,
     closed: Result<(), ServeError>,
 }
 
@@ -40,6 +41,7 @@ impl PublishedState {
         Self {
             ok: false,
             forward,
+            unsubscribed: false,
             closed: Ok(()),
         }
     }
@@ -55,7 +57,6 @@ pub struct Published {
     publisher: Publisher,
     state: State<PublishedState>,
     track: Option<TrackReader>,
-    served: bool,
 
     pub info: PublishedInfo,
 }
@@ -71,7 +72,6 @@ impl Published {
             publisher,
             state,
             track: Some(track),
-            served: false,
             info,
         }
     }
@@ -115,14 +115,26 @@ impl Published {
     /// This waits for PUBLISH_OK before serving. draft-16 allows serving before
     /// PUBLISH_OK, but does not require it; waiting keeps the first cut simple.
     pub async fn serve(mut self) -> Result<(), SessionError> {
+        let res = self.serve_inner().await;
+        if let Err(err) = &res {
+            self.close_state(err.clone().into())?;
+        }
+
+        res
+    }
+
+    async fn serve_inner(&mut self) -> Result<(), SessionError> {
         self.ok().await?;
 
         let forward = self.state.lock().forward;
         if !forward {
-            let res = self.closed().await;
-            self.served = true;
+            let track = self.track.take().ok_or(SessionError::Internal)?;
+            let res = tokio::select! {
+                res = track.closed() => res,
+                res = self.closed() => res,
+            };
             return match res {
-                Ok(()) | Err(ServeError::Cancel) => Ok(()),
+                Ok(()) | Err(ServeError::Done | ServeError::Cancel) => Ok(()),
                 Err(err) => Err(err.into()),
             };
         }
@@ -141,7 +153,6 @@ impl Published {
             end_group_id: None,
         };
 
-        self.served = true;
         match forwarder.serve(track, delivery_filter).await {
             Err(SessionError::Serve(ServeError::Cancel)) => Ok(()),
             res => res,
@@ -149,6 +160,10 @@ impl Published {
     }
 
     pub fn close(self, err: ServeError) -> Result<(), ServeError> {
+        self.close_state(err)
+    }
+
+    fn close_state(&self, err: ServeError) -> Result<(), ServeError> {
         let state = self
             .state
             .try_lock()
@@ -172,10 +187,6 @@ impl ops::Deref for Published {
 
 impl Drop for Published {
     fn drop(&mut self) {
-        if self.served {
-            return;
-        }
-
         let state = match self.state.try_lock() {
             Ok(state) => state,
             Err(_) => {
@@ -186,19 +197,9 @@ impl Drop for Published {
                 return;
             }
         };
-        // If the subscriber rejected the PUBLISH with REQUEST_ERROR before it
-        // became established, the request is already terminal (§5.1). Do not
-        // send a second terminal message.
-        if !state.ok && state.closed.is_err() {
+        let Some(err) = publish_done_error_on_drop(&state) else {
             return;
-        }
-
-        let err = state
-            .closed
-            .as_ref()
-            .err()
-            .cloned()
-            .unwrap_or(ServeError::Done);
+        };
         drop(state);
 
         if self
@@ -252,7 +253,15 @@ impl PublishedRecv {
     }
 
     pub fn recv_unsubscribe(&mut self) -> Result<(), ServeError> {
-        self.recv_error(ServeError::Cancel)
+        let state = self.state.lock();
+        state.closed.clone()?;
+
+        if let Some(mut state) = state.into_mut() {
+            state.unsubscribed = true;
+            state.closed = Err(ServeError::Cancel);
+        }
+
+        Ok(())
     }
 }
 
@@ -268,6 +277,24 @@ fn publish_done_code(err: &ServeError) -> u64 {
         ServeError::Closed(code) => *code,
         _ => message::PublishDoneCode::InternalError as u64,
     }
+}
+
+fn publish_done_error_on_drop(state: &PublishedState) -> Option<ServeError> {
+    // If the subscriber rejected the PUBLISH with REQUEST_ERROR before it
+    // became established, the request is already terminal (§5.1). If the
+    // subscriber sent UNSUBSCRIBE, it already terminated its side.
+    if state.unsubscribed || (!state.ok && state.closed.is_err()) {
+        return None;
+    }
+
+    Some(
+        state
+            .closed
+            .as_ref()
+            .err()
+            .cloned()
+            .unwrap_or(ServeError::Done),
+    )
 }
 
 #[cfg(test)]
@@ -294,5 +321,34 @@ mod tests {
             publish_done_code(&ServeError::Done),
             message::PublishDoneCode::TrackEnded as u64
         );
+    }
+
+    #[test]
+    fn drop_terminal_error_sends_done_after_accepted_normal_completion() {
+        let mut state = PublishedState::new(true);
+        state.ok = true;
+
+        assert_eq!(publish_done_error_on_drop(&state), Some(ServeError::Done));
+    }
+
+    #[test]
+    fn drop_terminal_error_skips_pre_accept_rejection() {
+        let mut state = PublishedState::new(true);
+        state.closed = Err(ServeError::Closed(123));
+
+        assert_eq!(publish_done_error_on_drop(&state), None);
+    }
+
+    #[test]
+    fn recv_unsubscribe_marks_unsubscribed_and_closes() {
+        let (_send, recv_state) = split_published_state(true);
+        let mut recv = PublishedRecv::new(recv_state);
+
+        recv.recv_unsubscribe().unwrap();
+
+        let state = recv.state.lock();
+        assert!(state.unsubscribed);
+        assert!(matches!(state.closed, Err(ServeError::Cancel)));
+        assert_eq!(publish_done_error_on_drop(&state), None);
     }
 }

--- a/moq-transport/src/session/published.rs
+++ b/moq-transport/src/session/published.rs
@@ -178,7 +178,7 @@ impl Drop for Published {
 
         let state = match self.state.try_lock() {
             Ok(state) => state,
-            Err(()) => {
+            Err(_) => {
                 tracing::error!(
                     request_id = self.info.id,
                     "published state lock poisoned while dropping PUBLISH"

--- a/moq-transport/src/session/published.rs
+++ b/moq-transport/src/session/published.rs
@@ -1,0 +1,265 @@
+// SPDX-FileCopyrightText: 2026 Cloudflare Inc.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Outbound PUBLISH handling: a publisher sends PUBLISH, receives PUBLISH_OK
+//! or REQUEST_ERROR, serves Objects, and terminates with PUBLISH_DONE.
+//!
+//! The data-plane serving path is intentionally reused from `Subscribed` via
+//! `Subscribed::new_for_publish`; this keeps PUBLISH serving and SUBSCRIBE
+//! serving on the same subgroup/datagram implementation.
+
+use std::ops;
+
+use crate::{
+    coding::{Location, ReasonPhrase, TrackName, TrackNamespace},
+    message,
+    serve::{ServeError, TrackReader},
+    watch::State,
+};
+
+use super::{Publisher, SessionError, Subscribed};
+
+#[derive(Debug, Clone)]
+pub struct PublishedInfo {
+    pub id: u64,
+    pub track_namespace: TrackNamespace,
+    pub track_name: TrackName,
+    pub track_alias: u64,
+    pub forward: bool,
+    pub largest_location: Option<Location>,
+}
+
+#[derive(Debug)]
+pub(crate) struct PublishedState {
+    ok: bool,
+    forward: bool,
+    closed: Result<(), ServeError>,
+}
+
+impl PublishedState {
+    fn new(forward: bool) -> Self {
+        Self {
+            ok: false,
+            forward,
+            closed: Ok(()),
+        }
+    }
+}
+
+/// Outbound PUBLISH created by [`Publisher::publish`].
+///
+/// Dropping without calling [`serve`] sends PUBLISH_DONE with a generic
+/// terminal status. Calling [`serve`] delegates to `Subscribed::serve`, whose
+/// Drop sends PUBLISH_DONE after the data-plane loop has stopped.
+#[must_use = "serve or drop to send PUBLISH_DONE"]
+pub struct Published {
+    publisher: Publisher,
+    state: State<PublishedState>,
+    track: Option<TrackReader>,
+    served: bool,
+
+    pub info: PublishedInfo,
+}
+
+impl Published {
+    pub(super) fn new(
+        publisher: Publisher,
+        info: PublishedInfo,
+        state: State<PublishedState>,
+        track: TrackReader,
+    ) -> Self {
+        Self {
+            publisher,
+            state,
+            track: Some(track),
+            served: false,
+            info,
+        }
+    }
+
+    /// Wait until the subscriber accepts with PUBLISH_OK (§9.14).
+    pub async fn ok(&mut self) -> Result<(), ServeError> {
+        loop {
+            {
+                let state = self.state.lock();
+                state.closed.clone()?;
+                if state.ok {
+                    return Ok(());
+                }
+                match state.modified() {
+                    Some(notify) => notify,
+                    None => return Err(ServeError::Done),
+                }
+            }
+            .await;
+        }
+    }
+
+    /// Wait until this PUBLISH is closed or rejected.
+    pub async fn closed(&self) -> Result<(), ServeError> {
+        loop {
+            {
+                let state = self.state.lock();
+                state.closed.clone()?;
+                match state.modified() {
+                    Some(notify) => notify,
+                    None => return Ok(()),
+                }
+            }
+            .await;
+        }
+    }
+
+    /// Serve Objects for this PUBLISH using the same data-plane path as
+    /// SUBSCRIBE serving.
+    ///
+    /// This waits for PUBLISH_OK before serving. draft-16 allows serving before
+    /// PUBLISH_OK, but does not require it; waiting keeps the first cut simple.
+    pub async fn serve(mut self) -> Result<(), SessionError> {
+        self.ok().await?;
+
+        let forward = self.state.lock().forward;
+        if !forward {
+            self.closed().await?;
+            self.served = true;
+            return Ok(());
+        }
+
+        let track = self.track.take().ok_or(SessionError::Internal)?;
+        let (subscribed, _recv) = Subscribed::new_for_publish(
+            self.publisher.clone(),
+            self.info.id,
+            self.info.track_alias,
+            self.info.track_namespace.clone(),
+            self.info.track_name.clone(),
+            forward,
+            None,
+        );
+
+        self.served = true;
+        subscribed.serve(track).await
+    }
+
+    pub fn close(self, err: ServeError) -> Result<(), ServeError> {
+        let state = self.state.lock();
+        state.closed.clone()?;
+
+        let mut state = state.into_mut().ok_or(ServeError::Done)?;
+        state.closed = Err(err);
+
+        Ok(())
+    }
+}
+
+impl ops::Deref for Published {
+    type Target = PublishedInfo;
+
+    fn deref(&self) -> &Self::Target {
+        &self.info
+    }
+}
+
+impl Drop for Published {
+    fn drop(&mut self) {
+        if self.served {
+            return;
+        }
+
+        let state = self.state.lock();
+        // If the subscriber rejected the PUBLISH with REQUEST_ERROR before it
+        // became established, the request is already terminal (§5.1). Do not
+        // send a second terminal message.
+        if !state.ok && state.closed.is_err() {
+            return;
+        }
+
+        let err = state
+            .closed
+            .as_ref()
+            .err()
+            .cloned()
+            .unwrap_or(ServeError::Done);
+        drop(state);
+
+        self.publisher.send_message(message::PublishDone {
+            id: self.info.id,
+            status_code: publish_done_code(&err),
+            stream_count: 0,
+            reason: ReasonPhrase("publish ended".to_string()),
+        });
+    }
+}
+
+pub(crate) struct PublishedRecv {
+    state: State<PublishedState>,
+}
+
+impl PublishedRecv {
+    pub fn new(state: State<PublishedState>) -> Self {
+        Self { state }
+    }
+
+    pub fn recv_ok(&mut self, msg: &message::PublishOk) -> Result<(), ServeError> {
+        let forward = msg
+            .params
+            .forward()
+            .map_err(|_| ServeError::internal_ctx("invalid FORWARD in PUBLISH_OK"))?;
+
+        if let Some(mut state) = self.state.lock_mut() {
+            state.ok = true;
+            if let Some(forward) = forward {
+                state.forward = forward;
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn recv_error(&mut self, err: ServeError) -> Result<(), ServeError> {
+        if let Some(mut state) = self.state.lock_mut() {
+            state.closed = Err(err);
+        }
+        Ok(())
+    }
+}
+
+pub(crate) fn split_published_state(
+    forward: bool,
+) -> (State<PublishedState>, State<PublishedState>) {
+    State::new(PublishedState::new(forward)).split()
+}
+
+fn publish_done_code(err: &ServeError) -> u64 {
+    match err {
+        ServeError::Done => message::PublishDoneCode::TrackEnded as u64,
+        ServeError::Closed(code) => *code,
+        _ => message::PublishDoneCode::InternalError as u64,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::coding::KeyValuePairs;
+
+    #[test]
+    fn recv_ok_sets_forward_when_present() {
+        let (_send, recv_state) = split_published_state(true);
+        let mut recv = PublishedRecv::new(recv_state);
+        let mut params = KeyValuePairs::default();
+        params.set_forward(false);
+
+        recv.recv_ok(&message::PublishOk { id: 0, params }).unwrap();
+
+        assert!(!recv.state.lock().forward);
+        assert!(recv.state.lock().ok);
+    }
+
+    #[test]
+    fn publish_done_code_maps_done_to_track_ended() {
+        assert_eq!(
+            publish_done_code(&ServeError::Done),
+            message::PublishDoneCode::TrackEnded as u64
+        );
+    }
+}

--- a/moq-transport/src/session/published_track.rs
+++ b/moq-transport/src/session/published_track.rs
@@ -1,0 +1,461 @@
+// SPDX-FileCopyrightText: 2026 Cloudflare Inc.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Inbound PUBLISH handling: a subscriber receives a PUBLISH from a publisher
+//! and can accept it with PUBLISH_OK, reject it with REQUEST_ERROR, and then
+//! receive Objects on the resulting subscription.
+//!
+//! # Ownership model (draft-16 §9.13 / §9.14)
+//!
+//! The transport layer retains the `TrackWriter` (stored inside
+//! `PublishedTrackRecv`) so that `recv_stream` and `recv_datagram` can write
+//! inbound Objects without application involvement.  The application receives
+//! the `TrackReader` by calling `PublishedTrack::ok`.
+//!
+//! This mirrors the existing outbound-SUBSCRIBE path where `SubscribeRecv`
+//! owns the writer and the stream/datagram handlers write into it.
+
+use crate::{
+    coding::{KeyValuePairs, Location, ReasonPhrase, TrackName, TrackNamespace},
+    data,
+    message::{self, RequestErrorCode},
+    serve::{self, ServeError, TrackReader, TrackWriterMode},
+    watch::State,
+};
+
+use super::Subscriber;
+
+// ── Shared state ──────────────────────────────────────────────────────────────
+
+/// State shared between `PublishedTrack` (application handle) and
+/// `PublishedTrackRecv` (transport handle).
+pub(crate) struct PublishedTrackState {
+    /// True once PUBLISH_DONE has been received from the publisher.
+    done: bool,
+    /// Terminal result; set when `done` becomes true.
+    closed: Result<(), ServeError>,
+}
+
+impl Default for PublishedTrackState {
+    fn default() -> Self {
+        Self {
+            done: false,
+            closed: Ok(()),
+        }
+    }
+}
+
+// ── Application-facing handle ─────────────────────────────────────────────────
+
+/// An inbound PUBLISH received by this endpoint acting as subscriber
+/// (draft-16 §9.13).
+///
+/// Call [`ok`] to accept the subscription and obtain the [`TrackReader`].
+/// Dropping without calling [`ok`] sends `REQUEST_ERROR UNINTERESTED` back to
+/// the publisher.
+pub struct PublishedTrack {
+    session: Subscriber,
+    state: State<PublishedTrackState>,
+
+    /// Request ID of the inbound PUBLISH (draft-16 §9.1).
+    request_id: u64,
+    /// Track Alias chosen by the publisher (§10.1).
+    track_alias: u64,
+    /// Full track identifier.
+    namespace: TrackNamespace,
+    name: TrackName,
+    /// Initial Forward value parsed from the PUBLISH params (§9.13 / §5.1).
+    initial_forward: bool,
+    /// LARGEST_OBJECT from the PUBLISH params, if present (§5.1).
+    largest_location: Option<Location>,
+
+    /// True once `ok()` has been called successfully.
+    ok: bool,
+    /// Optional override for the rejection error sent on drop.
+    error: Option<ServeError>,
+}
+
+impl PublishedTrack {
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn new(
+        session: Subscriber,
+        request_id: u64,
+        track_alias: u64,
+        namespace: TrackNamespace,
+        name: TrackName,
+        initial_forward: bool,
+        largest_location: Option<Location>,
+        state: State<PublishedTrackState>,
+    ) -> Self {
+        Self {
+            session,
+            state,
+            request_id,
+            track_alias,
+            namespace,
+            name,
+            initial_forward,
+            largest_location,
+            ok: false,
+            error: None,
+        }
+    }
+
+    /// Accept the PUBLISH by sending PUBLISH_OK (draft-16 §9.14).
+    ///
+    /// Returns the `TrackReader` the application should poll for Objects.
+    ///
+    /// `forward` sets the initial Forward State:
+    ///   - `true`  — publisher may start transmitting Objects immediately.
+    ///   - `false` — publisher pauses until the subscriber sends REQUEST_UPDATE
+    ///               with Forward=1.
+    ///
+    /// # Protocol note
+    /// PUBLISH has a dedicated success response (§9.14, type 0x1E).  Do not
+    /// use REQUEST_OK (§9.7) here.
+    pub fn ok(&mut self, forward: bool) -> Result<TrackReader, ServeError> {
+        if self.ok {
+            return Err(ServeError::Duplicate);
+        }
+
+        let mut params = KeyValuePairs::default();
+        params.set_forward(forward);
+
+        // PUBLISH_OK uses its own message type 0x1E (§9.14).
+        self.session.send_message(message::PublishOk {
+            id: self.request_id,
+            params,
+        });
+        self.ok = true;
+
+        // Take the TrackReader that was pre-allocated in recv_publish.
+        let reader = self
+            .session
+            .take_published_track_reader(self.request_id)
+            .ok_or(ServeError::Done)?;
+
+        Ok(reader)
+    }
+
+    /// Mark this track for rejection with a specific error on drop.
+    pub fn close(mut self, err: ServeError) {
+        self.error = Some(err);
+    }
+
+    /// Wait until the publisher sends PUBLISH_DONE or the session closes.
+    ///
+    /// Returns `Ok(())` on clean termination (TRACK_ENDED), or the error code
+    /// from PUBLISH_DONE on all other outcomes.
+    pub async fn closed(&self) -> Result<(), ServeError> {
+        loop {
+            {
+                let state = self.state.lock();
+                state.closed.clone()?;
+                match state.modified() {
+                    Some(notify) => notify,
+                    None => return Ok(()),
+                }
+            }
+            .await;
+        }
+    }
+
+    /// Toggle Forward state by sending REQUEST_UPDATE (draft-16 §9.11).
+    ///
+    /// Waits for the publisher's REQUEST_OK or returns the error from
+    /// REQUEST_ERROR.
+    pub async fn set_forward(&mut self, forward: bool) -> Result<(), ServeError> {
+        self.session
+            .send_request_update_for_publish(self.request_id, forward)
+            .await
+    }
+
+    pub fn namespace(&self) -> &TrackNamespace {
+        &self.namespace
+    }
+
+    pub fn name(&self) -> &TrackName {
+        &self.name
+    }
+
+    pub fn track_alias(&self) -> u64 {
+        self.track_alias
+    }
+
+    pub fn initial_forward(&self) -> bool {
+        self.initial_forward
+    }
+
+    pub fn largest_location(&self) -> Option<Location> {
+        self.largest_location
+    }
+}
+
+impl Drop for PublishedTrack {
+    fn drop(&mut self) {
+        if self.ok {
+            // Already accepted; nothing to send — PUBLISH_DONE arrives from the
+            // publisher to terminate.
+            return;
+        }
+
+        // Never accepted: send REQUEST_ERROR to reject the subscription (§9.8).
+        let err = self.error.clone().unwrap_or(ServeError::Cancel);
+
+        let error_code = match &err {
+            ServeError::Cancel | ServeError::Done => RequestErrorCode::Uninterested as u64,
+            ServeError::Duplicate => RequestErrorCode::DuplicateSubscription as u64,
+            ServeError::NotFound | ServeError::NotFoundWithId(_, _) => {
+                RequestErrorCode::DoesNotExist as u64
+            }
+            ServeError::NotImplemented(_) | ServeError::NotImplementedWithId(_, _) => {
+                RequestErrorCode::NotSupported as u64
+            }
+            ServeError::Internal(_) | ServeError::InternalWithId(_, _) => {
+                RequestErrorCode::InternalError as u64
+            }
+            ServeError::Closed(code) => *code,
+            _ => RequestErrorCode::InternalError as u64,
+        };
+
+        self.session.send_request_error(
+            "publish",
+            message::RequestError {
+                id: self.request_id,
+                error_code,
+                retry_interval: 0,
+                reason: ReasonPhrase("uninterested".to_string()),
+            },
+        );
+
+        // Clean up subscriber-side state for this PUBLISH.
+        self.session.remove_published_track(self.request_id);
+    }
+}
+
+// ── Transport-facing recv handle ──────────────────────────────────────────────
+
+/// Transport-side bookkeeping for a single inbound PUBLISH.
+///
+/// Stored in `Subscriber::published_tracks`.  Stream and datagram receive
+/// paths write Objects directly into the `TrackWriterMode` here.
+pub(crate) struct PublishedTrackRecv {
+    /// Shared state so both the transport and app can observe PUBLISH_DONE.
+    state: State<PublishedTrackState>,
+
+    /// Write half for inbound Objects.  The transport owns this so it can push
+    /// Objects without going through the application.
+    writer: Option<TrackWriterMode>,
+
+    /// Read half returned to the application on `PublishedTrack::ok`.
+    /// Wrapped in `Option` so it can be taken exactly once.
+    reader: Option<TrackReader>,
+}
+
+impl PublishedTrackRecv {
+    /// Create a `PublishedTrack` / `PublishedTrackRecv` pair from a PUBLISH message.
+    ///
+    /// Returns both the application-facing handle and the transport-facing recv,
+    /// pre-wired to the same shared state.
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn produce(
+        session: Subscriber,
+        request_id: u64,
+        track_alias: u64,
+        namespace: TrackNamespace,
+        name: TrackName,
+        initial_forward: bool,
+        largest_location: Option<Location>,
+        writer: serve::TrackWriter,
+        reader: TrackReader,
+    ) -> (PublishedTrack, PublishedTrackRecv) {
+        let (app_state, transport_state) = State::<PublishedTrackState>::default().split();
+
+        let app = PublishedTrack::new(
+            session,
+            request_id,
+            track_alias,
+            namespace,
+            name,
+            initial_forward,
+            largest_location,
+            app_state,
+        );
+        let recv = Self {
+            state: transport_state,
+            writer: Some(writer.into()),
+            reader: Some(reader),
+        };
+
+        (app, recv)
+    }
+
+    /// Take the `TrackReader` out exactly once (for `PublishedTrack::ok`).
+    pub fn take_reader(&mut self) -> Option<TrackReader> {
+        self.reader.take()
+    }
+
+    /// Open a subgroup writer for the given subgroup header.
+    ///
+    /// Mirrors `SubscribeRecv::subgroup` so the same `recv_subgroup` code path
+    /// can serve both SUBSCRIBE-initiated and PUBLISH-initiated subscriptions.
+    pub fn subgroup(
+        &mut self,
+        header: data::SubgroupHeader,
+    ) -> Result<serve::SubgroupWriter, ServeError> {
+        let writer = self.writer.take().ok_or(ServeError::Done)?;
+
+        let mut subgroups = match writer {
+            TrackWriterMode::Track(track) => track.subgroups()?,
+            TrackWriterMode::Subgroups(subgroups) => subgroups,
+            _ => return Err(ServeError::Mode),
+        };
+
+        let subgroup_writer = subgroups.create(serve::Subgroup {
+            group_id: header.group_id,
+            subgroup_id: header.subgroup_id.unwrap_or(0),
+            priority: header.publisher_priority,
+        })?;
+
+        self.writer = Some(subgroups.into());
+        Ok(subgroup_writer)
+    }
+
+    /// Write a datagram Object into the track.
+    ///
+    /// Mirrors `SubscribeRecv::datagram`.
+    pub fn datagram(&mut self, datagram: data::Datagram) -> Result<(), ServeError> {
+        let writer = self.writer.take().ok_or(ServeError::Done)?;
+
+        match writer {
+            TrackWriterMode::Track(track) => {
+                let mut datagrams = track.datagrams()?;
+                datagrams.write(serve::Datagram {
+                    group_id: datagram.group_id,
+                    object_id: datagram.object_id.unwrap_or(0),
+                    priority: datagram.publisher_priority,
+                    payload: datagram.payload.unwrap_or_default(),
+                    extension_headers: datagram.extension_headers.unwrap_or_default(),
+                })?;
+                self.writer = Some(TrackWriterMode::Datagrams(datagrams));
+                Ok(())
+            }
+            TrackWriterMode::Datagrams(mut datagrams) => {
+                datagrams.write(serve::Datagram {
+                    group_id: datagram.group_id,
+                    object_id: datagram.object_id.unwrap_or(0),
+                    priority: datagram.publisher_priority,
+                    payload: datagram.payload.unwrap_or_default(),
+                    extension_headers: datagram.extension_headers.unwrap_or_default(),
+                })?;
+                self.writer = Some(TrackWriterMode::Datagrams(datagrams));
+                Ok(())
+            }
+            other => {
+                self.writer = Some(other);
+                Err(ServeError::Mode)
+            }
+        }
+    }
+
+    /// Called when PUBLISH_DONE arrives (§9.15).
+    ///
+    /// Closes the writer so the `TrackReader` sees end-of-track.
+    pub fn recv_done(&mut self, status_code: u64) {
+        if let Some(mut state) = self.state.lock_mut() {
+            state.done = true;
+            state.closed = if status_code == message::PublishDoneCode::TrackEnded as u64 {
+                Err(ServeError::Done)
+            } else {
+                Err(ServeError::Closed(status_code))
+            };
+        }
+        // Drop the writer to signal end-of-track to any downstream readers.
+        self.writer = None;
+    }
+}
+
+// ── Pending REQUEST_UPDATE for set_forward ────────────────────────────────────
+
+/// Bookkeeping for a pending REQUEST_UPDATE sent by `PublishedTrack::set_forward`.
+///
+/// Stored in `Subscriber::pending_publish_updates` keyed by the REQUEST_UPDATE
+/// request id.  When REQUEST_OK or REQUEST_ERROR arrives it is removed and the
+/// sender is notified.
+pub(crate) struct PendingPublishUpdate {
+    /// One-shot channel to wake the `set_forward` caller.
+    pub result_tx: tokio::sync::oneshot::Sender<Result<(), ServeError>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        coding::TrackNamespace,
+        serve::Track,
+        session::{Queue, RequestId},
+    };
+
+    fn make_pair(
+        request_id: u64,
+    ) -> (
+        PublishedTrack,
+        PublishedTrackRecv,
+        crate::session::Subscriber,
+    ) {
+        let rid = RequestId::new(0, 100, 100, 0);
+        let subscriber = crate::session::Subscriber::new(Queue::default(), None, rid);
+        let (writer, reader) =
+            Track::new(TrackNamespace::from_utf8_path("test"), "0.mp4").produce();
+        let (pt, recv) = PublishedTrackRecv::produce(
+            subscriber.clone(),
+            request_id,
+            42,
+            TrackNamespace::from_utf8_path("test"),
+            "0.mp4".into(),
+            true,
+            None,
+            writer,
+            reader,
+        );
+        (pt, recv, subscriber)
+    }
+
+    #[test]
+    fn take_reader_returns_once() {
+        let (_pt, mut recv, _sub) = make_pair(0);
+        assert!(recv.take_reader().is_some());
+        assert!(
+            recv.take_reader().is_none(),
+            "reader must only be given out once"
+        );
+    }
+
+    #[test]
+    fn recv_done_closes_writer_and_sets_state() {
+        let (_pt, mut recv, _sub) = make_pair(1);
+        assert!(recv.writer.is_some());
+
+        recv.recv_done(message::PublishDoneCode::TrackEnded as u64);
+
+        assert!(
+            recv.writer.is_none(),
+            "writer must be dropped after PUBLISH_DONE"
+        );
+    }
+
+    #[test]
+    fn recv_done_non_track_ended_stores_code() {
+        let (_pt, mut recv, _sub) = make_pair(2);
+        recv.recv_done(message::PublishDoneCode::Expired as u64);
+        // No panic and writer is gone.
+        assert!(recv.writer.is_none());
+    }
+
+    #[test]
+    fn published_track_drop_without_ok_does_not_panic() {
+        let (pt, _recv, _sub) = make_pair(3);
+        // Drop without calling ok() — should send REQUEST_ERROR, not panic.
+        drop(pt);
+    }
+}

--- a/moq-transport/src/session/publisher.rs
+++ b/moq-transport/src/session/publisher.rs
@@ -19,11 +19,60 @@ use crate::{
 use crate::watch::Queue;
 
 use super::{
-    split_published_state, PublishNamespace, PublishNamespaceRecv, Published, PublishedInfo,
-    PublishedRecv, RequestId, RequestIdAllocation, Session, SessionConfig, SessionError,
-    Subscribed, SubscribedRecv, TrackStatusRequested,
+    split_published_state, ObjectForwarderRecv, PendingRequest, PendingRequests, PublishNamespace,
+    PublishNamespaceRecv, Published, PublishedInfo, PublishedRecv, RequestId, RequestIdAllocation,
+    Session, SessionConfig, SessionError, Subscribed, TrackStatusRequested,
 };
 use crate::message::RequestErrorCode;
+
+#[derive(Default)]
+struct NameRegistry {
+    by_name: HashMap<FullTrackName, u64>,
+    by_id: HashMap<u64, FullTrackName>,
+}
+
+impl NameRegistry {
+    fn contains_name(&self, name: &FullTrackName) -> bool {
+        self.by_name.contains_key(name)
+    }
+
+    fn insert(&mut self, name: FullTrackName, id: u64) {
+        if let Some(old_name) = self.by_id.insert(id, name.clone()) {
+            self.by_name.remove(&old_name);
+        }
+        if let Some(old_id) = self.by_name.insert(name, id) {
+            self.by_id.remove(&old_id);
+        }
+    }
+
+    fn remove_id(&mut self, id: u64) -> Option<FullTrackName> {
+        let name = self.by_id.remove(&id)?;
+        self.by_name.remove(&name);
+        Some(name)
+    }
+}
+
+struct PublishedEntry {
+    recv: PublishedRecv,
+    forwarder: Option<ObjectForwarderRecv>,
+}
+
+impl PublishedEntry {
+    fn new(recv: PublishedRecv) -> Self {
+        Self {
+            recv,
+            forwarder: None,
+        }
+    }
+
+    fn recv_unsubscribe(&mut self) -> Result<(), ServeError> {
+        self.recv.recv_unsubscribe()?;
+        if let Some(forwarder) = &mut self.forwarder {
+            forwarder.recv_unsubscribe()?;
+        }
+        Ok(())
+    }
+}
 
 // TODO remove Clone.
 #[derive(Clone)]
@@ -34,18 +83,17 @@ pub struct Publisher {
     publish_namespaces: Arc<Mutex<HashMap<TrackNamespace, PublishNamespaceRecv>>>,
 
     /// Active outbound PUBLISH requests, keyed by request id.
-    publisheds: Arc<Mutex<HashMap<u64, PublishedRecv>>>,
+    publisheds: Arc<Mutex<HashMap<u64, PublishedEntry>>>,
 
     /// Active outbound PUBLISHes keyed by Full Track Name for §5.1 same-role
     /// duplicate-subscription checks.
-    published_names: Arc<Mutex<HashMap<FullTrackName, u64>>>,
+    published_names: Arc<Mutex<NameRegistry>>,
 
-    /// When a Subscribe is received and we have a matching publish_namespace entry, the
-    /// subscription is routed to that PublishNamespaceRecv.  Otherwise it goes here.
-    subscribeds: Arc<Mutex<HashMap<u64, SubscribedRecv>>>,
+    /// Active inbound SUBSCRIBE requests, keyed by request id.
+    subscribeds: Arc<Mutex<HashMap<u64, ObjectForwarderRecv>>>,
 
     /// Active inbound SUBSCRIBEs keyed by Full Track Name.
-    subscribed_names: Arc<Mutex<HashMap<FullTrackName, u64>>>,
+    subscribed_names: Arc<Mutex<NameRegistry>>,
 
     /// Subscriptions for namespaces that have no matching PUBLISH_NAMESPACE.
     unknown_subscribed: Queue<Subscribed>,
@@ -64,6 +112,9 @@ pub struct Publisher {
     /// QUIC connection then request IDs start at 1 and increment by 2 (odd numbers).
     request_id: RequestId,
 
+    /// Tracks outbound publisher-role requests waiting for OK/error responses.
+    pending_requests: PendingRequests,
+
     /// Optional mlog writer for logging transport events
     mlog: Option<Arc<Mutex<mlog::MlogWriter>>>,
 }
@@ -74,6 +125,7 @@ impl Publisher {
         webtransport: web_transport::Session,
         mlog: Option<Arc<Mutex<mlog::MlogWriter>>>,
         request_id: RequestId,
+        pending_requests: PendingRequests,
     ) -> Self {
         Self {
             webtransport,
@@ -86,6 +138,7 @@ impl Publisher {
             unknown_track_status_requested: Default::default(),
             outgoing,
             request_id,
+            pending_requests,
             mlog,
         }
     }
@@ -148,9 +201,12 @@ impl Publisher {
                         return Err(SessionError::TooManyRequests);
                     }
                 };
-                let (send, recv) =
+                self.pending_requests
+                    .insert(request_id, PendingRequest::PublishNamespace)?;
+                let (mut send, recv) =
                     PublishNamespace::new(self.clone(), request_id, tracks.namespace.clone());
                 entry.insert(recv);
+                send.send_request();
                 send
             }
         };
@@ -233,7 +289,8 @@ impl Publisher {
                 .published_names
                 .lock()
                 .map_err(|_| SessionError::Internal)?;
-            if subscribed_names.contains_key(&full_name) || published_names.contains_key(&full_name)
+            if subscribed_names.contains_name(&full_name)
+                || published_names.contains_name(&full_name)
             {
                 return Err(SessionError::Serve(ServeError::Duplicate));
             }
@@ -277,14 +334,25 @@ impl Publisher {
 
         // Register state before queuing PUBLISH so fast PUBLISH_OK / REQUEST_ERROR
         // can be routed.
-        self.published_names
-            .lock()
-            .map_err(|_| SessionError::Internal)?
-            .insert(full_name, request_id);
-        self.publisheds
-            .lock()
-            .map_err(|_| SessionError::Internal)?
-            .insert(request_id, PublishedRecv::new(recv_state));
+        {
+            let mut published_names = self
+                .published_names
+                .lock()
+                .map_err(|_| SessionError::Internal)?;
+            let mut publisheds = self.publisheds.lock().map_err(|_| SessionError::Internal)?;
+            published_names.insert(full_name, request_id);
+            publisheds.insert(
+                request_id,
+                PublishedEntry::new(PublishedRecv::new(recv_state)),
+            );
+        }
+        if let Err(err) = self
+            .pending_requests
+            .insert(request_id, PendingRequest::Publish)
+        {
+            let _ = self.remove_published(request_id)?;
+            return Err(err);
+        }
 
         self.send_message(message::Publish {
             id: request_id,
@@ -446,7 +514,7 @@ impl Publisher {
     }
 
     /// Handle REQUEST_OK from subscriber (draft-16 §9.7).
-    fn recv_request_ok(&mut self, msg: message::RequestOk) -> Result<(), SessionError> {
+    pub(super) fn recv_request_ok(&mut self, msg: message::RequestOk) -> Result<(), SessionError> {
         self.log_request_ok_parsed("request_ok", &msg);
         // The publish_namespaces map is keyed by namespace; we must search by request_id.
         // TODO(itzmanish): maintain a second index keyed by request_id to make this O(1).
@@ -462,14 +530,14 @@ impl Publisher {
     }
 
     /// Handle PUBLISH_OK from subscriber — acceptance of our PUBLISH (draft-16 §9.14).
-    fn recv_publish_ok(&mut self, msg: message::PublishOk) -> Result<(), SessionError> {
+    pub(super) fn recv_publish_ok(&mut self, msg: message::PublishOk) -> Result<(), SessionError> {
         if let Some(published) = self
             .publisheds
             .lock()
             .map_err(|_| SessionError::Internal)?
             .get_mut(&msg.id)
         {
-            published.recv_ok(&msg)?;
+            published.recv.recv_ok(&msg)?;
         } else {
             tracing::debug!(
                 target: "moq_transport::control",
@@ -482,23 +550,44 @@ impl Publisher {
     }
 
     /// Handle REQUEST_ERROR from subscriber (draft-16 §9.8).
-    fn recv_request_error(&mut self, msg: message::RequestError) -> Result<(), SessionError> {
+    pub(super) fn recv_request_error(
+        &mut self,
+        msg: message::RequestError,
+    ) -> Result<(), SessionError> {
         self.log_request_error_parsed("request_error", &msg);
         if let Some(recv) = self.drop_publish_namespace(msg.id) {
             recv.recv_error(ServeError::Closed(msg.error_code))?;
             return Ok(());
         }
 
-        let published = self
-            .publisheds
-            .lock()
-            .map_err(|_| SessionError::Internal)?
-            .remove(&msg.id);
+        let published = self.remove_published(msg.id)?;
         if let Some(mut published) = published {
-            published.recv_error(ServeError::Closed(msg.error_code))?;
-            if let Ok(mut names) = self.published_names.lock() {
-                names.retain(|_, id| *id != msg.id);
+            published
+                .recv
+                .recv_error(ServeError::Closed(msg.error_code))?;
+        }
+
+        Ok(())
+    }
+
+    pub(super) fn recv_request_timeout(
+        &mut self,
+        id: u64,
+        request: PendingRequest,
+    ) -> Result<(), SessionError> {
+        let err = ServeError::internal_ctx(format!("{:?} response timed out", request));
+        match request {
+            PendingRequest::PublishNamespace => {
+                if let Some(recv) = self.drop_publish_namespace(id) {
+                    recv.recv_error(err)?;
+                }
             }
+            PendingRequest::Publish => {
+                if let Some(mut published) = self.remove_published(id)? {
+                    published.recv.recv_error(err)?;
+                }
+            }
+            PendingRequest::Subscribe => return Err(SessionError::Internal),
         }
 
         Ok(())
@@ -571,9 +660,9 @@ impl Publisher {
                 .published_names
                 .lock()
                 .map_err(|_| SessionError::Internal)?
-                .contains_key(&full_name);
+                .contains_name(&full_name);
 
-            if subscribed_names.contains_key(&full_name) || already_published {
+            if subscribed_names.contains_name(&full_name) || already_published {
                 let id = msg.id;
                 drop(subscribed_names);
                 drop(subscribeds);
@@ -644,19 +733,16 @@ impl Publisher {
     }
 
     fn recv_unsubscribe(&mut self, msg: message::Unsubscribe) -> Result<(), SessionError> {
-        {
-            let mut subscribeds = self
-                .subscribeds
-                .lock()
-                .map_err(|_| SessionError::Internal)?;
-            if let Some(subscribed) = subscribeds.get_mut(&msg.id) {
-                subscribed.recv_unsubscribe()?;
-            } else {
-                return Ok(());
-            }
+        if let Some(mut subscribed) = self.remove_subscribe(msg.id)? {
+            subscribed.recv_unsubscribe()?;
+            return Ok(());
         }
 
-        self.remove_subscribe(msg.id)
+        if let Some(mut published) = self.remove_published(msg.id)? {
+            published.recv_unsubscribe()?;
+        }
+
+        Ok(())
     }
 
     /// Pre-send hook: clean up internal state when terminal publisher messages are enqueued.
@@ -689,6 +775,15 @@ impl Publisher {
         self.outgoing.push(msg.into()).ok();
     }
 
+    /// Enqueue a control message without panicking on poisoned queue state.
+    pub(super) fn try_send_message<T: Into<message::Publisher> + Into<Message>>(
+        &mut self,
+        msg: T,
+    ) -> Result<(), ()> {
+        let msg = self.act_on_message_to_send(msg);
+        self.outgoing.try_push(msg.into()).map_err(|_| ())
+    }
+
     /// Enqueue a control message and wait until it has been dequeued for sending.
     pub(super) async fn send_message_and_wait<T: Into<message::Publisher> + Into<Message>>(
         &mut self,
@@ -702,30 +797,56 @@ impl Publisher {
     }
 
     pub(super) fn drop_subscribe(&mut self, id: u64) {
-        let _ = self.remove_subscribe(id);
+        if let Err(err) = self.remove_subscribe(id) {
+            tracing::error!(request_id = id, error = %err, "failed to drop subscribe state");
+        }
     }
 
-    fn remove_subscribe(&mut self, id: u64) -> Result<(), SessionError> {
-        self.subscribeds
+    pub(super) fn register_published_subscription(
+        &mut self,
+        id: u64,
+        recv: ObjectForwarderRecv,
+    ) -> Result<(), SessionError> {
+        let mut publisheds = self.publisheds.lock().map_err(|_| SessionError::Internal)?;
+        let published = publisheds.get_mut(&id).ok_or(SessionError::Internal)?;
+        if published.forwarder.is_some() {
+            return Err(SessionError::Duplicate);
+        }
+        published.forwarder = Some(recv);
+        Ok(())
+    }
+
+    fn remove_subscribe(&mut self, id: u64) -> Result<Option<ObjectForwarderRecv>, SessionError> {
+        let mut subscribeds = self
+            .subscribeds
             .lock()
-            .map_err(|_| SessionError::Internal)?
-            .remove(&id);
-        Self::drop_subscribed_name(&self.subscribed_names, id)
+            .map_err(|_| SessionError::Internal)?;
+        let mut subscribed_names = self
+            .subscribed_names
+            .lock()
+            .map_err(|_| SessionError::Internal)?;
+
+        let subscribed = subscribeds.remove(&id);
+        subscribed_names.remove_id(id);
+
+        Ok(subscribed)
     }
 
+    #[cfg(test)]
     fn drop_subscribed_name(
-        subscribed_names: &Arc<Mutex<HashMap<FullTrackName, u64>>>,
+        subscribed_names: &Arc<Mutex<NameRegistry>>,
         id: u64,
     ) -> Result<(), SessionError> {
         subscribed_names
             .lock()
             .map_err(|_| SessionError::Internal)?
-            .retain(|_, request_id| *request_id != id);
+            .remove_id(id);
 
         Ok(())
     }
 
     fn drop_publish_namespace(&mut self, id: u64) -> Option<PublishNamespaceRecv> {
+        let _ = self.pending_requests.remove(id);
         if let Ok(mut ns) = self.publish_namespaces.lock() {
             let key = ns
                 .iter()
@@ -739,12 +860,25 @@ impl Publisher {
     }
 
     fn drop_published(&mut self, id: u64) {
-        if let Ok(mut publisheds) = self.publisheds.lock() {
-            publisheds.remove(&id);
+        if let Err(err) = self.remove_published(id) {
+            tracing::error!(request_id = id, error = %err, "failed to drop published state");
         }
-        if let Ok(mut names) = self.published_names.lock() {
-            names.retain(|_, request_id| *request_id != id);
+    }
+
+    fn remove_published(&mut self, id: u64) -> Result<Option<PublishedEntry>, SessionError> {
+        let _ = self.pending_requests.remove(id);
+        let mut published_names = self
+            .published_names
+            .lock()
+            .map_err(|_| SessionError::Internal)?;
+        let mut publisheds = self.publisheds.lock().map_err(|_| SessionError::Internal)?;
+
+        let published = publisheds.remove(&id);
+        if published.is_some() {
+            published_names.remove_id(id);
         }
+
+        Ok(published)
     }
 
     pub(super) async fn open_uni(&mut self) -> Result<web_transport::SendStream, SessionError> {
@@ -758,17 +892,14 @@ impl Publisher {
 
 #[cfg(test)]
 mod tests {
-    use std::{
-        collections::HashMap,
-        sync::{Arc, Mutex},
-    };
+    use std::sync::{Arc, Mutex};
 
     use crate::{
         coding::{TrackName, TrackNamespace},
         serve::FullTrackName,
     };
 
-    use super::Publisher;
+    use super::{NameRegistry, Publisher};
 
     fn full_track_name(namespace: &str, name: &str) -> FullTrackName {
         FullTrackName {
@@ -779,7 +910,7 @@ mod tests {
 
     #[test]
     fn drop_subscribed_name_removes_only_matching_request_id() {
-        let subscribed_names = Arc::new(Mutex::new(HashMap::new()));
+        let subscribed_names = Arc::new(Mutex::new(NameRegistry::default()));
         let unsubscribed_track = full_track_name("bb1", "video.m4s");
         let active_track = full_track_name("bb1", "audio.m4s");
 
@@ -792,7 +923,7 @@ mod tests {
         Publisher::drop_subscribed_name(&subscribed_names, 6).unwrap();
 
         let names = subscribed_names.lock().unwrap();
-        assert!(!names.contains_key(&unsubscribed_track));
-        assert_eq!(names.get(&active_track), Some(&8));
+        assert!(!names.contains_name(&unsubscribed_track));
+        assert_eq!(names.by_name.get(&active_track), Some(&8));
     }
 }

--- a/moq-transport/src/session/publisher.rs
+++ b/moq-transport/src/session/publisher.rs
@@ -36,6 +36,16 @@ impl NameRegistry {
         self.by_name.contains_key(name)
     }
 
+    fn reserve(&mut self, name: FullTrackName, id: u64) -> bool {
+        if self.by_name.contains_key(&name) || self.by_id.contains_key(&id) {
+            return false;
+        }
+
+        self.by_id.insert(id, name.clone());
+        self.by_name.insert(name, id);
+        true
+    }
+
     fn insert(&mut self, name: FullTrackName, id: u64) {
         if let Some(old_name) = self.by_id.insert(id, name.clone()) {
             self.by_name.remove(&old_name);
@@ -277,37 +287,6 @@ impl Publisher {
             name: track.name.clone(),
         };
 
-        // §5.1: this endpoint can have at most one publisher-role subscription
-        // for a track.  Inbound SUBSCRIBE and outbound PUBLISH are both
-        // publisher-role subscriptions from this endpoint's perspective.
-        {
-            let subscribed_names = self
-                .subscribed_names
-                .lock()
-                .map_err(|_| SessionError::Internal)?;
-            let published_names = self
-                .published_names
-                .lock()
-                .map_err(|_| SessionError::Internal)?;
-            if subscribed_names.contains_name(&full_name)
-                || published_names.contains_name(&full_name)
-            {
-                return Err(SessionError::Serve(ServeError::Duplicate));
-            }
-        }
-
-        let request_id = match self.request_id.allocate()? {
-            RequestIdAllocation::Allocated(id) => id,
-            blocked @ RequestIdAllocation::Blocked { .. } => {
-                if let Some(msg) = blocked.requests_blocked() {
-                    let _ = self.outgoing.push(msg.into());
-                }
-                return Err(SessionError::TooManyRequests);
-            }
-        };
-
-        let track_alias = request_id;
-
         if let Some(largest) = track.largest_location() {
             params
                 .set_largest_object(largest)
@@ -320,6 +299,43 @@ impl Publisher {
             .unwrap_or(true);
         let largest_location = params.largest_object().map_err(SessionError::Decode)?;
 
+        // §5.1: this endpoint can have at most one publisher-role subscription
+        // for a track. Inbound SUBSCRIBE and outbound PUBLISH are both
+        // publisher-role subscriptions from this endpoint's perspective. Keep
+        // the duplicate check and published-name reservation atomic.
+        let request_id = {
+            let subscribed_names = self
+                .subscribed_names
+                .lock()
+                .map_err(|_| SessionError::Internal)?;
+            let mut published_names = self
+                .published_names
+                .lock()
+                .map_err(|_| SessionError::Internal)?;
+            if subscribed_names.contains_name(&full_name)
+                || published_names.contains_name(&full_name)
+            {
+                return Err(SessionError::Serve(ServeError::Duplicate));
+            }
+
+            let request_id = match self.request_id.allocate()? {
+                RequestIdAllocation::Allocated(id) => id,
+                blocked @ RequestIdAllocation::Blocked { .. } => {
+                    if let Some(msg) = blocked.requests_blocked() {
+                        let _ = self.outgoing.push(msg.into());
+                    }
+                    return Err(SessionError::TooManyRequests);
+                }
+            };
+
+            if !published_names.reserve(full_name.clone(), request_id) {
+                return Err(SessionError::Duplicate);
+            }
+            request_id
+        };
+
+        let track_alias = request_id;
+
         let info = PublishedInfo {
             id: request_id,
             track_namespace: track.namespace.clone(),
@@ -330,21 +346,22 @@ impl Publisher {
         };
 
         let (published_state, recv_state) = split_published_state(forward);
-        let published = Published::new(self.clone(), info, published_state, track);
 
         // Register state before queuing PUBLISH so fast PUBLISH_OK / REQUEST_ERROR
         // can be routed.
-        {
-            let mut published_names = self
-                .published_names
-                .lock()
-                .map_err(|_| SessionError::Internal)?;
-            let mut publisheds = self.publisheds.lock().map_err(|_| SessionError::Internal)?;
-            published_names.insert(full_name, request_id);
-            publisheds.insert(
-                request_id,
-                PublishedEntry::new(PublishedRecv::new(recv_state)),
-            );
+        match self.publisheds.lock() {
+            Ok(mut publisheds) => {
+                publisheds.insert(
+                    request_id,
+                    PublishedEntry::new(PublishedRecv::new(recv_state)),
+                );
+            }
+            Err(_) => {
+                if let Ok(mut published_names) = self.published_names.lock() {
+                    published_names.remove_id(request_id);
+                }
+                return Err(SessionError::Internal);
+            }
         }
         if let Err(err) = self
             .pending_requests
@@ -354,14 +371,16 @@ impl Publisher {
             return Err(err);
         }
 
-        self.send_message(message::Publish {
+        let msg = message::Publish {
             id: request_id,
-            track_namespace: published.info.track_namespace.clone(),
-            track_name: published.info.track_name.clone(),
+            track_namespace: info.track_namespace.clone(),
+            track_name: info.track_name.clone(),
             track_alias,
             params,
             track_extensions: Default::default(),
-        });
+        };
+        let published = Published::new(self.clone(), info, published_state, track);
+        self.send_message(msg);
 
         Ok(published)
     }
@@ -925,5 +944,18 @@ mod tests {
         let names = subscribed_names.lock().unwrap();
         assert!(!names.contains_name(&unsubscribed_track));
         assert_eq!(names.by_name.get(&active_track), Some(&8));
+    }
+
+    #[test]
+    fn name_registry_reserve_rejects_duplicate_without_overwrite() {
+        let mut names = NameRegistry::default();
+        let track = full_track_name("bb1", "video.m4s");
+
+        assert!(names.reserve(track.clone(), 6));
+        assert!(!names.reserve(track.clone(), 8));
+
+        assert_eq!(names.by_name.get(&track), Some(&6));
+        assert_eq!(names.by_id.get(&6), Some(&track));
+        assert!(!names.by_id.contains_key(&8));
     }
 }

--- a/moq-transport/src/session/publisher.rs
+++ b/moq-transport/src/session/publisher.rs
@@ -10,17 +10,18 @@ use std::{
 use futures::{stream::FuturesUnordered, StreamExt};
 
 use crate::{
-    coding::TrackNamespace,
+    coding::{KeyValuePairs, TrackNamespace},
     message::{self, Message},
     mlog,
-    serve::{FullTrackName, ServeError, TracksReader},
+    serve::{FullTrackName, ServeError, TrackReader, TracksReader},
 };
 
 use crate::watch::Queue;
 
 use super::{
-    PublishNamespace, PublishNamespaceRecv, RequestId, RequestIdAllocation, Session, SessionConfig,
-    SessionError, Subscribed, SubscribedRecv, TrackStatusRequested,
+    split_published_state, PublishNamespace, PublishNamespaceRecv, Published, PublishedInfo,
+    PublishedRecv, RequestId, RequestIdAllocation, Session, SessionConfig, SessionError,
+    Subscribed, SubscribedRecv, TrackStatusRequested,
 };
 use crate::message::RequestErrorCode;
 
@@ -31,6 +32,13 @@ pub struct Publisher {
 
     /// Active outbound PUBLISH_NAMESPACE requests, keyed by namespace.
     publish_namespaces: Arc<Mutex<HashMap<TrackNamespace, PublishNamespaceRecv>>>,
+
+    /// Active outbound PUBLISH requests, keyed by request id.
+    publisheds: Arc<Mutex<HashMap<u64, PublishedRecv>>>,
+
+    /// Active outbound PUBLISHes keyed by Full Track Name for §5.1 same-role
+    /// duplicate-subscription checks.
+    published_names: Arc<Mutex<HashMap<FullTrackName, u64>>>,
 
     /// When a Subscribe is received and we have a matching publish_namespace entry, the
     /// subscription is routed to that PublishNamespaceRecv.  Otherwise it goes here.
@@ -70,6 +78,8 @@ impl Publisher {
         Self {
             webtransport,
             publish_namespaces: Default::default(),
+            publisheds: Default::default(),
+            published_names: Default::default(),
             subscribeds: Default::default(),
             subscribed_names: Default::default(),
             unknown_subscribed: Default::default(),
@@ -195,6 +205,99 @@ impl Publisher {
         }
     }
 
+    /// Send PUBLISH for a specific track and return a handle that can serve it.
+    ///
+    /// The publisher chooses the Track Alias.  For the first cut, we use
+    /// `track_alias = request_id` because request ids are already unique in the
+    /// session and draft-16 §10.1 only requires uniqueness, not a separate
+    /// allocator.
+    pub async fn publish(
+        &mut self,
+        track: TrackReader,
+        mut params: KeyValuePairs,
+    ) -> Result<Published, SessionError> {
+        let full_name = FullTrackName {
+            namespace: track.namespace.clone(),
+            name: track.name.clone(),
+        };
+
+        // §5.1: this endpoint can have at most one publisher-role subscription
+        // for a track.  Inbound SUBSCRIBE and outbound PUBLISH are both
+        // publisher-role subscriptions from this endpoint's perspective.
+        {
+            let subscribed_names = self
+                .subscribed_names
+                .lock()
+                .map_err(|_| SessionError::Internal)?;
+            let published_names = self
+                .published_names
+                .lock()
+                .map_err(|_| SessionError::Internal)?;
+            if subscribed_names.contains_key(&full_name) || published_names.contains_key(&full_name)
+            {
+                return Err(SessionError::Serve(ServeError::Duplicate));
+            }
+        }
+
+        let request_id = match self.request_id.allocate()? {
+            RequestIdAllocation::Allocated(id) => id,
+            blocked @ RequestIdAllocation::Blocked { .. } => {
+                if let Some(msg) = blocked.requests_blocked() {
+                    let _ = self.outgoing.push(msg.into());
+                }
+                return Err(SessionError::TooManyRequests);
+            }
+        };
+
+        let track_alias = request_id;
+
+        if let Some(largest) = track.largest_location() {
+            params
+                .set_largest_object(largest)
+                .map_err(|_| SessionError::Internal)?;
+        }
+
+        let forward = params
+            .forward()
+            .map_err(SessionError::Decode)?
+            .unwrap_or(true);
+        let largest_location = params.largest_object().map_err(SessionError::Decode)?;
+
+        let info = PublishedInfo {
+            id: request_id,
+            track_namespace: track.namespace.clone(),
+            track_name: track.name.clone(),
+            track_alias,
+            forward,
+            largest_location,
+        };
+
+        let (published_state, recv_state) = split_published_state(forward);
+        let published = Published::new(self.clone(), info, published_state, track);
+
+        // Register state before queuing PUBLISH so fast PUBLISH_OK / REQUEST_ERROR
+        // can be routed.
+        self.published_names
+            .lock()
+            .map_err(|_| SessionError::Internal)?
+            .insert(full_name, request_id);
+        self.publisheds
+            .lock()
+            .map_err(|_| SessionError::Internal)?
+            .insert(request_id, PublishedRecv::new(recv_state));
+
+        self.send_message(message::Publish {
+            id: request_id,
+            track_namespace: published.info.track_namespace.clone(),
+            track_name: published.info.track_name.clone(),
+            track_alias,
+            params,
+            track_extensions: Default::default(),
+        });
+
+        Ok(published)
+    }
+
     pub async fn serve_subscribe(
         subscribed: Subscribed,
         mut tracks: TracksReader,
@@ -285,14 +388,15 @@ impl Publisher {
     pub(crate) fn recv_message(&mut self, msg: message::Subscriber) -> Result<(), SessionError> {
         match msg {
             message::Subscriber::Subscribe(msg) => self.recv_subscribe(msg)?,
-            // REQUEST_UPDATE: not yet implemented — send REQUEST_ERROR NOT_SUPPORTED (§4).
-            message::Subscriber::RequestUpdate(msg) => {
-                self.send_not_supported(msg.id, "request_update");
-            }
-            // Draft-16: REQUEST_OK from subscriber is acceptance of PUBLISH_NAMESPACE.
-            message::Subscriber::RequestOk(msg) => self.recv_publish_namespace_ok(msg)?,
-            // Draft-16: REQUEST_ERROR from subscriber is rejection of PUBLISH_NAMESPACE.
-            message::Subscriber::RequestError(msg) => self.recv_publish_namespace_error(msg)?,
+            // REQUEST_UPDATE is intentionally rejected for now. Dynamic Forward
+            // updates require making the data-plane delivery filter mutable;
+            // until then this is explicit and simple.
+            message::Subscriber::RequestUpdate(msg) => self.recv_request_update(msg)?,
+            // Draft-16: REQUEST_OK is used for PUBLISH_NAMESPACE acceptance and
+            // REQUEST_UPDATE responses. PUBLISH acceptance uses PUBLISH_OK.
+            message::Subscriber::RequestOk(msg) => self.recv_request_ok(msg)?,
+            // Draft-16: REQUEST_ERROR rejects PUBLISH_NAMESPACE or PUBLISH.
+            message::Subscriber::RequestError(msg) => self.recv_request_error(msg)?,
             message::Subscriber::Unsubscribe(msg) => self.recv_unsubscribe(msg)?,
             // FETCH not yet implemented — send REQUEST_ERROR NOT_SUPPORTED (§4).
             message::Subscriber::Fetch(msg) => {
@@ -314,15 +418,7 @@ impl Publisher {
             message::Subscriber::PublishNamespaceCancel(msg) => {
                 self.recv_publish_namespace_cancel(msg)?;
             }
-            // PUBLISH_OK is for publisher-initiated subscriptions, which are not
-            // yet implemented — log and ignore.
-            message::Subscriber::PublishOk(msg) => {
-                tracing::debug!(
-                    target: "moq_transport::control",
-                    request_id = msg.id,
-                    "received PUBLISH_OK for unsupported PUBLISH — ignoring"
-                );
-            }
+            message::Subscriber::PublishOk(msg) => self.recv_publish_ok(msg)?,
         }
 
         Ok(())
@@ -349,9 +445,9 @@ impl Publisher {
         );
     }
 
-    /// Handle REQUEST_OK from subscriber — acceptance of our PUBLISH_NAMESPACE (draft-16 §9.7).
-    fn recv_publish_namespace_ok(&mut self, msg: message::RequestOk) -> Result<(), SessionError> {
-        self.log_request_ok_parsed("publish_namespace", &msg);
+    /// Handle REQUEST_OK from subscriber (draft-16 §9.7).
+    fn recv_request_ok(&mut self, msg: message::RequestOk) -> Result<(), SessionError> {
+        self.log_request_ok_parsed("request_ok", &msg);
         // The publish_namespaces map is keyed by namespace; we must search by request_id.
         // TODO(itzmanish): maintain a second index keyed by request_id to make this O(1).
         let mut namespaces = self
@@ -365,15 +461,64 @@ impl Publisher {
         Ok(())
     }
 
-    /// Handle REQUEST_ERROR from subscriber — rejection of our PUBLISH_NAMESPACE (draft-16 §9.8).
-    fn recv_publish_namespace_error(
-        &mut self,
-        msg: message::RequestError,
-    ) -> Result<(), SessionError> {
-        self.log_request_error_parsed("publish_namespace", &msg);
+    /// Handle PUBLISH_OK from subscriber — acceptance of our PUBLISH (draft-16 §9.14).
+    fn recv_publish_ok(&mut self, msg: message::PublishOk) -> Result<(), SessionError> {
+        if let Some(published) = self
+            .publisheds
+            .lock()
+            .map_err(|_| SessionError::Internal)?
+            .get_mut(&msg.id)
+        {
+            published.recv_ok(&msg)?;
+        } else {
+            tracing::debug!(
+                target: "moq_transport::control",
+                request_id = msg.id,
+                "received PUBLISH_OK for unknown PUBLISH — ignoring"
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Handle REQUEST_ERROR from subscriber (draft-16 §9.8).
+    fn recv_request_error(&mut self, msg: message::RequestError) -> Result<(), SessionError> {
+        self.log_request_error_parsed("request_error", &msg);
         if let Some(recv) = self.drop_publish_namespace(msg.id) {
             recv.recv_error(ServeError::Closed(msg.error_code))?;
+            return Ok(());
         }
+
+        let published = self
+            .publisheds
+            .lock()
+            .map_err(|_| SessionError::Internal)?
+            .remove(&msg.id);
+        if let Some(mut published) = published {
+            published.recv_error(ServeError::Closed(msg.error_code))?;
+            if let Ok(mut names) = self.published_names.lock() {
+                names.retain(|_, id| *id != msg.id);
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Handle REQUEST_UPDATE from subscriber (draft-16 §9.11).
+    ///
+    /// First-cut behavior: reject all updates with NOT_SUPPORTED. This avoids
+    /// pretending dynamic Forward updates are wired into the data-plane serve
+    /// loop.
+    fn recv_request_update(&mut self, msg: message::RequestUpdate) -> Result<(), SessionError> {
+        self.send_request_error(
+            "request_update",
+            message::RequestError {
+                id: msg.id,
+                error_code: RequestErrorCode::NotSupported as u64,
+                retry_interval: 0,
+                reason: crate::coding::ReasonPhrase("not supported".to_string()),
+            },
+        );
         Ok(())
     }
 
@@ -422,7 +567,13 @@ impl Publisher {
                 .subscribed_names
                 .lock()
                 .map_err(|_| SessionError::Internal)?;
-            if subscribed_names.contains_key(&full_name) {
+            let already_published = self
+                .published_names
+                .lock()
+                .map_err(|_| SessionError::Internal)?
+                .contains_key(&full_name);
+
+            if subscribed_names.contains_key(&full_name) || already_published {
                 let id = msg.id;
                 drop(subscribed_names);
                 drop(subscribeds);
@@ -515,7 +666,13 @@ impl Publisher {
     ) -> message::Publisher {
         let msg = msg.into();
         match &msg {
-            message::Publisher::PublishDone(m) => self.drop_subscribe(m.id),
+            message::Publisher::PublishDone(m) => {
+                // PUBLISH_DONE terminates either SUBSCRIBE-initiated serving or
+                // outbound PUBLISH serving. Clean up both maps; only one will
+                // contain the id.
+                self.drop_subscribe(m.id);
+                self.drop_published(m.id);
+            }
             // Draft-16: PUBLISH_NAMESPACE_DONE carries Request ID, not namespace.
             // Dropping the recv state signals that the namespace is done.
             message::Publisher::PublishNamespaceDone(m) => {
@@ -579,6 +736,15 @@ impl Publisher {
             }
         }
         None
+    }
+
+    fn drop_published(&mut self, id: u64) {
+        if let Ok(mut publisheds) = self.publisheds.lock() {
+            publisheds.remove(&id);
+        }
+        if let Ok(mut names) = self.published_names.lock() {
+            names.retain(|_, request_id| *request_id != id);
+        }
     }
 
     pub(super) async fn open_uni(&mut self) -> Result<web_transport::SendStream, SessionError> {

--- a/moq-transport/src/session/subscribe.rs
+++ b/moq-transport/src/session/subscribe.rs
@@ -175,7 +175,7 @@ pub struct Subscribe {
 
 impl Subscribe {
     pub(super) fn new(
-        mut subscriber: Subscriber,
+        subscriber: Subscriber,
         request_id: u64,
         track: TrackWriter,
     ) -> (Subscribe, SubscribeRecv) {
@@ -203,8 +203,6 @@ impl Subscribe {
             }
         });
 
-        subscriber.send_message(subscribe_message);
-
         let (send, recv) = State::default().split();
 
         let send = Subscribe {
@@ -219,6 +217,15 @@ impl Subscribe {
         };
 
         (send, recv)
+    }
+
+    pub(super) fn send_request(&mut self) {
+        self.subscriber.send_message(message::Subscribe {
+            id: self.info.id,
+            track_namespace: self.info.track_namespace.clone(),
+            track_name: self.info.track_name.clone(),
+            params: self.info.params.clone(),
+        });
     }
 
     pub async fn closed(&self) -> Result<(), ServeError> {
@@ -290,11 +297,6 @@ impl SubscribeRecv {
         }
 
         Ok(())
-    }
-
-    pub fn track_alias(&self) -> Option<u64> {
-        let state = self.state.lock();
-        state.track_alias
     }
 
     pub fn error(mut self, err: ServeError) -> Result<(), ServeError> {

--- a/moq-transport/src/session/subscribe.rs
+++ b/moq-transport/src/session/subscribe.rs
@@ -232,7 +232,11 @@ impl Subscribe {
         loop {
             {
                 let state = self.state.lock();
-                state.closed.clone()?;
+                match state.closed.clone() {
+                    Ok(()) => {}
+                    Err(ServeError::Done) => return Ok(()),
+                    Err(err) => return Err(err),
+                }
 
                 match state.modified() {
                     Some(notify) => notify,
@@ -442,5 +446,45 @@ mod tests {
 
         assert!(!filter.allows(0, 0));
         assert!(!filter.allows(100, 100));
+    }
+
+    #[tokio::test]
+    async fn closed_returns_ok_for_track_ended() {
+        let rid = crate::session::RequestId::new(0, 100, 100, 0);
+        let subscriber = crate::session::Subscriber::new(
+            crate::session::Queue::default(),
+            None,
+            rid,
+            crate::session::PendingRequests::default(),
+        );
+        let (writer, _reader) =
+            serve::Track::new(TrackNamespace::from_utf8_path("test"), "track").produce();
+        let (subscribe, recv) = Subscribe::new(subscriber, 1, writer);
+
+        recv.error(ServeError::Done).unwrap();
+
+        assert_eq!(subscribe.closed().await, Ok(()));
+    }
+
+    #[tokio::test]
+    async fn closed_returns_error_for_non_track_ended() {
+        let rid = crate::session::RequestId::new(0, 100, 100, 0);
+        let subscriber = crate::session::Subscriber::new(
+            crate::session::Queue::default(),
+            None,
+            rid,
+            crate::session::PendingRequests::default(),
+        );
+        let (writer, _reader) =
+            serve::Track::new(TrackNamespace::from_utf8_path("test"), "track").produce();
+        let (subscribe, recv) = Subscribe::new(subscriber, 1, writer);
+
+        recv.error(ServeError::Closed(message::PublishDoneCode::Expired as u64))
+            .unwrap();
+
+        assert!(matches!(
+            subscribe.closed().await,
+            Err(ServeError::Closed(code)) if code == message::PublishDoneCode::Expired as u64
+        ));
     }
 }

--- a/moq-transport/src/session/subscribed.rs
+++ b/moq-transport/src/session/subscribed.rs
@@ -20,7 +20,7 @@ use super::{DeliveryFilter, Publisher, SessionError, SubscribeInfo, Writer};
 // This file defines Publisher handling of inbound Subscriptions
 
 #[derive(Debug)]
-struct SubscribedState {
+struct ObjectForwarderState {
     largest_location: Option<Location>,
     stream_count: u64,
     /// Set to true when UNSUBSCRIBE is received.  When true, Drop skips sending
@@ -29,7 +29,7 @@ struct SubscribedState {
     closed: Result<(), ServeError>,
 }
 
-impl SubscribedState {
+impl ObjectForwarderState {
     fn record_stream_opened(&mut self) {
         self.stream_count = self.stream_count.saturating_add(1);
     }
@@ -46,7 +46,7 @@ impl SubscribedState {
     }
 }
 
-impl Default for SubscribedState {
+impl Default for ObjectForwarderState {
     fn default() -> Self {
         Self {
             largest_location: None,
@@ -58,35 +58,141 @@ impl Default for SubscribedState {
 }
 
 pub struct Subscribed {
-    /// The sessions Publisher manager, used to send control messages,
-    /// create new QUIC streams, and send datagrams
-    publisher: Publisher,
-
     /// The tracknamespace and trackname for the subscription.
     pub info: SubscribeInfo,
 
-    state: State<SubscribedState>,
+    forwarder: ObjectForwarder,
 
     /// Tracks if SubscribeOk has been sent yet or not. Used to send
     /// PUBLISH_DONE vs REQUEST_ERROR on drop.
     ok: bool,
+}
 
-    /// Whether `serve_inner` should send SUBSCRIBE_OK before sending data.
-    ///
-    /// True for SUBSCRIBE-initiated subscriptions. False for PUBLISH-initiated
-    /// subscriptions because the success response is PUBLISH_OK sent by the
-    /// subscriber, not SUBSCRIBE_OK from us.
-    send_subscribe_ok: bool,
-
-    /// Track Alias used in subgroup/datagram headers.
-    ///
-    /// For SUBSCRIBE-initiated subscriptions this equals `info.id`, preserving
-    /// existing behavior. For PUBLISH-initiated subscriptions this is the alias
-    /// sent in PUBLISH.
+pub(super) struct ObjectForwarder {
+    /// The sessions Publisher manager, used to create streams and datagrams.
+    publisher: Publisher,
+    state: State<ObjectForwarderState>,
     track_alias: u64,
-
-    /// Optional mlog writer for logging transport events
     mlog: Option<Arc<Mutex<mlog::MlogWriter>>>,
+}
+
+impl ObjectForwarder {
+    pub(super) fn new(
+        publisher: Publisher,
+        track_alias: u64,
+        mlog: Option<Arc<Mutex<mlog::MlogWriter>>>,
+    ) -> (Self, ObjectForwarderRecv) {
+        let (send, recv) = State::default().split();
+        let send = Self {
+            publisher,
+            state: send,
+            track_alias,
+            mlog,
+        };
+        let recv = ObjectForwarderRecv { state: recv };
+        (send, recv)
+    }
+
+    pub(super) fn set_largest_location(
+        &self,
+        largest_location: Option<Location>,
+    ) -> Result<(), ServeError> {
+        self.state
+            .lock_mut()
+            .ok_or(ServeError::Cancel)?
+            .largest_location = largest_location;
+        Ok(())
+    }
+
+    fn terminal_state(&self) -> (ServeError, u64, bool) {
+        let state = self.state.lock();
+        let err = state
+            .closed
+            .as_ref()
+            .err()
+            .cloned()
+            .unwrap_or(ServeError::Done);
+        (err, state.stream_count, state.unsubscribed)
+    }
+
+    fn close(&self, err: ServeError) -> Result<(), ServeError> {
+        let state = self.state.lock();
+        state.closed.clone()?;
+
+        let mut state = state.into_mut().ok_or(ServeError::Done)?;
+        state.closed = Err(err);
+
+        Ok(())
+    }
+
+    async fn closed(&self) -> Result<(), ServeError> {
+        loop {
+            {
+                let state = self.state.lock();
+                state.closed.clone()?;
+
+                match state.modified() {
+                    Some(notify) => notify,
+                    None => return Ok(()),
+                }
+            }
+            .await;
+        }
+    }
+
+    pub(super) async fn serve(
+        &mut self,
+        track: serve::TrackReader,
+        delivery_filter: DeliveryFilter,
+    ) -> Result<(), SessionError> {
+        match track.mode().await? {
+            TrackReaderMode::Stream(_stream) => panic!("deprecated"),
+            TrackReaderMode::Subgroups(subgroups) => {
+                self.serve_subgroups(subgroups, delivery_filter).await
+            }
+            TrackReaderMode::Datagrams(datagrams) => {
+                self.serve_datagrams(datagrams, delivery_filter).await
+            }
+        }
+    }
+}
+
+enum SubgroupOutput {
+    Stream(Writer),
+    #[cfg(test)]
+    Buffer(bytes::BytesMut),
+}
+
+impl SubgroupOutput {
+    async fn encode<T: Encode>(&mut self, msg: &T) -> Result<(), SessionError> {
+        match self {
+            Self::Stream(writer) => writer.encode(msg).await,
+            #[cfg(test)]
+            Self::Buffer(buffer) => {
+                msg.encode(buffer)?;
+                Ok(())
+            }
+        }
+    }
+
+    async fn write(&mut self, buf: &[u8]) -> Result<(), SessionError> {
+        match self {
+            Self::Stream(writer) => writer.write(buf).await,
+            #[cfg(test)]
+            Self::Buffer(buffer) => {
+                buffer.extend_from_slice(buf);
+                Ok(())
+            }
+        }
+    }
+
+    #[cfg(test)]
+    fn into_buffer(self) -> bytes::BytesMut {
+        match self {
+            Self::Buffer(buffer) => buffer,
+            Self::Stream(_) => unreachable!("test output should use a buffer"),
+        }
+    }
 }
 
 impl Subscribed {
@@ -94,66 +200,17 @@ impl Subscribed {
         publisher: Publisher,
         msg: message::Subscribe,
         mlog: Option<Arc<Mutex<mlog::MlogWriter>>>,
-    ) -> Result<(Self, SubscribedRecv), SessionError> {
-        let (send, recv) = State::default().split();
+    ) -> Result<(Self, ObjectForwarderRecv), SessionError> {
         let info = SubscribeInfo::new_from_subscribe(&msg)?;
         let track_alias = info.id;
+        let (forwarder, recv) = ObjectForwarder::new(publisher, track_alias, mlog);
         let send = Self {
-            publisher,
-            state: send,
             info,
+            forwarder,
             ok: false,
-            send_subscribe_ok: true,
-            track_alias,
-            mlog,
         };
-
-        // Prevents updates after being closed
-        let recv = SubscribedRecv { state: recv };
 
         Ok((send, recv))
-    }
-
-    /// Create a publisher-side subscription for a PUBLISH-initiated track.
-    ///
-    /// This reuses the same serve loop as inbound SUBSCRIBE. The only protocol
-    /// differences are that the Track Alias is chosen by the publisher and the
-    /// subscription is already considered accepted for purposes of sending
-    /// PUBLISH_DONE on Drop.
-    pub(super) fn new_for_publish(
-        publisher: Publisher,
-        request_id: u64,
-        track_alias: u64,
-        namespace: crate::coding::TrackNamespace,
-        name: crate::coding::TrackName,
-        forward: bool,
-        mlog: Option<Arc<Mutex<mlog::MlogWriter>>>,
-    ) -> (Self, SubscribedRecv) {
-        let (send, recv) = State::default().split();
-        let info = SubscribeInfo {
-            id: request_id,
-            track_namespace: namespace,
-            track_name: name,
-            subscriber_priority: 128,
-            group_order: crate::message::GroupOrder::Publisher,
-            forward,
-            filter_type: crate::message::FilterType::AbsoluteStart,
-            start_location: None,
-            end_group_id: None,
-            filter: None,
-            params: Default::default(),
-            track_status: false,
-        };
-        let send = Self {
-            publisher,
-            state: send,
-            info,
-            ok: true,
-            send_subscribe_ok: false,
-            track_alias,
-            mlog,
-        };
-        (send, SubscribedRecv { state: recv })
     }
 
     pub async fn serve(mut self, track: serve::TrackReader) -> Result<(), SessionError> {
@@ -168,10 +225,7 @@ impl Subscribed {
     async fn serve_inner(&mut self, track: serve::TrackReader) -> Result<(), SessionError> {
         // Update largest location before sending SubscribeOk
         let largest_location = track.largest_location();
-        self.state
-            .lock_mut()
-            .ok_or(ServeError::Cancel)?
-            .largest_location = largest_location;
+        self.forwarder.set_largest_location(largest_location)?;
 
         // Send SubscribeOk using send_message_and_wait to ensure it is sent at least to the QUIC stack before
         // we start serving the track.  If a subscriber gets the stream before SubscribeOk
@@ -183,57 +237,29 @@ impl Subscribed {
                 .map_err(|_| SessionError::Internal)?;
         }
 
-        if self.send_subscribe_ok {
-            self.publisher
-                .send_message_and_wait(message::SubscribeOk {
-                    id: self.info.id,
-                    track_alias: self.track_alias,
-                    params,
-                    track_extensions: Default::default(),
-                })
-                .await;
+        self.forwarder
+            .publisher
+            .send_message_and_wait(message::SubscribeOk {
+                id: self.info.id,
+                track_alias: self.info.id,
+                params,
+                track_extensions: Default::default(),
+            })
+            .await;
 
-            self.ok = true; // So we send PUBLISH_DONE on drop
-        }
+        self.ok = true; // So we send PUBLISH_DONE on drop
 
         let delivery_filter = self.info.delivery_filter(largest_location);
 
-        // Serve based on track mode
-        match track.mode().await? {
-            // TODO cancel track/datagrams on closed
-            TrackReaderMode::Stream(_stream) => panic!("deprecated"),
-            TrackReaderMode::Subgroups(subgroups) => {
-                self.serve_subgroups(subgroups, delivery_filter).await
-            }
-            TrackReaderMode::Datagrams(datagrams) => {
-                self.serve_datagrams(datagrams, delivery_filter).await
-            }
-        }
+        self.forwarder.serve(track, delivery_filter).await
     }
 
     pub fn close(self, err: ServeError) -> Result<(), ServeError> {
-        let state = self.state.lock();
-        state.closed.clone()?;
-
-        let mut state = state.into_mut().ok_or(ServeError::Done)?;
-        state.closed = Err(err);
-
-        Ok(())
+        self.forwarder.close(err)
     }
 
     pub async fn closed(&self) -> Result<(), ServeError> {
-        loop {
-            {
-                let state = self.state.lock();
-                state.closed.clone()?;
-
-                match state.modified() {
-                    Some(notify) => notify,
-                    None => return Ok(()),
-                }
-            }
-            .await;
-        }
+        self.forwarder.closed().await
     }
 }
 
@@ -247,16 +273,7 @@ impl ops::Deref for Subscribed {
 
 impl Drop for Subscribed {
     fn drop(&mut self) {
-        let state = self.state.lock();
-        let err = state
-            .closed
-            .as_ref()
-            .err()
-            .cloned()
-            .unwrap_or(ServeError::Done);
-        let stream_count = state.stream_count;
-        let unsubscribed = state.unsubscribed;
-        drop(state); // Important to avoid a deadlock
+        let (err, stream_count, unsubscribed) = self.forwarder.terminal_state();
 
         // Subscriber already sent UNSUBSCRIBE — no terminal message needed.
         if unsubscribed {
@@ -264,7 +281,7 @@ impl Drop for Subscribed {
         }
 
         if self.ok {
-            self.publisher.send_message(message::PublishDone {
+            self.forwarder.publisher.send_message(message::PublishDone {
                 id: self.info.id,
                 status_code: Self::publish_done_code(&err),
                 stream_count,
@@ -273,7 +290,7 @@ impl Drop for Subscribed {
         } else {
             // Draft-16 §9.8: subscription rejection uses REQUEST_ERROR, not the
             // legacy SUBSCRIBE_ERROR.
-            self.publisher.send_request_error(
+            self.forwarder.publisher.send_request_error(
                 "subscribe",
                 message::RequestError {
                     id: self.info.id,
@@ -282,7 +299,7 @@ impl Drop for Subscribed {
                     reason: ReasonPhrase(err.to_string()),
                 },
             );
-            self.publisher.drop_subscribe(self.info.id);
+            self.forwarder.publisher.drop_subscribe(self.info.id);
         };
     }
 }
@@ -320,7 +337,9 @@ impl Subscribed {
             SessionError::Serve(ServeError::Cancel | ServeError::Done)
         )
     }
+}
 
+impl ObjectForwarder {
     async fn serve_subgroups(
         &mut self,
         mut subgroups: serve::SubgroupsReader,
@@ -348,7 +367,7 @@ impl Subscribed {
 
                         tasks.push(async move {
                             if let Err(err) = Self::serve_subgroup(header, subgroup, publisher, state, mlog, delivery_filter).await {
-                                if Self::is_expected_serve_shutdown(&err) {
+                                if Subscribed::is_expected_serve_shutdown(&err) {
                                     tracing::debug!(subgroup_info = ?info, error = %err, "stopped serving subgroup");
                                 } else {
                                     tracing::warn!(subgroup_info = ?info, error = %err, "failed to serve subgroup");
@@ -370,7 +389,7 @@ impl Subscribed {
         header: data::SubgroupHeader,
         mut subgroup_reader: serve::SubgroupReader,
         mut publisher: Publisher,
-        state: State<SubscribedState>,
+        state: State<ObjectForwarderState>,
         mlog: Option<Arc<Mutex<mlog::MlogWriter>>>,
         delivery_filter: DeliveryFilter,
     ) -> Result<(), SessionError> {
@@ -381,57 +400,98 @@ impl Subscribed {
             subgroup_reader.priority
         );
 
-        let mut writer: Option<Writer> = None;
-        let mut object_count = 0;
-        while let Some(mut subgroup_object_reader) = subgroup_reader.next().await? {
-            if !delivery_filter.allows(subgroup_reader.group_id, subgroup_object_reader.object_id) {
-                tracing::trace!(
-                    "[PUBLISHER] serve_subgroup: filtered object group_id={}, object_id={}",
-                    subgroup_reader.group_id,
-                    subgroup_object_reader.object_id
-                );
-                continue;
+        let Some(first_object) =
+            Self::next_allowed_object(&mut subgroup_reader, delivery_filter).await?
+        else {
+            return Ok(());
+        };
+
+        let mut send_stream = publisher.open_uni().await?;
+        tracing::trace!("[PUBLISHER] serve_subgroup: opened unidirectional stream");
+
+        state
+            .lock_mut()
+            .ok_or(ServeError::Done)?
+            .record_stream_opened();
+
+        // TODO figure out u32 vs u64 priority
+        send_stream.set_priority(subgroup_reader.priority as i32);
+
+        let mut output = SubgroupOutput::Stream(Writer::new(send_stream));
+        Self::serve_subgroup_objects(
+            header,
+            subgroup_reader,
+            first_object,
+            &mut output,
+            state,
+            mlog,
+            delivery_filter,
+        )
+        .await
+    }
+
+    async fn next_allowed_object(
+        subgroup_reader: &mut serve::SubgroupReader,
+        delivery_filter: DeliveryFilter,
+    ) -> Result<Option<serve::SubgroupObjectReader>, ServeError> {
+        while let Some(subgroup_object_reader) = subgroup_reader.next().await? {
+            if delivery_filter.allows(subgroup_reader.group_id, subgroup_object_reader.object_id) {
+                return Ok(Some(subgroup_object_reader));
             }
 
-            if writer.is_none() {
-                let mut send_stream = publisher.open_uni().await?;
-                tracing::trace!("[PUBLISHER] serve_subgroup: opened unidirectional stream");
+            tracing::trace!(
+                "[PUBLISHER] serve_subgroup: filtered object group_id={}, object_id={}",
+                subgroup_reader.group_id,
+                subgroup_object_reader.object_id
+            );
+        }
 
-                state
-                    .lock_mut()
-                    .ok_or(ServeError::Done)?
-                    .record_stream_opened();
+        Ok(None)
+    }
 
-                // TODO figure out u32 vs u64 priority
-                send_stream.set_priority(subgroup_reader.priority as i32);
+    async fn serve_subgroup_objects(
+        header: data::SubgroupHeader,
+        mut subgroup_reader: serve::SubgroupReader,
+        first_object: serve::SubgroupObjectReader,
+        output: &mut SubgroupOutput,
+        state: State<ObjectForwarderState>,
+        mlog: Option<Arc<Mutex<mlog::MlogWriter>>>,
+        delivery_filter: DeliveryFilter,
+    ) -> Result<(), SessionError> {
+        tracing::trace!(
+            "[PUBLISHER] serve_subgroup: sending header - track_alias={}, group_id={}, subgroup_id={:?}, priority={}, header_type={:?}",
+            header.track_alias,
+            header.group_id,
+            header.subgroup_id,
+            header.publisher_priority,
+            header.header_type
+        );
 
-                let mut new_writer = Writer::new(send_stream);
+        output.encode(&header).await?;
 
-                tracing::trace!(
-                    "[PUBLISHER] serve_subgroup: sending header - track_alias={}, group_id={}, subgroup_id={:?}, priority={}, header_type={:?}",
-                    header.track_alias,
-                    header.group_id,
-                    header.subgroup_id,
-                    header.publisher_priority,
-                    header.header_type
-                );
+        // Log subgroup header created/sent
+        if let Some(ref mlog) = mlog {
+            if let Ok(mut mlog_guard) = mlog.lock() {
+                let time = mlog_guard.elapsed_ms();
+                let stream_id = 0; // TODO: Placeholder, need actual QUIC stream ID
+                let event = mlog::subgroup_header_created(time, stream_id, &header);
+                let _ = mlog_guard.add_event(event);
+            }
+        }
 
-                new_writer.encode(&header).await?;
-
-                // Log subgroup header created/sent
-                if let Some(ref mlog) = mlog {
-                    if let Ok(mut mlog_guard) = mlog.lock() {
-                        let time = mlog_guard.elapsed_ms();
-                        let stream_id = 0; // TODO: Placeholder, need actual QUIC stream ID
-                        let event = mlog::subgroup_header_created(time, stream_id, &header);
-                        let _ = mlog_guard.add_event(event);
+        let mut object_count = 0;
+        let mut next_object = Some(first_object);
+        loop {
+            let mut subgroup_object_reader = match next_object.take() {
+                Some(reader) => reader,
+                None => {
+                    match Self::next_allowed_object(&mut subgroup_reader, delivery_filter).await? {
+                        Some(reader) => reader,
+                        None => break,
                     }
                 }
+            };
 
-                writer = Some(new_writer);
-            }
-
-            let writer = writer.as_mut().ok_or(SessionError::Internal)?;
             let subgroup_object = data::SubgroupObjectExt {
                 // TODO(itzmanish): compute real delta when the receive side uses object IDs
                 // for ordering. Both sender and receiver must agree on the same prev tracking
@@ -457,7 +517,7 @@ impl Subscribed {
                 subgroup_object.extension_headers
             );
 
-            writer.encode(&subgroup_object).await?;
+            output.encode(&subgroup_object).await?;
 
             // Log subgroup object created/sent
             if let Some(ref mlog) = mlog {
@@ -494,7 +554,7 @@ impl Subscribed {
                     chunk.len()
                 );
                 bytes_sent += chunk.len();
-                writer.write(&chunk).await?;
+                output.write(&chunk).await?;
                 chunks_sent += 1;
             }
 
@@ -515,6 +575,39 @@ impl Subscribed {
         );
 
         Ok(())
+    }
+
+    #[cfg(test)]
+    async fn serve_subgroup_to_buffer(
+        header: data::SubgroupHeader,
+        mut subgroup_reader: serve::SubgroupReader,
+        state: State<ObjectForwarderState>,
+        delivery_filter: DeliveryFilter,
+    ) -> Result<bytes::BytesMut, SessionError> {
+        let Some(first_object) =
+            Self::next_allowed_object(&mut subgroup_reader, delivery_filter).await?
+        else {
+            return Ok(bytes::BytesMut::new());
+        };
+
+        state
+            .lock_mut()
+            .ok_or(ServeError::Done)?
+            .record_stream_opened();
+
+        let mut output = SubgroupOutput::Buffer(bytes::BytesMut::new());
+        Self::serve_subgroup_objects(
+            header,
+            subgroup_reader,
+            first_object,
+            &mut output,
+            state,
+            None,
+            delivery_filter,
+        )
+        .await?;
+
+        Ok(output.into_buffer())
     }
 
     async fn serve_datagrams(
@@ -613,11 +706,11 @@ impl Subscribed {
     }
 }
 
-pub(super) struct SubscribedRecv {
-    state: State<SubscribedState>,
+pub(super) struct ObjectForwarderRecv {
+    state: State<ObjectForwarderState>,
 }
 
-impl SubscribedRecv {
+impl ObjectForwarderRecv {
     pub fn recv_unsubscribe(&mut self) -> Result<(), ServeError> {
         let state = self.state.lock();
         state.closed.clone()?;
@@ -637,7 +730,7 @@ mod tests {
 
     #[test]
     fn subscribed_state_counts_opened_streams() {
-        let mut state = SubscribedState::default();
+        let mut state = ObjectForwarderState::default();
         assert_eq!(state.stream_count, 0);
 
         state.record_stream_opened();
@@ -649,9 +742,9 @@ mod tests {
 
     #[test]
     fn recv_unsubscribe_marks_unsubscribed_and_closes() {
-        let state = State::<SubscribedState>::default();
+        let state = State::<ObjectForwarderState>::default();
         let (_send, recv_state) = state.split();
-        let mut recv = SubscribedRecv { state: recv_state };
+        let mut recv = ObjectForwarderRecv { state: recv_state };
 
         assert!(!recv.state.lock().unsubscribed);
 
@@ -660,6 +753,75 @@ mod tests {
         let locked = recv.state.lock();
         assert!(locked.unsubscribed);
         assert!(matches!(locked.closed, Err(ServeError::Cancel)));
+    }
+
+    #[tokio::test]
+    async fn object_forwarder_forwards_subgroup_object_to_output() {
+        use bytes::{Buf, Bytes};
+
+        use crate::{coding::Decode, coding::TrackNamespace};
+
+        let (track_writer, track_reader) =
+            serve::Track::new(TrackNamespace::from_utf8_path("test"), "video").produce();
+        let mut subgroups_writer = track_writer.subgroups().unwrap();
+        let mut subgroup_writer = subgroups_writer
+            .create(serve::Subgroup {
+                group_id: 7,
+                subgroup_id: 2,
+                priority: 9,
+            })
+            .unwrap();
+        subgroup_writer.write(Bytes::from_static(b"hello")).unwrap();
+        drop(subgroup_writer);
+        drop(subgroups_writer);
+
+        let mut subgroups = match track_reader.mode().await.unwrap() {
+            TrackReaderMode::Subgroups(subgroups) => subgroups,
+            _ => panic!("expected subgroups mode"),
+        };
+        let subgroup = subgroups
+            .next()
+            .await
+            .unwrap()
+            .expect("subgroup should be available");
+        let state = State::<ObjectForwarderState>::default();
+        let header = data::SubgroupHeader {
+            header_type: data::StreamHeaderType::SubgroupIdExt,
+            track_alias: 42,
+            group_id: subgroup.group_id,
+            subgroup_id: Some(subgroup.subgroup_id),
+            publisher_priority: subgroup.priority,
+        };
+
+        let output = ObjectForwarder::serve_subgroup_to_buffer(
+            header.clone(),
+            subgroup,
+            state.clone(),
+            DeliveryFilter {
+                forward: true,
+                start_location: None,
+                end_group_id: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(state.lock().stream_count, 1);
+
+        let mut output = output.freeze();
+        let header_type = data::StreamHeaderType::decode(&mut output).unwrap();
+        let decoded_header = data::SubgroupHeader::decode(header_type, &mut output).unwrap();
+        assert_eq!(decoded_header, header);
+
+        let object = data::SubgroupObjectExt::decode(&mut output).unwrap();
+        assert_eq!(object.object_id_delta, 0);
+        assert!(object.extension_headers.is_empty());
+        assert_eq!(object.payload_length, 5);
+        assert_eq!(object.status, None);
+
+        let payload = output.copy_to_bytes(object.payload_length);
+        assert_eq!(&payload[..], b"hello");
+        assert!(!output.has_remaining());
     }
 
     #[test]

--- a/moq-transport/src/session/subscribed.rs
+++ b/moq-transport/src/session/subscribed.rs
@@ -146,7 +146,9 @@ impl ObjectForwarder {
         delivery_filter: DeliveryFilter,
     ) -> Result<(), SessionError> {
         match track.mode().await? {
-            TrackReaderMode::Stream(_stream) => panic!("deprecated"),
+            TrackReaderMode::Stream(_stream) => Err(SessionError::Serve(
+                ServeError::not_implemented_ctx("stream track reader mode"),
+            )),
             TrackReaderMode::Subgroups(subgroups) => {
                 self.serve_subgroups(subgroups, delivery_filter).await
             }

--- a/moq-transport/src/session/subscribed.rs
+++ b/moq-transport/src/session/subscribed.rs
@@ -71,6 +71,20 @@ pub struct Subscribed {
     /// PUBLISH_DONE vs REQUEST_ERROR on drop.
     ok: bool,
 
+    /// Whether `serve_inner` should send SUBSCRIBE_OK before sending data.
+    ///
+    /// True for SUBSCRIBE-initiated subscriptions. False for PUBLISH-initiated
+    /// subscriptions because the success response is PUBLISH_OK sent by the
+    /// subscriber, not SUBSCRIBE_OK from us.
+    send_subscribe_ok: bool,
+
+    /// Track Alias used in subgroup/datagram headers.
+    ///
+    /// For SUBSCRIBE-initiated subscriptions this equals `info.id`, preserving
+    /// existing behavior. For PUBLISH-initiated subscriptions this is the alias
+    /// sent in PUBLISH.
+    track_alias: u64,
+
     /// Optional mlog writer for logging transport events
     mlog: Option<Arc<Mutex<mlog::MlogWriter>>>,
 }
@@ -83,11 +97,14 @@ impl Subscribed {
     ) -> Result<(Self, SubscribedRecv), SessionError> {
         let (send, recv) = State::default().split();
         let info = SubscribeInfo::new_from_subscribe(&msg)?;
+        let track_alias = info.id;
         let send = Self {
             publisher,
             state: send,
             info,
             ok: false,
+            send_subscribe_ok: true,
+            track_alias,
             mlog,
         };
 
@@ -95,6 +112,48 @@ impl Subscribed {
         let recv = SubscribedRecv { state: recv };
 
         Ok((send, recv))
+    }
+
+    /// Create a publisher-side subscription for a PUBLISH-initiated track.
+    ///
+    /// This reuses the same serve loop as inbound SUBSCRIBE. The only protocol
+    /// differences are that the Track Alias is chosen by the publisher and the
+    /// subscription is already considered accepted for purposes of sending
+    /// PUBLISH_DONE on Drop.
+    pub(super) fn new_for_publish(
+        publisher: Publisher,
+        request_id: u64,
+        track_alias: u64,
+        namespace: crate::coding::TrackNamespace,
+        name: crate::coding::TrackName,
+        forward: bool,
+        mlog: Option<Arc<Mutex<mlog::MlogWriter>>>,
+    ) -> (Self, SubscribedRecv) {
+        let (send, recv) = State::default().split();
+        let info = SubscribeInfo {
+            id: request_id,
+            track_namespace: namespace,
+            track_name: name,
+            subscriber_priority: 128,
+            group_order: crate::message::GroupOrder::Publisher,
+            forward,
+            filter_type: crate::message::FilterType::AbsoluteStart,
+            start_location: None,
+            end_group_id: None,
+            filter: None,
+            params: Default::default(),
+            track_status: false,
+        };
+        let send = Self {
+            publisher,
+            state: send,
+            info,
+            ok: true,
+            send_subscribe_ok: false,
+            track_alias,
+            mlog,
+        };
+        (send, SubscribedRecv { state: recv })
     }
 
     pub async fn serve(mut self, track: serve::TrackReader) -> Result<(), SessionError> {
@@ -124,16 +183,18 @@ impl Subscribed {
                 .map_err(|_| SessionError::Internal)?;
         }
 
-        self.publisher
-            .send_message_and_wait(message::SubscribeOk {
-                id: self.info.id,
-                track_alias: self.info.id, // use subscription id as track alias
-                params,
-                track_extensions: Default::default(),
-            })
-            .await;
+        if self.send_subscribe_ok {
+            self.publisher
+                .send_message_and_wait(message::SubscribeOk {
+                    id: self.info.id,
+                    track_alias: self.track_alias,
+                    params,
+                    track_extensions: Default::default(),
+                })
+                .await;
 
-        self.ok = true; // So we send SubscribeDone on drop
+            self.ok = true; // So we send PUBLISH_DONE on drop
+        }
 
         let delivery_filter = self.info.delivery_filter(largest_location);
 
@@ -274,7 +335,7 @@ impl Subscribed {
                     Ok(Some(subgroup)) => {
                         let header = data::SubgroupHeader {
                             header_type: data::StreamHeaderType::SubgroupIdExt,  // SubGroupId = Yes, Extensions = Yes, ContainsEndOfGroup = No
-                            track_alias: self.info.id, // use subscription id as track_alias
+                            track_alias: self.track_alias,
                             group_id: subgroup.group_id,
                             subgroup_id: Some(subgroup.subgroup_id),
                             publisher_priority: subgroup.priority,
@@ -484,7 +545,7 @@ impl Subscribed {
 
             let encoded_datagram = data::Datagram {
                 datagram_type,
-                track_alias: self.info.id, // use subscription id as track_alias
+                track_alias: self.track_alias,
                 group_id: datagram.group_id,
                 object_id: Some(datagram.object_id),
                 publisher_priority: datagram.priority,

--- a/moq-transport/src/session/subscriber.rs
+++ b/moq-transport/src/session/subscriber.rs
@@ -258,22 +258,18 @@ impl Subscriber {
     }
 
     fn remove_publish_received_state(&self, request_id: u64) -> Result<(), SessionError> {
-        let mut publishes_received = self
-            .publishes_received
+        self.publishes_received
             .lock()
-            .map_err(|_| SessionError::Internal)?;
-        let mut aliases = self
-            .track_alias_map
+            .map_err(|_| SessionError::Internal)?
+            .remove(&request_id);
+        self.track_alias_map
             .lock()
-            .map_err(|_| SessionError::Internal)?;
-        let mut names = self
-            .subscriber_names
+            .map_err(|_| SessionError::Internal)?
+            .remove_by_request_id(request_id);
+        self.subscriber_names
             .lock()
-            .map_err(|_| SessionError::Internal)?;
-
-        publishes_received.remove(&request_id);
-        aliases.remove_by_request_id(request_id);
-        names.remove_by_request_id(request_id);
+            .map_err(|_| SessionError::Internal)?
+            .remove_by_request_id(request_id);
         Ok(())
     }
 
@@ -595,8 +591,8 @@ impl Subscriber {
             .unwrap_or(true);
         let largest_location = msg.params.largest_object().map_err(SessionError::Decode)?;
 
-        // Reserve the alias and track name before queueing the PublishReceived.
-        // The duplicate-subscription check intentionally runs before the alias
+        // Reserve the track name before queueing the PublishReceived. The
+        // duplicate-subscription check intentionally runs before the alias
         // check so a duplicate PUBLISH for the same track is rejected as a
         // request error instead of a duplicate-alias session close.
         {
@@ -618,19 +614,29 @@ impl Subscriber {
                 return Ok(());
             }
 
-            let mut aliases = self
-                .track_alias_map
-                .lock()
-                .map_err(|_| SessionError::Internal)?;
-            if aliases.contains_alias(msg.track_alias) {
-                // §9.13: duplicate Track Alias for a different track closes the session.
-                return Err(SessionError::Duplicate);
-            }
-
             names.insert(full_name.clone(), msg.id);
-            aliases
-                .insert(msg.track_alias, TrackOrigin::Publish(msg.id))
-                .map_err(|_| SessionError::Duplicate)?;
+        }
+
+        // Then reserve the alias without holding subscriber_names, avoiding a
+        // lock-order dependency between cleanup and inbound PUBLISH handling.
+        let alias_result = match self.track_alias_map.lock() {
+            Ok(mut aliases) => {
+                if aliases.contains_alias(msg.track_alias) {
+                    // §9.13: duplicate Track Alias for a different track closes the session.
+                    Err(SessionError::Duplicate)
+                } else {
+                    aliases
+                        .insert(msg.track_alias, TrackOrigin::Publish(msg.id))
+                        .map_err(|_| SessionError::Duplicate)
+                }
+            }
+            Err(_) => Err(SessionError::Internal),
+        };
+        if let Err(err) = alias_result {
+            if let Ok(mut names) = self.subscriber_names.lock() {
+                names.remove_by_request_id(msg.id);
+            }
+            return Err(err);
         }
 
         // Allocate the track.  The transport owns the writer; the application
@@ -1390,6 +1396,16 @@ mod tests {
         let err = subscriber.recv_publish(&publish_msg(3, 10, "1.mp4"));
 
         assert!(matches!(err, Err(SessionError::Duplicate)));
+
+        let failed_name = FullTrackName {
+            namespace: TrackNamespace::from_utf8_path("test"),
+            name: TrackName::from("1.mp4"),
+        };
+        assert!(!subscriber
+            .subscriber_names
+            .lock()
+            .unwrap()
+            .contains_name(&failed_name));
     }
 
     #[test]

--- a/moq-transport/src/session/subscriber.rs
+++ b/moq-transport/src/session/subscriber.rs
@@ -16,7 +16,7 @@ use crate::{
     data,
     message::{self, Message, RequestErrorCode},
     mlog,
-    serve::{self, FullTrackName, ServeError, TrackReader},
+    serve::{self, FullTrackName, ServeError},
 };
 
 use crate::watch::Queue;
@@ -168,17 +168,6 @@ impl Subscriber {
     /// [`PublishReceived::ok`] or dropped to reject.
     pub async fn publish_received(&mut self) -> Option<PublishReceived> {
         self.publish_received_queue.pop().await
-    }
-
-    /// Take the [`TrackReader`] stored for a PUBLISH request id.
-    ///
-    /// Called by [`PublishReceived::ok`] exactly once per subscription.
-    pub(super) fn take_publish_received_reader(&self, request_id: u64) -> Option<TrackReader> {
-        self.publishes_received
-            .lock()
-            .ok()?
-            .get_mut(&request_id)?
-            .take_reader()
     }
 
     /// Remove all subscriber-side state for an inbound PUBLISH.

--- a/moq-transport/src/session/subscriber.rs
+++ b/moq-transport/src/session/subscriber.rs
@@ -708,7 +708,12 @@ impl Subscriber {
     fn recv_publish_done(&mut self, msg: &message::PublishDone) -> Result<(), SessionError> {
         // Check SUBSCRIBE-initiated subscriptions first.
         if let Some(subscribe) = self.remove_subscribe(msg.id) {
-            subscribe.error(ServeError::Closed(msg.status_code))?;
+            let err = if msg.status_code == message::PublishDoneCode::TrackEnded as u64 {
+                ServeError::Done
+            } else {
+                ServeError::Closed(msg.status_code)
+            };
+            subscribe.error(err)?;
             return Ok(());
         }
 

--- a/moq-transport/src/session/subscriber.rs
+++ b/moq-transport/src/session/subscriber.rs
@@ -22,9 +22,9 @@ use crate::{
 use crate::watch::Queue;
 
 use super::{
-    PublishReceived, PublishReceivedRecv, PublishedNamespace, PublishedNamespaceRecv, Reader,
-    RequestId, RequestIdAllocation, Session, SessionConfig, SessionError, Subscribe,
-    SubscribeRecv,
+    PendingRequest, PendingRequests, PublishReceived, PublishReceivedRecv, PublishedNamespace,
+    PublishedNamespaceRecv, Reader, RequestId, RequestIdAllocation, Session, SessionConfig,
+    SessionError, Subscribe, SubscribeRecv,
 };
 
 // Default timeout for waiting for subscribe aliases to become available via SUBSCRIBE_OK (1 second)
@@ -50,7 +50,7 @@ pub struct Subscriber {
     /// Track Aliases are session-scoped and shared between SUBSCRIBE-initiated
     /// and PUBLISH-initiated subscriptions, so a single map keyed by alias
     /// resolves an inbound stream/datagram to the correct receiver.
-    track_alias_map: Arc<Mutex<HashMap<u64, TrackOrigin>>>,
+    track_alias_map: Arc<Mutex<TrackAliasRegistry>>,
 
     /// Notify when `track_alias_map` is updated (for stream/datagram routing
     /// that may arrive before SUBSCRIBE_OK populates the alias).
@@ -67,7 +67,7 @@ pub struct Subscriber {
     /// Tracks which (namespace, name) pairs this endpoint is subscribed to
     /// (as subscriber role) — covers both outbound SUBSCRIBE and inbound PUBLISH.
     /// Used for §5.1 same-role duplicate-subscription enforcement.
-    subscriber_names: Arc<Mutex<HashMap<FullTrackName, u64>>>,
+    subscriber_names: Arc<Mutex<SubscriberNameRegistry>>,
 
     /// The queue we will write any outbound control messages we want to send, the session run_send task
     /// will process the queue and send the message on the control stream.
@@ -80,6 +80,9 @@ pub struct Subscriber {
     /// IDs start at 0 and increment by 2 (even numbers).  If we accepted an inbound
     /// QUIC connection then request IDs start at 1 and increment by 2 (odd numbers).
     request_id: RequestId,
+
+    /// Tracks outbound subscriber-role requests waiting for OK/error responses.
+    pending_requests: PendingRequests,
 
     /// Optional mlog writer for logging transport events
     mlog: Option<Arc<Mutex<mlog::MlogWriter>>>,
@@ -98,11 +101,85 @@ enum TrackOrigin {
     Publish(u64),
 }
 
+impl TrackOrigin {
+    fn request_id(self) -> u64 {
+        match self {
+            Self::Subscribe(id) | Self::Publish(id) => id,
+        }
+    }
+}
+
+#[derive(Default)]
+struct TrackAliasRegistry {
+    by_alias: HashMap<u64, TrackOrigin>,
+    by_request_id: HashMap<u64, u64>,
+}
+
+impl TrackAliasRegistry {
+    fn contains_alias(&self, alias: u64) -> bool {
+        self.by_alias.contains_key(&alias)
+    }
+
+    fn get(&self, alias: u64) -> Option<TrackOrigin> {
+        self.by_alias.get(&alias).copied()
+    }
+
+    fn insert(&mut self, alias: u64, origin: TrackOrigin) -> Result<(), ()> {
+        if self.by_alias.contains_key(&alias) {
+            return Err(());
+        }
+
+        if let Some(old_alias) = self.by_request_id.insert(origin.request_id(), alias) {
+            self.by_alias.remove(&old_alias);
+        }
+        self.by_alias.insert(alias, origin);
+        Ok(())
+    }
+
+    fn remove_by_request_id(&mut self, request_id: u64) -> Option<TrackOrigin> {
+        let alias = self.by_request_id.remove(&request_id)?;
+        self.by_alias.remove(&alias)
+    }
+
+    #[cfg(test)]
+    fn is_empty(&self) -> bool {
+        self.by_alias.is_empty() && self.by_request_id.is_empty()
+    }
+}
+
+#[derive(Default)]
+struct SubscriberNameRegistry {
+    by_name: HashMap<FullTrackName, u64>,
+    by_request_id: HashMap<u64, FullTrackName>,
+}
+
+impl SubscriberNameRegistry {
+    fn contains_name(&self, name: &FullTrackName) -> bool {
+        self.by_name.contains_key(name)
+    }
+
+    fn insert(&mut self, name: FullTrackName, request_id: u64) {
+        if let Some(old_name) = self.by_request_id.insert(request_id, name.clone()) {
+            self.by_name.remove(&old_name);
+        }
+        if let Some(old_id) = self.by_name.insert(name, request_id) {
+            self.by_request_id.remove(&old_id);
+        }
+    }
+
+    fn remove_by_request_id(&mut self, request_id: u64) -> Option<FullTrackName> {
+        let name = self.by_request_id.remove(&request_id)?;
+        self.by_name.remove(&name);
+        Some(name)
+    }
+}
+
 impl Subscriber {
     pub(super) fn new(
         outgoing: Queue<Message>,
         mlog: Option<Arc<Mutex<mlog::MlogWriter>>>,
         request_id: RequestId,
+        pending_requests: PendingRequests,
     ) -> Self {
         Self {
             published_namespaces: Default::default(),
@@ -116,6 +193,7 @@ impl Subscriber {
             subscriber_names: Default::default(),
             outgoing,
             request_id,
+            pending_requests,
             mlog,
         }
     }
@@ -174,20 +252,29 @@ impl Subscriber {
     ///
     /// Called by `PublishReceived::drop` when the app did not call `ok()`.
     pub(super) fn remove_publish_received(&self, request_id: u64) {
-        if let Ok(mut tracks) = self.publishes_received.lock() {
-            tracks.remove(&request_id);
+        if let Err(err) = self.remove_publish_received_state(request_id) {
+            tracing::error!(request_id, error = %err, "failed to remove inbound PUBLISH state");
         }
-        // Alias cleanup: remove the alias entry pointing at this PUBLISH.
-        // TODO(itzmanish): maintain a reverse map to make this O(1).
-        if let Ok(mut aliases) = self.track_alias_map.lock() {
-            aliases.retain(
-                |_alias, origin| !matches!(origin, TrackOrigin::Publish(id) if *id == request_id),
-            );
-        }
-        // Clean up subscriber_names for this request id.
-        if let Ok(mut names) = self.subscriber_names.lock() {
-            names.retain(|_name, id| *id != request_id);
-        }
+    }
+
+    fn remove_publish_received_state(&self, request_id: u64) -> Result<(), SessionError> {
+        let mut publishes_received = self
+            .publishes_received
+            .lock()
+            .map_err(|_| SessionError::Internal)?;
+        let mut aliases = self
+            .track_alias_map
+            .lock()
+            .map_err(|_| SessionError::Internal)?;
+        let mut names = self
+            .subscriber_names
+            .lock()
+            .map_err(|_| SessionError::Internal)?;
+
+        publishes_received.remove(&request_id);
+        aliases.remove_by_request_id(request_id);
+        names.remove_by_request_id(request_id);
+        Ok(())
     }
 
     fn add_mlog_event<F>(&self, make_event: F)
@@ -294,17 +381,39 @@ impl Subscriber {
                 .subscriber_names
                 .lock()
                 .map_err(|_| ServeError::internal_ctx("subscriber_names lock poisoned"))?;
-            if names.contains_key(&full_name) {
+            if names.contains_name(&full_name) {
                 return Err(ServeError::Duplicate);
             }
-            names.insert(full_name, request_id);
+            names.insert(full_name.clone(), request_id);
         }
 
-        let (send, recv) = Subscribe::new(self.clone(), request_id, track);
-        self.subscribes
-            .lock()
-            .map_err(|_| ServeError::internal_ctx("subscribe lock poisoned"))?
-            .insert(request_id, recv);
+        if let Err(err) = self
+            .pending_requests
+            .insert(request_id, PendingRequest::Subscribe)
+        {
+            if let Ok(mut names) = self.subscriber_names.lock() {
+                names.remove_by_request_id(request_id);
+            }
+            return Err(ServeError::internal_ctx(format!(
+                "pending request insert: {}",
+                err
+            )));
+        }
+
+        let (mut send, recv) = Subscribe::new(self.clone(), request_id, track);
+        match self.subscribes.lock() {
+            Ok(mut subscribes) => {
+                subscribes.insert(request_id, recv);
+            }
+            Err(_) => {
+                let _ = self.pending_requests.remove(request_id);
+                if let Ok(mut names) = self.subscriber_names.lock() {
+                    names.remove_by_request_id(request_id);
+                }
+                return Err(ServeError::internal_ctx("subscribe lock poisoned"));
+            }
+        }
+        send.send_request();
         send.ok().await?;
         Ok(send)
     }
@@ -394,7 +503,10 @@ impl Subscriber {
     }
 
     /// Handle the reception of a SUBSCRIBE_OK message from the publisher.
-    fn recv_subscribe_ok(&mut self, msg: &message::SubscribeOk) -> Result<(), SessionError> {
+    pub(super) fn recv_subscribe_ok(
+        &mut self,
+        msg: &message::SubscribeOk,
+    ) -> Result<(), SessionError> {
         if let Some(subscribe) = self
             .subscribes
             .lock()
@@ -409,10 +521,12 @@ impl Subscriber {
                     .track_alias_map
                     .lock()
                     .map_err(|_| SessionError::Internal)?;
-                if aliases.contains_key(&msg.track_alias) {
+                if aliases.contains_alias(msg.track_alias) {
                     return Err(SessionError::Duplicate);
                 }
-                aliases.insert(msg.track_alias, TrackOrigin::Subscribe(msg.id));
+                aliases
+                    .insert(msg.track_alias, TrackOrigin::Subscribe(msg.id))
+                    .map_err(|_| SessionError::Duplicate)?;
             }
 
             // Notify waiting tasks that the alias map has been updated.
@@ -427,18 +541,13 @@ impl Subscriber {
 
     /// Remove a subscribe from our map of active subscribes, the alias map, and subscriber_names.
     pub(super) fn remove_subscribe(&mut self, id: u64) -> Option<SubscribeRecv> {
+        let _ = self.pending_requests.remove(id);
         let subscribe = self.subscribes.lock().ok().and_then(|mut s| s.remove(&id));
-        if let Some(ref sub) = subscribe {
-            if let Some(track_alias) = sub.track_alias() {
-                if let Ok(mut alias_map) = self.track_alias_map.lock() {
-                    alias_map.remove(&track_alias);
-                }
-            }
+        if let Ok(mut alias_map) = self.track_alias_map.lock() {
+            alias_map.remove_by_request_id(id);
         }
-        // Clean up the subscriber_names entry for this request id.
-        // TODO(itzmanish): maintain a reverse map to make this O(1).
         if let Ok(mut names) = self.subscriber_names.lock() {
-            names.retain(|_name, req_id| *req_id != id);
+            names.remove_by_request_id(id);
         }
         subscribe
     }
@@ -468,19 +577,6 @@ impl Subscriber {
             return Ok(());
         }
 
-        // Track Aliases are session-scoped (§10.1); the unified alias map covers
-        // both SUBSCRIBE and PUBLISH, so one lookup detects any collision.
-        {
-            let aliases = self
-                .track_alias_map
-                .lock()
-                .map_err(|_| SessionError::Internal)?;
-            if aliases.contains_key(&msg.track_alias) {
-                // §9.13: duplicate Track Alias closes the session.
-                return Err(SessionError::Duplicate);
-            }
-        }
-
         // §5.1: enforce single subscriber-role subscription per track.
         // Both outbound SUBSCRIBE and inbound PUBLISH make this endpoint the
         // subscriber for the given (namespace, name).
@@ -488,32 +584,54 @@ impl Subscriber {
             namespace: msg.track_namespace.clone(),
             name: msg.track_name.clone(),
         };
-        let duplicate_subscription = {
-            self.subscriber_names
-                .lock()
-                .map_err(|_| SessionError::Internal)?
-                .contains_key(&full_name)
-        };
-        if duplicate_subscription {
-            self.send_request_error(
-                "publish",
-                message::RequestError {
-                    id: msg.id,
-                    error_code: RequestErrorCode::DuplicateSubscription as u64,
-                    retry_interval: 0,
-                    reason: crate::coding::ReasonPhrase("duplicate subscription".to_string()),
-                },
-            );
-            return Ok(());
-        }
 
-        // Parse FORWARD and LARGEST_OBJECT from the PUBLISH params.
+        // Parse FORWARD and LARGEST_OBJECT from the PUBLISH params before
+        // reserving session state, so malformed parameters cannot leave stale
+        // alias/name entries behind.
         let initial_forward = msg
             .params
             .forward()
             .map_err(SessionError::Decode)?
             .unwrap_or(true);
         let largest_location = msg.params.largest_object().map_err(SessionError::Decode)?;
+
+        // Reserve the alias and track name before queueing the PublishReceived.
+        // The duplicate-subscription check intentionally runs before the alias
+        // check so a duplicate PUBLISH for the same track is rejected as a
+        // request error instead of a duplicate-alias session close.
+        {
+            let mut names = self
+                .subscriber_names
+                .lock()
+                .map_err(|_| SessionError::Internal)?;
+            if names.contains_name(&full_name) {
+                drop(names);
+                self.send_request_error(
+                    "publish",
+                    message::RequestError {
+                        id: msg.id,
+                        error_code: RequestErrorCode::DuplicateSubscription as u64,
+                        retry_interval: 0,
+                        reason: crate::coding::ReasonPhrase("duplicate subscription".to_string()),
+                    },
+                );
+                return Ok(());
+            }
+
+            let mut aliases = self
+                .track_alias_map
+                .lock()
+                .map_err(|_| SessionError::Internal)?;
+            if aliases.contains_alias(msg.track_alias) {
+                // §9.13: duplicate Track Alias for a different track closes the session.
+                return Err(SessionError::Duplicate);
+            }
+
+            names.insert(full_name.clone(), msg.id);
+            aliases
+                .insert(msg.track_alias, TrackOrigin::Publish(msg.id))
+                .map_err(|_| SessionError::Duplicate)?;
+        }
 
         // Allocate the track.  The transport owns the writer; the application
         // receives the reader via PublishReceived::ok.
@@ -533,27 +651,26 @@ impl Subscriber {
             reader,
         );
 
-        // Register the alias BEFORE queueing the PublishReceived so that Object
-        // streams racing the PUBLISH (§5.1 allows pre-PUBLISH_OK delivery) can
-        // be resolved immediately.
-        self.track_alias_map
-            .lock()
-            .map_err(|_| SessionError::Internal)?
-            .insert(msg.track_alias, TrackOrigin::Publish(msg.id));
+        // The alias was registered before queueing the PublishReceived so that
+        // Object streams racing the PUBLISH (§5.1 allows pre-PUBLISH_OK
+        // delivery) can be resolved immediately.
         self.track_alias_notify.notify_waiters();
 
-        // Register subscriber_names so a duplicate SUBSCRIBE or PUBLISH for the
-        // same track is rejected with DUPLICATE_SUBSCRIPTION (§5.1).
-        self.subscriber_names
-            .lock()
-            .map_err(|_| SessionError::Internal)?
-            .insert(full_name, msg.id);
-
         // Store the transport recv handle keyed by request id.
-        self.publishes_received
-            .lock()
-            .map_err(|_| SessionError::Internal)?
-            .insert(msg.id, recv);
+        match self.publishes_received.lock() {
+            Ok(mut publishes_received) => {
+                publishes_received.insert(msg.id, recv);
+            }
+            Err(_) => {
+                if let Ok(mut aliases) = self.track_alias_map.lock() {
+                    aliases.remove_by_request_id(msg.id);
+                }
+                if let Ok(mut names) = self.subscriber_names.lock() {
+                    names.remove_by_request_id(msg.id);
+                }
+                return Err(SessionError::Internal);
+            }
+        }
 
         tracing::debug!(
             target: "moq_transport::control",
@@ -569,18 +686,7 @@ impl Subscriber {
         // which sends REQUEST_ERROR back to the publisher.
         if self.publish_received_queue.push(publish_received).is_err() {
             // Queue is closed; clean up state we just inserted.
-            self.track_alias_map
-                .lock()
-                .ok()
-                .map(|mut m| m.remove(&msg.track_alias));
-            self.publishes_received
-                .lock()
-                .ok()
-                .map(|mut m| m.remove(&msg.id));
-            self.subscriber_names
-                .lock()
-                .ok()
-                .map(|mut m| m.retain(|_, id| *id != msg.id));
+            self.remove_publish_received(msg.id);
         }
 
         Ok(())
@@ -608,16 +714,14 @@ impl Subscriber {
             .remove(&msg.id);
         if let Some(mut recv) = recv {
             recv.recv_done(msg.status_code);
-            // Clean up alias and name maps.
-            // TODO(itzmanish): maintain reverse maps to make these O(1).
-            if let Ok(mut aliases) = self.track_alias_map.lock() {
-                aliases.retain(
-                    |_alias, origin| !matches!(origin, TrackOrigin::Publish(id) if *id == msg.id),
-                );
-            }
-            if let Ok(mut names) = self.subscriber_names.lock() {
-                names.retain(|_name, id| *id != msg.id);
-            }
+            self.track_alias_map
+                .lock()
+                .map_err(|_| SessionError::Internal)?
+                .remove_by_request_id(msg.id);
+            self.subscriber_names
+                .lock()
+                .map_err(|_| SessionError::Internal)?
+                .remove_by_request_id(msg.id);
         } else {
             tracing::debug!(
                 target: "moq_transport::control",
@@ -661,7 +765,10 @@ impl Subscriber {
     /// Handle REQUEST_ERROR from the publisher (draft-16 §9.8).
     ///
     /// Routes to an active SUBSCRIBE by request id, otherwise logs and ignores.
-    fn recv_request_error(&mut self, msg: &message::RequestError) -> Result<(), SessionError> {
+    pub(super) fn recv_request_error(
+        &mut self,
+        msg: &message::RequestError,
+    ) -> Result<(), SessionError> {
         // Route to a matching SUBSCRIBE if present.
         if let Some(subscribe) = self.remove_subscribe(msg.id) {
             self.log_request_error_parsed("subscribe", msg);
@@ -700,6 +807,25 @@ impl Subscriber {
             reason = %msg.reason.0,
             "received REQUEST_ERROR"
         );
+        Ok(())
+    }
+
+    pub(super) fn recv_request_timeout(
+        &mut self,
+        id: u64,
+        request: PendingRequest,
+    ) -> Result<(), SessionError> {
+        match request {
+            PendingRequest::Subscribe => {
+                if let Some(subscribe) = self.remove_subscribe(id) {
+                    subscribe.error(ServeError::internal_ctx("SUBSCRIBE response timed out"))?;
+                }
+            }
+            PendingRequest::PublishNamespace | PendingRequest::Publish => {
+                return Err(SessionError::Internal)
+            }
+        }
+
         Ok(())
     }
 
@@ -744,7 +870,7 @@ impl Subscriber {
                 .track_alias_map
                 .lock()
                 .map_err(|_| SessionError::Internal)?;
-            if let Some(origin) = aliases.get(&track_alias).copied() {
+            if let Some(origin) = aliases.get(track_alias) {
                 return Ok(Some(origin));
             }
         }
@@ -765,7 +891,7 @@ impl Subscriber {
                         .track_alias_map
                         .lock()
                         .map_err(|_| SessionError::Internal)?;
-                    if let Some(origin) = aliases.get(&track_alias).copied() {
+                    if let Some(origin) = aliases.get(track_alias) {
                         return Ok(Some(origin));
                     }
                 }
@@ -865,14 +991,8 @@ impl Subscriber {
                 )))
             })?;
 
-        self.recv_subgroup(
-            stream_header_type,
-            subgroup_header,
-            origin,
-            reader,
-            mlog,
-        )
-        .await?;
+        self.recv_subgroup(stream_header_type, subgroup_header, origin, reader, mlog)
+            .await?;
 
         tracing::trace!(
             "[SUBSCRIBER] recv_stream_inner: completed processing stream for track_alias={}",
@@ -1219,7 +1339,57 @@ mod tests {
 
     fn subscriber() -> Subscriber {
         let request_id = RequestId::new(0, 100, 100, 0);
-        Subscriber::new(Queue::default(), None, request_id)
+        Subscriber::new(
+            Queue::default(),
+            None,
+            request_id,
+            PendingRequests::default(),
+        )
+    }
+
+    fn publish_msg(id: u64, alias: u64, track: &str) -> message::Publish {
+        message::Publish {
+            id,
+            track_namespace: TrackNamespace::from_utf8_path("test"),
+            track_name: TrackName::from(track),
+            track_alias: alias,
+            params: Default::default(),
+            track_extensions: Default::default(),
+        }
+    }
+
+    #[tokio::test]
+    async fn duplicate_publish_for_same_track_sends_request_error() {
+        let mut subscriber = subscriber();
+
+        subscriber
+            .recv_publish(&publish_msg(1, 10, "0.mp4"))
+            .unwrap();
+        subscriber
+            .recv_publish(&publish_msg(3, 10, "0.mp4"))
+            .unwrap();
+
+        let msg = subscriber.outgoing.pop().await.unwrap();
+        let message::Message::RequestError(err) = msg else {
+            panic!("expected REQUEST_ERROR for duplicate PUBLISH");
+        };
+        assert_eq!(err.id, 3);
+        assert_eq!(
+            err.error_code,
+            RequestErrorCode::DuplicateSubscription as u64
+        );
+    }
+
+    #[test]
+    fn duplicate_publish_alias_for_different_track_closes_session() {
+        let mut subscriber = subscriber();
+
+        subscriber
+            .recv_publish(&publish_msg(1, 10, "0.mp4"))
+            .unwrap();
+        let err = subscriber.recv_publish(&publish_msg(3, 10, "1.mp4"));
+
+        assert!(matches!(err, Err(SessionError::Duplicate)));
     }
 
     #[test]
@@ -1310,7 +1480,7 @@ mod tests {
 
         assert_eq!(observer.subscribes.lock().unwrap().len(), 1);
         assert!(matches!(
-            observer.track_alias_map.lock().unwrap().get(&10),
+            observer.track_alias_map.lock().unwrap().get(10),
             Some(TrackOrigin::Subscribe(0))
         ));
 

--- a/moq-transport/src/session/subscriber.rs
+++ b/moq-transport/src/session/subscriber.rs
@@ -14,16 +14,17 @@ use tokio::sync::Notify;
 use crate::{
     coding::{Decode, TrackName, TrackNamespace},
     data,
-    message::{self, Message},
+    message::{self, Message, RequestErrorCode},
     mlog,
-    serve::{self, ServeError},
+    serve::{self, FullTrackName, ServeError, TrackReader},
 };
 
 use crate::watch::Queue;
 
 use super::{
-    PublishedNamespace, PublishedNamespaceRecv, Reader, RequestId, RequestIdAllocation, Session,
-    SessionConfig, SessionError, Subscribe, SubscribeRecv,
+    PendingPublishUpdate, PublishedNamespace, PublishedNamespaceRecv, PublishedTrack,
+    PublishedTrackRecv, Reader, RequestId, RequestIdAllocation, Session, SessionConfig,
+    SessionError, Subscribe, SubscribeRecv,
 };
 
 // Default timeout for waiting for subscribe aliases to become available via SUBSCRIBE_OK (1 second)
@@ -44,11 +45,41 @@ pub struct Subscriber {
     /// Outbound TRACK_STATUS requests awaiting a shared REQUEST_OK / REQUEST_ERROR response.
     track_statuses: Arc<Mutex<HashSet<u64>>>,
 
-    /// Map of track alias to subscription id for quick lookup when receiving streams/datagrams.
+    /// Map of track alias → SUBSCRIBE request id.
+    /// Populated on SUBSCRIBE_OK.  Both alias maps must be collision-free:
+    /// Track Aliases are session-scoped (§10.1), so SUBSCRIBE and PUBLISH aliases
+    /// share the same namespace.
     subscribe_alias_map: Arc<Mutex<HashMap<u64, u64>>>,
 
-    /// Notify when subscribe alias map is updated
+    /// Notify when subscribe alias map is updated.
     subscribe_alias_notify: Arc<Notify>,
+
+    /// Active inbound PUBLISH subscriptions, keyed by PUBLISH request id.
+    /// The transport writes Objects into the TrackWriter stored here;
+    /// the application receives the TrackReader from PublishedTrack::ok.
+    published_tracks: Arc<Mutex<HashMap<u64, PublishedTrackRecv>>>,
+
+    /// Map of track alias → PUBLISH request id.
+    /// Track Aliases are session-scoped (§10.1), so both alias maps must be
+    /// checked together when validating incoming alias usage.
+    publish_alias_map: Arc<Mutex<HashMap<u64, u64>>>,
+
+    /// Notify when publish alias map is updated.
+    publish_alias_notify: Arc<Notify>,
+
+    /// Queue of inbound PUBLISH events waiting for the application to accept.
+    published_track_queue: Queue<PublishedTrack>,
+
+    /// Tracks which (namespace, name) pairs this endpoint is subscribed to
+    /// (as subscriber role) — covers both outbound SUBSCRIBE and inbound PUBLISH.
+    /// Used for §5.1 same-role duplicate-subscription enforcement.
+    subscriber_names: Arc<Mutex<HashMap<FullTrackName, u64>>>,
+
+    /// Pending REQUEST_UPDATE messages sent by PublishedTrack::set_forward,
+    /// keyed by the REQUEST_UPDATE's own request id.
+    /// When REQUEST_OK / REQUEST_ERROR arrives for one of these ids, the
+    /// corresponding oneshot sender is notified.
+    pending_publish_updates: Arc<Mutex<HashMap<u64, PendingPublishUpdate>>>,
 
     /// The queue we will write any outbound control messages we want to send, the session run_send task
     /// will process the queue and send the message on the control stream.
@@ -66,6 +97,17 @@ pub struct Subscriber {
     mlog: Option<Arc<Mutex<mlog::MlogWriter>>>,
 }
 
+/// Outcome of resolving a Track Alias: which subscription kind owns it.
+///
+/// Track Aliases are session-scoped (§10.1).  SUBSCRIBE and PUBLISH share the
+/// same alias namespace, so lookup must check both maps.
+enum AliasBinding {
+    /// Alias belongs to an outbound SUBSCRIBE; carries the subscribe request id.
+    Subscribe(u64),
+    /// Alias belongs to an inbound PUBLISH; carries the PUBLISH request id.
+    Publish(u64),
+}
+
 impl Subscriber {
     pub(super) fn new(
         outgoing: Queue<Message>,
@@ -78,10 +120,16 @@ impl Subscriber {
             subscribes: Default::default(),
             track_statuses: Default::default(),
             subscribe_alias_map: Default::default(),
+            subscribe_alias_notify: Arc::new(Notify::new()),
+            published_tracks: Default::default(),
+            publish_alias_map: Default::default(),
+            publish_alias_notify: Arc::new(Notify::new()),
+            published_track_queue: Default::default(),
+            subscriber_names: Default::default(),
+            pending_publish_updates: Default::default(),
             outgoing,
             request_id,
             mlog,
-            subscribe_alias_notify: Arc::new(Notify::new()),
         }
     }
 
@@ -125,6 +173,82 @@ impl Subscriber {
     /// Wait for the next inbound PUBLISH_NAMESPACE from the peer, if any.
     pub async fn published_namespace(&mut self) -> Option<PublishedNamespace> {
         self.published_namespace_queue.pop().await
+    }
+
+    /// Wait for the next inbound PUBLISH from the peer, if any.
+    ///
+    /// The returned [`PublishedTrack`] must be accepted with
+    /// [`PublishedTrack::ok`] or dropped to reject.
+    pub async fn published_track(&mut self) -> Option<PublishedTrack> {
+        self.published_track_queue.pop().await
+    }
+
+    /// Take the [`TrackReader`] stored for a PUBLISH request id.
+    ///
+    /// Called by [`PublishedTrack::ok`] exactly once per subscription.
+    pub(super) fn take_published_track_reader(&self, request_id: u64) -> Option<TrackReader> {
+        self.published_tracks
+            .lock()
+            .ok()?
+            .get_mut(&request_id)?
+            .take_reader()
+    }
+
+    /// Remove all subscriber-side state for an inbound PUBLISH.
+    ///
+    /// Called by `PublishedTrack::drop` when the app did not call `ok()`.
+    pub(super) fn remove_published_track(&self, request_id: u64) {
+        if let Ok(mut tracks) = self.published_tracks.lock() {
+            if let Some(recv) = tracks.remove(&request_id) {
+                // Recover the alias so we can clean up the alias map too.
+                drop(recv);
+            }
+        }
+        // Alias cleanup: scan publish_alias_map for entries pointing at this
+        // request id and remove them.
+        // TODO(itzmanish): maintain a reverse map to make this O(1).
+        if let Ok(mut aliases) = self.publish_alias_map.lock() {
+            aliases.retain(|_alias, id| *id != request_id);
+        }
+        // Clean up subscriber_names for this request id.
+        if let Ok(mut names) = self.subscriber_names.lock() {
+            names.retain(|_name, id| *id != request_id);
+        }
+    }
+
+    /// Send REQUEST_UPDATE to toggle Forward state on an established PUBLISH
+    /// subscription (draft-16 §9.11), then wait for REQUEST_OK / REQUEST_ERROR.
+    ///
+    /// Called by [`PublishedTrack::set_forward`].
+    pub(super) async fn send_request_update_for_publish(
+        &mut self,
+        publish_request_id: u64,
+        forward: bool,
+    ) -> Result<(), ServeError> {
+        let update_id = self
+            .get_next_request_id()
+            .map_err(|e| ServeError::internal_ctx(format!("request ID limit: {e}")))?;
+
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        {
+            let mut updates = self
+                .pending_publish_updates
+                .lock()
+                .map_err(|_| ServeError::internal_ctx("pending_publish_updates lock poisoned"))?;
+            updates.insert(update_id, PendingPublishUpdate { result_tx: tx });
+        }
+
+        let mut params = crate::coding::KeyValuePairs::default();
+        params.set_forward(forward);
+
+        self.send_message(message::RequestUpdate {
+            id: update_id,
+            existing_request_id: publish_request_id,
+            params,
+        });
+
+        rx.await
+            .unwrap_or(Err(ServeError::internal_ctx("set_forward sender dropped")))
     }
 
     fn add_mlog_event<F>(&self, make_event: F)
@@ -218,6 +342,25 @@ impl Subscriber {
         let request_id = self
             .get_next_request_id()
             .map_err(|e| ServeError::internal_ctx(format!("request ID limit: {}", e)))?;
+
+        // §5.1: enforce single subscriber-role subscription per track.
+        // Both outbound SUBSCRIBE and inbound PUBLISH make this endpoint the
+        // subscriber for the track.
+        let full_name = FullTrackName {
+            namespace: track.namespace.clone(),
+            name: track.name.clone(),
+        };
+        {
+            let mut names = self
+                .subscriber_names
+                .lock()
+                .map_err(|_| ServeError::internal_ctx("subscriber_names lock poisoned"))?;
+            if names.contains_key(&full_name) {
+                return Err(ServeError::Duplicate);
+            }
+            names.insert(full_name, request_id);
+        }
+
         let (send, recv) = Subscribe::new(self.clone(), request_id, track);
         self.subscribes
             .lock()
@@ -249,11 +392,11 @@ impl Subscriber {
             message::Publisher::PublishNamespaceDone(msg) => {
                 self.recv_publish_namespace_done(msg)?;
             }
-            // PUBLISH (publisher-initiated subscription) not yet implemented.
-            // Send REQUEST_ERROR NOT_SUPPORTED so the publisher knows we cannot accept it.
-            message::Publisher::Publish(msg) => {
-                self.send_not_supported(msg.id, "publish");
-            }
+            // PUBLISH: publisher-initiated subscription (draft-16 §9.13).
+            message::Publisher::Publish(msg) => self.recv_publish(msg)?,
+            // PUBLISH_DONE terminates either a SUBSCRIBE-created or PUBLISH-created
+            // subscription.  The request id alone does not tell us which map to look
+            // in; we check both (§9.15).
             message::Publisher::PublishDone(msg) => self.recv_publish_done(msg)?,
             message::Publisher::SubscribeOk(msg) => self.recv_subscribe_ok(msg)?,
             // Draft-16 shared responses (REQUEST_OK / REQUEST_ERROR).
@@ -270,27 +413,6 @@ impl Subscriber {
         }
 
         Ok(())
-    }
-
-    /// Send REQUEST_ERROR NOT_SUPPORTED for an incoming request we do not implement.
-    ///
-    /// Draft-16 §4: limited endpoints SHOULD respond with NOT_SUPPORTED rather
-    /// than ignoring unsupported request types.
-    fn send_not_supported(&mut self, request_id: u64, request_kind: &str) {
-        tracing::debug!(
-            target: "moq_transport::control",
-            request_id,
-            "sending REQUEST_ERROR NOT_SUPPORTED for unimplemented request"
-        );
-        self.send_request_error(
-            request_kind,
-            message::RequestError {
-                id: request_id,
-                error_code: crate::message::RequestErrorCode::NotSupported as u64,
-                retry_interval: 0,
-                reason: crate::coding::ReasonPhrase("not supported".to_string()),
-            },
-        );
     }
 
     /// Handle reception of an inbound PUBLISH_NAMESPACE from the publisher.
@@ -332,7 +454,7 @@ impl Subscriber {
         Ok(())
     }
 
-    /// Handle the reception of a SubscribeOk message from the publisher.
+    /// Handle the reception of a SUBSCRIBE_OK message from the publisher.
     fn recv_subscribe_ok(&mut self, msg: &message::SubscribeOk) -> Result<(), SessionError> {
         if let Some(subscribe) = self
             .subscribes
@@ -340,23 +462,43 @@ impl Subscriber {
             .map_err(|_| SessionError::Internal)?
             .get_mut(&msg.id)
         {
-            // Map track alias to subscription id for quick lookup when receiving streams/datagrams
+            // Track Aliases are session-scoped (§10.1).  The SUBSCRIBE_OK alias
+            // must not collide with any alias already bound by a SUBSCRIBE or a
+            // PUBLISH subscription.
+            {
+                let sub_aliases = self
+                    .subscribe_alias_map
+                    .lock()
+                    .map_err(|_| SessionError::Internal)?;
+                let pub_aliases = self
+                    .publish_alias_map
+                    .lock()
+                    .map_err(|_| SessionError::Internal)?;
+                if sub_aliases.contains_key(&msg.track_alias)
+                    || pub_aliases.contains_key(&msg.track_alias)
+                {
+                    return Err(SessionError::Duplicate);
+                }
+            }
+
+            // Map track alias → subscription id for quick lookup when receiving
+            // streams/datagrams.
             self.subscribe_alias_map
                 .lock()
                 .map_err(|_| SessionError::Internal)?
                 .insert(msg.track_alias, msg.id);
 
-            // Notify waiting tasks that the alias map has been updated
+            // Notify waiting tasks that the alias map has been updated.
             self.subscribe_alias_notify.notify_waiters();
 
-            // Notify the subscribe of the successful subscription
+            // Notify the subscribe of the successful subscription.
             subscribe.ok(msg.track_alias)?;
         }
 
         Ok(())
     }
 
-    /// Remove a subscribe from our map of active subscribes, and the alias map if present.
+    /// Remove a subscribe from our map of active subscribes, the alias map, and subscriber_names.
     pub(super) fn remove_subscribe(&mut self, id: u64) -> Option<SubscribeRecv> {
         let subscribe = self.subscribes.lock().ok().and_then(|mut s| s.remove(&id));
         if let Some(ref sub) = subscribe {
@@ -366,30 +508,244 @@ impl Subscriber {
                 }
             }
         }
+        // Clean up the subscriber_names entry for this request id.
+        // TODO(itzmanish): maintain a reverse map to make this O(1).
+        if let Ok(mut names) = self.subscriber_names.lock() {
+            names.retain(|_name, req_id| *req_id != id);
+        }
         subscribe
     }
 
-    /// Handle the reception of a PublishDone message from the publisher.
-    fn recv_publish_done(&mut self, msg: &message::PublishDone) -> Result<(), SessionError> {
-        if let Some(subscribe) = self.remove_subscribe(msg.id) {
-            subscribe.error(ServeError::Closed(msg.status_code))?;
+    /// Handle an inbound PUBLISH from the publisher (draft-16 §9.13).
+    ///
+    /// This establishes a publisher-initiated subscription.  The endpoint
+    /// becomes the subscriber for this track.
+    fn recv_publish(&mut self, msg: &message::Publish) -> Result<(), SessionError> {
+        // First-cut policy: reject non-empty TrackExtensions.
+        // We do not yet propagate track extensions through the serve model, so
+        // accepting them would silently drop relay-visible metadata (§8.6).
+        // TODO(itzmanish): lift this restriction once TrackExtensions are
+        // carried through TrackReader/TrackWriter.
+        if !msg.track_extensions.is_empty() {
+            self.send_request_error(
+                "publish",
+                message::RequestError {
+                    id: msg.id,
+                    error_code: RequestErrorCode::NotSupported as u64,
+                    retry_interval: 0,
+                    reason: crate::coding::ReasonPhrase(
+                        "track extensions not supported".to_string(),
+                    ),
+                },
+            );
+            return Ok(());
+        }
+
+        // Track Aliases are session-scoped (§10.1).  Both alias maps share the
+        // namespace, so we must check both for collisions.
+        {
+            let sub_aliases = self
+                .subscribe_alias_map
+                .lock()
+                .map_err(|_| SessionError::Internal)?;
+            let pub_aliases = self
+                .publish_alias_map
+                .lock()
+                .map_err(|_| SessionError::Internal)?;
+            if sub_aliases.contains_key(&msg.track_alias)
+                || pub_aliases.contains_key(&msg.track_alias)
+            {
+                // §9.13: duplicate Track Alias closes the session.
+                return Err(SessionError::Duplicate);
+            }
+        }
+
+        // §5.1: enforce single subscriber-role subscription per track.
+        // Both outbound SUBSCRIBE and inbound PUBLISH make this endpoint the
+        // subscriber for the given (namespace, name).
+        let full_name = FullTrackName {
+            namespace: msg.track_namespace.clone(),
+            name: msg.track_name.clone(),
+        };
+        let duplicate_subscription = {
+            self.subscriber_names
+                .lock()
+                .map_err(|_| SessionError::Internal)?
+                .contains_key(&full_name)
+        };
+        if duplicate_subscription {
+            self.send_request_error(
+                "publish",
+                message::RequestError {
+                    id: msg.id,
+                    error_code: RequestErrorCode::DuplicateSubscription as u64,
+                    retry_interval: 0,
+                    reason: crate::coding::ReasonPhrase("duplicate subscription".to_string()),
+                },
+            );
+            return Ok(());
+        }
+
+        // Parse FORWARD and LARGEST_OBJECT from the PUBLISH params.
+        let initial_forward = msg
+            .params
+            .forward()
+            .map_err(SessionError::Decode)?
+            .unwrap_or(true);
+        let largest_location = msg.params.largest_object().map_err(SessionError::Decode)?;
+
+        // Allocate the track.  The transport owns the writer; the application
+        // receives the reader via PublishedTrack::ok.
+        let (writer, reader) =
+            crate::serve::Track::new(msg.track_namespace.clone(), msg.track_name.clone()).produce();
+
+        // Build both handles sharing the same state.
+        let (published_track, recv) = PublishedTrackRecv::produce(
+            self.clone(),
+            msg.id,
+            msg.track_alias,
+            msg.track_namespace.clone(),
+            msg.track_name.clone(),
+            initial_forward,
+            largest_location,
+            writer,
+            reader,
+        );
+
+        // Register the alias BEFORE queueing the PublishedTrack so that Object
+        // streams racing the PUBLISH (§5.1 allows pre-PUBLISH_OK delivery) can
+        // be resolved immediately.
+        self.publish_alias_map
+            .lock()
+            .map_err(|_| SessionError::Internal)?
+            .insert(msg.track_alias, msg.id);
+        self.publish_alias_notify.notify_waiters();
+
+        // Register subscriber_names so a duplicate SUBSCRIBE or PUBLISH for the
+        // same track is rejected with DUPLICATE_SUBSCRIPTION (§5.1).
+        self.subscriber_names
+            .lock()
+            .map_err(|_| SessionError::Internal)?
+            .insert(full_name, msg.id);
+
+        // Store the transport recv handle keyed by request id.
+        self.published_tracks
+            .lock()
+            .map_err(|_| SessionError::Internal)?
+            .insert(msg.id, recv);
+
+        tracing::debug!(
+            target: "moq_transport::control",
+            request_id = msg.id,
+            track_alias = msg.track_alias,
+            namespace = %msg.track_namespace,
+            name = %msg.track_name,
+            forward = initial_forward,
+            "received PUBLISH"
+        );
+
+        // If the application is no longer listening, drop the PublishedTrack
+        // which sends REQUEST_ERROR back to the publisher.
+        if self.published_track_queue.push(published_track).is_err() {
+            // Queue is closed; clean up state we just inserted.
+            self.publish_alias_map
+                .lock()
+                .ok()
+                .map(|mut m| m.remove(&msg.track_alias));
+            self.published_tracks
+                .lock()
+                .ok()
+                .map(|mut m| m.remove(&msg.id));
+            self.subscriber_names
+                .lock()
+                .ok()
+                .map(|mut m| m.retain(|_, id| *id != msg.id));
         }
 
         Ok(())
     }
 
-    /// Handle REQUEST_OK from the publisher.
+    /// Handle PUBLISH_DONE from the publisher (draft-16 §9.15).
+    ///
+    /// PUBLISH_DONE terminates either a SUBSCRIBE-created subscription
+    /// (publisher sends PUBLISH_DONE after SUBSCRIBE was sent to it) or a
+    /// PUBLISH-created subscription (publisher sends PUBLISH_DONE to end its
+    /// push).  The request id alone does not tell us which map to look in,
+    /// so we check both.
+    fn recv_publish_done(&mut self, msg: &message::PublishDone) -> Result<(), SessionError> {
+        // Check SUBSCRIBE-initiated subscriptions first.
+        if let Some(subscribe) = self.remove_subscribe(msg.id) {
+            subscribe.error(ServeError::Closed(msg.status_code))?;
+            return Ok(());
+        }
+
+        // Then check PUBLISH-initiated subscriptions.
+        let recv = self
+            .published_tracks
+            .lock()
+            .map_err(|_| SessionError::Internal)?
+            .remove(&msg.id);
+        if let Some(mut recv) = recv {
+            recv.recv_done(msg.status_code);
+            // Clean up alias and name maps.
+            // TODO(itzmanish): maintain reverse maps to make these O(1).
+            if let Ok(mut aliases) = self.publish_alias_map.lock() {
+                aliases.retain(|_alias, id| *id != msg.id);
+            }
+            if let Ok(mut names) = self.subscriber_names.lock() {
+                names.retain(|_name, id| *id != msg.id);
+            }
+        } else {
+            tracing::debug!(
+                target: "moq_transport::control",
+                request_id = msg.id,
+                "received PUBLISH_DONE for unknown subscription — ignoring"
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Handle REQUEST_OK from the publisher (draft-16 §9.7).
     ///
     /// REQUEST_OK is the shared positive response for REQUEST_UPDATE, TRACK_STATUS,
     /// SUBSCRIBE_NAMESPACE, and PUBLISH_NAMESPACE. SUBSCRIBE uses its own dedicated
     /// SUBSCRIBE_OK message (§9.10) and does not come through this handler.
     fn recv_request_ok(&mut self, msg: &message::RequestOk) -> Result<(), SessionError> {
-        let request_kind = if self.drop_track_status(msg.id)? {
-            "track_status"
-        } else {
-            "unknown"
-        };
+        if self.drop_track_status(msg.id)? {
+            let request_kind = "track_status";
+            self.log_request_ok_parsed(request_kind, msg);
+            tracing::debug!(
+                target: "moq_transport::control",
+                request_id = msg.id,
+                request_kind,
+                "received REQUEST_OK"
+            );
+            return Ok(());
+        }
 
+        // Check if this is a response to a pending REQUEST_UPDATE from set_forward.
+        let pending = self
+            .pending_publish_updates
+            .lock()
+            .map_err(|_| SessionError::Internal)?
+            .remove(&msg.id);
+
+        if let Some(update) = pending {
+            let request_kind = "request_update";
+            self.log_request_ok_parsed(request_kind, msg);
+            tracing::debug!(
+                target: "moq_transport::control",
+                request_id = msg.id,
+                request_kind,
+                "received REQUEST_OK"
+            );
+            // Wake the set_forward caller with success.
+            let _ = update.result_tx.send(Ok(()));
+            return Ok(());
+        }
+
+        let request_kind = "unknown";
         self.log_request_ok_parsed(request_kind, msg);
         tracing::debug!(
             target: "moq_transport::control",
@@ -400,25 +756,67 @@ impl Subscriber {
         Ok(())
     }
 
-    /// Handle REQUEST_ERROR from the publisher.
+    /// Handle REQUEST_ERROR from the publisher (draft-16 §9.8).
     ///
-    /// Routes to the matching active subscribe (via request ID) if one
-    /// exists, otherwise logs and ignores.  Full per-flow routing is
-    /// wired up (TODO itzmanish).
+    /// Routes to: active SUBSCRIBE (by request id), pending REQUEST_UPDATE
+    /// from set_forward, or logs and ignores.
     fn recv_request_error(&mut self, msg: &message::RequestError) -> Result<(), SessionError> {
-        // Route to a matching subscribe if present.
+        // Route to a matching SUBSCRIBE if present.
         if let Some(subscribe) = self.remove_subscribe(msg.id) {
             self.log_request_error_parsed("subscribe", msg);
             subscribe.error(ServeError::Closed(msg.error_code))?;
+            tracing::debug!(
+                target: "moq_transport::control",
+                request_id = msg.id,
+                request_kind = "subscribe",
+                error_code = msg.error_code,
+                retry_interval = msg.retry_interval,
+                reason = %msg.reason.0,
+                "received REQUEST_ERROR"
+            );
+            return Ok(());
         } else if self.drop_track_status(msg.id)? {
             self.log_request_error_parsed("track_status", msg);
-        } else {
-            self.log_request_error_parsed("unknown", msg);
+            tracing::debug!(
+                target: "moq_transport::control",
+                request_id = msg.id,
+                request_kind = "track_status",
+                error_code = msg.error_code,
+                retry_interval = msg.retry_interval,
+                reason = %msg.reason.0,
+                "received REQUEST_ERROR"
+            );
+            return Ok(());
         }
 
+        // Route to a pending REQUEST_UPDATE from PublishedTrack::set_forward.
+        let pending = self
+            .pending_publish_updates
+            .lock()
+            .map_err(|_| SessionError::Internal)?
+            .remove(&msg.id);
+        if let Some(update) = pending {
+            self.log_request_error_parsed("request_update", msg);
+            tracing::debug!(
+                target: "moq_transport::control",
+                request_id = msg.id,
+                request_kind = "request_update",
+                error_code = msg.error_code,
+                retry_interval = msg.retry_interval,
+                reason = %msg.reason.0,
+                "received REQUEST_ERROR"
+            );
+            let _ = update
+                .result_tx
+                .send(Err(ServeError::Closed(msg.error_code)));
+            return Ok(());
+        }
+
+        self.log_request_error_parsed("unknown", msg);
         tracing::debug!(
             target: "moq_transport::control",
             request_id = msg.id,
+            request_kind = "unknown",
             error_code = msg.error_code,
             retry_interval = msg.retry_interval,
             reason = %msg.reason.0,
@@ -448,25 +846,49 @@ impl Subscriber {
         None
     }
 
-    /// Get a subscribe id by track alias, waiting up to the specified timeout if not present.
-    /// If timeout_ms is None, only check if already present and return None if not.
-    async fn get_subscribe_id_by_alias(
+    /// Resolve a Track Alias to the request id and subscription kind.
+    ///
+    /// Checks both alias maps in order:
+    ///   1. `subscribe_alias_map` (populated by SUBSCRIBE_OK).
+    ///   2. `publish_alias_map`   (populated eagerly by recv_publish before PUBLISH_OK).
+    ///
+    /// PUBLISH aliases are registered before PUBLISH_OK so that Object streams
+    /// racing the control message (§5.1 allows pre-PUBLISH_OK delivery) route
+    /// correctly.  The SUBSCRIBE map still uses a wait-with-timeout because
+    /// SUBSCRIBE_OK may arrive after the stream due to buffering.
+    ///
+    /// Returns `None` if the alias is not found within the timeout.
+    async fn resolve_alias(
         &self,
         track_alias: u64,
         timeout_ms: Option<u64>,
-    ) -> Result<Option<u64>, SessionError> {
-        // If no timeout specified, don't wait
+    ) -> Result<Option<AliasBinding>, SessionError> {
+        // Check the PUBLISH alias map first (no wait needed: inserted eagerly).
+        {
+            let pub_map = self
+                .publish_alias_map
+                .lock()
+                .map_err(|_| SessionError::Internal)?;
+            if let Some(&req_id) = pub_map.get(&track_alias) {
+                return Ok(Some(AliasBinding::Publish(req_id)));
+            }
+        }
+
+        // Fall through to the SUBSCRIBE alias map, which may need a brief wait.
         let timeout_ms = match timeout_ms {
             Some(ms) => ms,
             None => {
-                // Just check once
+                // Caller does not want to wait — check once and return.
                 return match self.subscribe_alias_map.lock() {
-                    Ok(aliases) => Ok(aliases.get(&track_alias).cloned()),
+                    Ok(aliases) => Ok(aliases
+                        .get(&track_alias)
+                        .copied()
+                        .map(AliasBinding::Subscribe)),
                     Err(_) => {
                         tracing::error!(
                             target: "moq_transport::control",
                             track_alias,
-                            "subscribe alias map lock poisoned"
+                            "subscribe_alias_map lock poisoned"
                         );
                         Err(SessionError::Internal)
                     }
@@ -474,36 +896,58 @@ impl Subscriber {
             }
         };
 
-        // Wait for it to appear, checking after each notification
+        // Wait for the alias to appear in the SUBSCRIBE map.
         let timeout_duration = Duration::from_millis(timeout_ms);
         tokio::time::timeout(timeout_duration, async {
             loop {
-                // Register for notification before checking map
+                // Register notification before checking to avoid a TOCTOU gap.
                 let notified = self.subscribe_alias_notify.notified();
 
-                // Check Map for alias
-                let id = match self.subscribe_alias_map.lock() {
-                    Ok(aliases) => aliases.get(&track_alias).cloned(),
+                // Re-check PUBLISH map first in case it was just inserted.
+                {
+                    let pub_map = match self.publish_alias_map.lock() {
+                        Ok(m) => m,
+                        Err(_) => return Err(SessionError::Internal),
+                    };
+                    if let Some(&req_id) = pub_map.get(&track_alias) {
+                        return Ok(Some(AliasBinding::Publish(req_id)));
+                    }
+                }
+
+                let sub_id = match self.subscribe_alias_map.lock() {
+                    Ok(aliases) => aliases.get(&track_alias).copied(),
                     Err(_) => {
                         tracing::error!(
                             target: "moq_transport::control",
                             track_alias,
-                            "subscribe alias map lock poisoned"
+                            "subscribe_alias_map lock poisoned"
                         );
                         return Err(SessionError::Internal);
                     }
                 };
 
-                if let Some(id) = id {
-                    return Ok(Some(id));
+                if let Some(id) = sub_id {
+                    return Ok(Some(AliasBinding::Subscribe(id)));
                 }
 
-                // Alias not present yet, wait for notification
                 notified.await;
             }
         })
         .await
         .unwrap_or(Ok(None))
+    }
+
+    /// Legacy helper — kept for the error-recovery path in `recv_stream`.
+    /// Returns the SUBSCRIBE request id only.
+    async fn get_subscribe_id_by_alias(
+        &self,
+        track_alias: u64,
+        timeout_ms: Option<u64>,
+    ) -> Result<Option<u64>, SessionError> {
+        match self.resolve_alias(track_alias, timeout_ms).await? {
+            Some(AliasBinding::Subscribe(id)) => Ok(Some(id)),
+            Some(AliasBinding::Publish(_)) | None => Ok(None),
+        }
     }
 
     /// Handle reception of a new stream from the QUIC session.
@@ -582,25 +1026,44 @@ impl Subscriber {
             track_alias
         );
 
-        let Some(subscribe_id) = self
-            .get_subscribe_id_by_alias(track_alias, Some(DEFAULT_ALIAS_WAIT_TIME_MS))
-            .await?
-        else {
-            return Err(SessionError::Serve(ServeError::not_found_ctx(format!(
-                "subscription track_alias={} not found",
-                track_alias
-            ))));
-        };
+        let binding = self
+            .resolve_alias(track_alias, Some(DEFAULT_ALIAS_WAIT_TIME_MS))
+            .await?;
 
-        tracing::trace!("[SUBSCRIBER] recv_stream_inner: receiving subgroup data");
-        self.recv_subgroup(
-            stream_header_type,
-            subgroup_header,
-            subscribe_id,
-            reader,
-            mlog,
-        )
-        .await?;
+        match binding {
+            Some(AliasBinding::Subscribe(subscribe_id)) => {
+                tracing::trace!(
+                    "[SUBSCRIBER] recv_stream_inner: receiving subgroup data (SUBSCRIBE)"
+                );
+                self.recv_subgroup(
+                    stream_header_type,
+                    subgroup_header,
+                    subscribe_id,
+                    reader,
+                    mlog,
+                )
+                .await?;
+            }
+            Some(AliasBinding::Publish(publish_id)) => {
+                tracing::trace!(
+                    "[SUBSCRIBER] recv_stream_inner: receiving subgroup data (PUBLISH)"
+                );
+                self.recv_subgroup_publish(
+                    stream_header_type,
+                    subgroup_header,
+                    publish_id,
+                    reader,
+                    mlog,
+                )
+                .await?;
+            }
+            None => {
+                return Err(SessionError::Serve(ServeError::not_found_ctx(format!(
+                    "track_alias={} not found in subscribe or publish maps",
+                    track_alias
+                ))));
+            }
+        }
 
         tracing::trace!(
             "[SUBSCRIBER] recv_stream_inner: completed processing stream for track_alias={}",
@@ -609,17 +1072,26 @@ impl Subscriber {
         Ok(())
     }
 
-    /// If new stream is a Subgroup stream, handle reception of subgroup objects and payloads.
-    async fn recv_subgroup(
-        &mut self,
+    /// Decode subgroup objects from a stream and write them via `get_writer`.
+    ///
+    /// This is the single implementation of the subgroup receive loop shared
+    /// by both SUBSCRIBE-initiated and PUBLISH-initiated subscriptions.
+    ///
+    /// `get_writer` is called once — on the first object in the subgroup — to
+    /// obtain a `SubgroupWriter`.  It receives the (possibly updated) subgroup
+    /// header and must open the writer against the correct map entry (either
+    /// `subscribes` for outbound SUBSCRIBE, or `published_tracks` for inbound
+    /// PUBLISH).  Keeping this as a closure avoids duplicating ~100 lines of
+    /// object decoding, ID tracking, validation, logging, and payload reading.
+    async fn recv_subgroup_objects(
         stream_header_type: data::StreamHeaderType,
         mut subgroup_header: data::SubgroupHeader,
-        subscribe_id: u64,
         mut reader: Reader,
         mlog: Option<Arc<Mutex<mlog::MlogWriter>>>,
+        mut get_writer: impl FnMut(data::SubgroupHeader) -> Result<serve::SubgroupWriter, SessionError>,
     ) -> Result<(), SessionError> {
         tracing::trace!(
-            "[SUBSCRIBER] recv_subgroup: starting - group_id={}, subgroup_id={:?}, priority={}",
+            "[SUBSCRIBER] recv_subgroup_objects: starting - group_id={}, subgroup_id={:?}, priority={}",
             subgroup_header.group_id,
             subgroup_header.subgroup_id,
             subgroup_header.publisher_priority
@@ -628,88 +1100,65 @@ impl Subscriber {
         let mut object_count = 0;
         let mut previous_object_id: Option<u64> = None;
         let mut subgroup_writer: Option<serve::SubgroupWriter> = None;
-        while !reader.done().await? {
-            tracing::trace!(
-                "[SUBSCRIBER] recv_subgroup: reading object #{} (has_ext_headers={})",
-                object_count + 1,
-                stream_header_type.has_extension_headers()
-            );
 
-            // Need to be able to decode the subgroup object conditionally based on the stream header type
-            // read the object payload length into remaining_bytes
+        while !reader.done().await? {
+            // Decode the object header.  Extension-header variant carries extra
+            // relay-visible fields; plain variant does not.
             let (mut remaining_bytes, object_id_delta, status, decoded_object) =
-                match stream_header_type.has_extension_headers() {
-                    true => {
-                        let object = reader.decode::<data::SubgroupObjectExt>().await?;
-                        tracing::trace!(
-                        "[SUBSCRIBER] recv_subgroup: object #{} with extension headers - object_id_delta={}, payload_length={}, status={:?}, extension_headers={:?}",
+                if stream_header_type.has_extension_headers() {
+                    let object = reader.decode::<data::SubgroupObjectExt>().await?;
+                    tracing::trace!(
+                        "[SUBSCRIBER] recv_subgroup_objects: object #{} with ext headers \
+                         object_id_delta={} payload={} status={:?} ext={:?}",
                         object_count + 1,
                         object.object_id_delta,
                         object.payload_length,
                         object.status,
                         object.extension_headers
                     );
-
-                        // Check for known draft-14 extension types
-
-                        // Check for Immutable Extensions (type 0xB = 11)
-                        if object.extension_headers.has(0xB) {
-                            tracing::trace!(
-                                "[SUBSCRIBER] recv_subgroup: object #{} contains IMMUTABLE EXTENSIONS (type 0xB) - will be forwarded",
-                                object_count + 1
-                            );
-                            if let Some(immutable_ext) = object.extension_headers.get(0xB) {
-                                tracing::trace!(
-                                    "[SUBSCRIBER] recv_subgroup: immutable extension details: {:?}",
-                                    immutable_ext
-                                );
-                            }
-                        }
-
-                        // Check for Prior Group ID Gap (type 0x3C = 60)
-                        if object.extension_headers.has(0x3C) {
-                            tracing::trace!(
-                                "[SUBSCRIBER] recv_subgroup: object #{} contains PRIOR GROUP ID GAP (type 0x3C)",
-                                object_count + 1
-                            );
-                            if let Some(gap_ext) = object.extension_headers.get(0x3C) {
-                                tracing::trace!(
-                                    "[SUBSCRIBER] recv_subgroup: prior group id gap details: {:?}",
-                                    gap_ext
-                                );
-                            }
-                        }
-
-                        let obj_copy = object.clone();
-                        (
-                            object.payload_length,
-                            object.object_id_delta,
-                            object.status,
-                            Some(obj_copy),
-                        )
-                    }
-                    false => {
-                        let object = reader.decode::<data::SubgroupObject>().await?;
+                    // Check for known draft-14 extension types
+                    if object.extension_headers.has(0xB) {
                         tracing::trace!(
-                        "[SUBSCRIBER] recv_subgroup: object #{} - object_id_delta={}, payload_length={}, status={:?}",
+                            "[SUBSCRIBER] recv_subgroup_objects: object #{} has IMMUTABLE EXTENSIONS (0xB)",
+                            object_count + 1
+                        );
+                    }
+                    if object.extension_headers.has(0x3C) {
+                        tracing::trace!(
+                            "[SUBSCRIBER] recv_subgroup_objects: object #{} has PRIOR GROUP ID GAP (0x3C)",
+                            object_count + 1
+                        );
+                    }
+                    let obj_copy = object.clone();
+                    (
+                        object.payload_length,
+                        object.object_id_delta,
+                        object.status,
+                        Some(obj_copy),
+                    )
+                } else {
+                    let object = reader.decode::<data::SubgroupObject>().await?;
+                    tracing::trace!(
+                        "[SUBSCRIBER] recv_subgroup_objects: object #{} \
+                         object_id_delta={} payload={} status={:?}",
                         object_count + 1,
                         object.object_id_delta,
                         object.payload_length,
                         object.status
                     );
-                        (
-                            object.payload_length,
-                            object.object_id_delta,
-                            object.status,
-                            None,
-                        )
-                    }
+                    (
+                        object.payload_length,
+                        object.object_id_delta,
+                        object.status,
+                        None,
+                    )
                 };
 
+            // Compute the absolute object ID from the delta.
             let current_object_id = match previous_object_id {
-                Some(previous) => previous
+                Some(prev) => prev
                     .checked_add(object_id_delta)
-                    .and_then(|value| value.checked_add(1))
+                    .and_then(|v| v.checked_add(1))
                     .ok_or_else(|| {
                         SessionError::ProtocolViolation("subgroup object id overflow".to_string())
                     })?,
@@ -717,38 +1166,26 @@ impl Subscriber {
             };
             previous_object_id = Some(current_object_id);
 
-            // Extract extension headers if present
-            let extension_headers = decoded_object
-                .as_ref()
-                .map(|obj| obj.extension_headers.clone());
+            let extension_headers = decoded_object.as_ref().map(|o| o.extension_headers.clone());
 
-            if status.is_some_and(|status| status != data::ObjectStatus::NormalObject)
-                && extension_headers
-                    .as_ref()
-                    .is_some_and(|headers| !headers.is_empty())
+            // Non-normal status with extension headers is a protocol violation.
+            if status.is_some_and(|s| s != data::ObjectStatus::NormalObject)
+                && extension_headers.as_ref().is_some_and(|h| !h.is_empty())
             {
                 return Err(SessionError::ProtocolViolation(
                     "non-normal object status with extension headers".to_string(),
                 ));
             }
 
+            // Open the subgroup writer on the first object.
             if subgroup_writer.is_none() {
                 if stream_header_type.uses_first_object_id_as_subgroup_id() {
                     subgroup_header.subgroup_id = Some(current_object_id);
                 }
-
-                let mut subscribes = self.subscribes.lock().map_err(|_| SessionError::Internal)?;
-                let subscribe = subscribes.get_mut(&subscribe_id).ok_or_else(|| {
-                    ServeError::not_found_ctx(format!(
-                        "subscribe_id={} not found for track_alias={}",
-                        subscribe_id, subgroup_header.track_alias
-                    ))
-                })?;
-
-                subgroup_writer = Some(subscribe.subgroup(subgroup_header.clone())?);
+                subgroup_writer = Some(get_writer(subgroup_header.clone())?);
             }
 
-            // Log subgroup object parsed/received
+            // Log the object.
             if let Some(ref mlog) = mlog {
                 if let Ok(mut mlog_guard) = mlog.lock() {
                     let time = mlog_guard.elapsed_ms();
@@ -782,58 +1219,93 @@ impl Subscriber {
                 }
             }
 
-            // Pass extension headers through to the serve layer
+            // Write the object payload.
             // TODO SLG - object_id_delta and object status are still being ignored
-
             let subgroup_writer = subgroup_writer.as_mut().ok_or(SessionError::Internal)?;
             let mut object_writer = subgroup_writer.create(remaining_bytes, extension_headers)?;
-            tracing::trace!(
-                "[SUBSCRIBER] recv_subgroup: reading payload for object #{} ({} bytes)",
-                object_count + 1,
-                remaining_bytes
-            );
 
-            let mut chunks_read = 0;
             while remaining_bytes > 0 {
-                let data = reader
-                    .read_chunk(remaining_bytes)
-                    .await?
-                    .ok_or_else(|| {
-                        tracing::error!(
-                            "[SUBSCRIBER] recv_subgroup: ERROR - stream ended with {} bytes remaining for object #{}",
-                            remaining_bytes,
-                            object_count + 1
-                        );
-                        SessionError::WrongSize
-                    })?;
-                tracing::trace!(
-                    "[SUBSCRIBER] recv_subgroup: received payload chunk #{} for object #{} ({} bytes, {} remaining)",
-                    chunks_read + 1,
-                    object_count + 1,
-                    data.len(),
-                    remaining_bytes - data.len()
-                );
-                remaining_bytes -= data.len();
-                object_writer.write(data)?;
-                chunks_read += 1;
+                let chunk = reader.read_chunk(remaining_bytes).await?.ok_or_else(|| {
+                    tracing::error!(
+                        "[SUBSCRIBER] recv_subgroup_objects: stream ended with {} bytes remaining",
+                        remaining_bytes
+                    );
+                    SessionError::WrongSize
+                })?;
+                remaining_bytes -= chunk.len();
+                object_writer.write(chunk)?;
             }
 
-            tracing::trace!(
-                "[SUBSCRIBER] recv_subgroup: completed object #{} ({} chunks)",
-                object_count + 1,
-                chunks_read
-            );
             object_count += 1;
         }
 
         tracing::trace!(
-            "[SUBSCRIBER] recv_subgroup: completed subgroup (group_id={}, subgroup_id={}, {} objects received)",
+            "[SUBSCRIBER] recv_subgroup_objects: completed (group_id={}, subgroup_id={}, {} objects)",
             subgroup_header.group_id,
             subgroup_header.subgroup_id.unwrap_or(0),
             object_count
         );
-
         Ok(())
+    }
+
+    /// Handle subgroup stream data for a SUBSCRIBE-initiated subscription.
+    async fn recv_subgroup(
+        &mut self,
+        stream_header_type: data::StreamHeaderType,
+        subgroup_header: data::SubgroupHeader,
+        subscribe_id: u64,
+        reader: Reader,
+        mlog: Option<Arc<Mutex<mlog::MlogWriter>>>,
+    ) -> Result<(), SessionError> {
+        let subscribes = self.subscribes.clone();
+        Self::recv_subgroup_objects(
+            stream_header_type,
+            subgroup_header,
+            reader,
+            mlog,
+            move |header| {
+                let mut map = subscribes.lock().map_err(|_| SessionError::Internal)?;
+                let recv = map.get_mut(&subscribe_id).ok_or_else(|| {
+                    SessionError::Serve(ServeError::not_found_ctx(format!(
+                        "subscribe_id={} not found for track_alias={}",
+                        subscribe_id, header.track_alias
+                    )))
+                })?;
+                Ok(recv.subgroup(header)?)
+            },
+        )
+        .await
+    }
+
+    /// Handle subgroup stream data for a PUBLISH-initiated subscription.
+    async fn recv_subgroup_publish(
+        &mut self,
+        stream_header_type: data::StreamHeaderType,
+        subgroup_header: data::SubgroupHeader,
+        publish_id: u64,
+        reader: Reader,
+        mlog: Option<Arc<Mutex<mlog::MlogWriter>>>,
+    ) -> Result<(), SessionError> {
+        let published_tracks = self.published_tracks.clone();
+        Self::recv_subgroup_objects(
+            stream_header_type,
+            subgroup_header,
+            reader,
+            mlog,
+            move |header| {
+                let mut map = published_tracks
+                    .lock()
+                    .map_err(|_| SessionError::Internal)?;
+                let recv = map.get_mut(&publish_id).ok_or_else(|| {
+                    SessionError::Serve(ServeError::not_found_ctx(format!(
+                        "publish_id={} not found for track_alias={}",
+                        publish_id, header.track_alias
+                    )))
+                })?;
+                Ok(recv.subgroup(header)?)
+            },
+        )
+        .await
     }
 
     /// Handle reception of a datagram from the QUIC session.
@@ -886,38 +1358,54 @@ impl Subscriber {
             }
         }
 
-        // Look up the subscribe id for this track alias
-        if let Some(subscribe_id) = self
-            .get_subscribe_id_by_alias(datagram.track_alias, Some(DEFAULT_ALIAS_WAIT_TIME_MS))
-            .await?
-        {
-            // Look up the subscribe by id
-            if let Some(subscribe) = self
-                .subscribes
-                .lock()
-                .ok()
-                .as_mut()
-                .and_then(|s| s.get_mut(&subscribe_id))
-            {
-                tracing::trace!(
-                    "[SUBSCRIBER] recv_datagram: track_alias={}, group_id={}, object_id={}, publisher_priority={}, status={}, payload_length={}",
-                    datagram.track_alias,
-                    datagram.group_id,
-                    datagram.object_id.unwrap_or(0),
-                    datagram.publisher_priority,
-                    datagram.status.as_ref().map_or("None".to_string(), |s| format!("{:?}", s)),
-                    datagram.payload.as_ref().map_or(0, |p| p.len()));
-                subscribe.datagram(datagram)?;
+        let track_alias = datagram.track_alias;
+        let binding = self
+            .resolve_alias(track_alias, Some(DEFAULT_ALIAS_WAIT_TIME_MS))
+            .await?;
+
+        match binding {
+            Some(AliasBinding::Subscribe(subscribe_id)) => {
+                if let Some(subscribe) = self
+                    .subscribes
+                    .lock()
+                    .ok()
+                    .as_mut()
+                    .and_then(|s| s.get_mut(&subscribe_id))
+                {
+                    tracing::trace!(
+                        "[SUBSCRIBER] recv_datagram (SUBSCRIBE): track_alias={}, group_id={}, object_id={}",
+                        track_alias,
+                        datagram.group_id,
+                        datagram.object_id.unwrap_or(0)
+                    );
+                    subscribe.datagram(datagram)?;
+                }
             }
-        } else {
-            tracing::warn!(
-                "[SUBSCRIBER] recv_datagram: discarded due to unknown track_alias: track_alias={}, group_id={}, object_id={}, publisher_priority={}, status={}, payload_length={}",
-                datagram.track_alias,
-                datagram.group_id,
-                datagram.object_id.unwrap_or(0),
-                datagram.publisher_priority,
-                datagram.status.as_ref().map_or("None".to_string(), |s| format!("{:?}", s)),
-                datagram.payload.as_ref().map_or(0, |p| p.len()));
+            Some(AliasBinding::Publish(publish_id)) => {
+                if let Some(recv) = self
+                    .published_tracks
+                    .lock()
+                    .ok()
+                    .as_mut()
+                    .and_then(|m| m.get_mut(&publish_id))
+                {
+                    tracing::trace!(
+                        "[SUBSCRIBER] recv_datagram (PUBLISH): track_alias={}, group_id={}, object_id={}",
+                        track_alias,
+                        datagram.group_id,
+                        datagram.object_id.unwrap_or(0)
+                    );
+                    recv.datagram(datagram)?;
+                }
+            }
+            None => {
+                tracing::warn!(
+                    "[SUBSCRIBER] recv_datagram: discarded due to unknown track_alias={}, group_id={}, object_id={}",
+                    track_alias,
+                    datagram.group_id,
+                    datagram.object_id.unwrap_or(0)
+                );
+            }
         }
 
         Ok(())

--- a/moq-transport/src/session/subscriber.rs
+++ b/moq-transport/src/session/subscriber.rs
@@ -22,9 +22,9 @@ use crate::{
 use crate::watch::Queue;
 
 use super::{
-    PendingPublishUpdate, PublishedNamespace, PublishedNamespaceRecv, PublishedTrack,
-    PublishedTrackRecv, Reader, RequestId, RequestIdAllocation, Session, SessionConfig,
-    SessionError, Subscribe, SubscribeRecv,
+    PublishReceived, PublishReceivedRecv, PublishedNamespace, PublishedNamespaceRecv, Reader,
+    RequestId, RequestIdAllocation, Session, SessionConfig, SessionError, Subscribe,
+    SubscribeRecv,
 };
 
 // Default timeout for waiting for subscribe aliases to become available via SUBSCRIBE_OK (1 second)
@@ -45,41 +45,29 @@ pub struct Subscriber {
     /// Outbound TRACK_STATUS requests awaiting a shared REQUEST_OK / REQUEST_ERROR response.
     track_statuses: Arc<Mutex<HashSet<u64>>>,
 
-    /// Map of track alias → SUBSCRIBE request id.
-    /// Populated on SUBSCRIBE_OK.  Both alias maps must be collision-free:
-    /// Track Aliases are session-scoped (§10.1), so SUBSCRIBE and PUBLISH aliases
-    /// share the same namespace.
-    subscribe_alias_map: Arc<Mutex<HashMap<u64, u64>>>,
+    /// Unified map of Track Alias → owning subscription (draft-16 §10.1).
+    ///
+    /// Track Aliases are session-scoped and shared between SUBSCRIBE-initiated
+    /// and PUBLISH-initiated subscriptions, so a single map keyed by alias
+    /// resolves an inbound stream/datagram to the correct receiver.
+    track_alias_map: Arc<Mutex<HashMap<u64, TrackOrigin>>>,
 
-    /// Notify when subscribe alias map is updated.
-    subscribe_alias_notify: Arc<Notify>,
+    /// Notify when `track_alias_map` is updated (for stream/datagram routing
+    /// that may arrive before SUBSCRIBE_OK populates the alias).
+    track_alias_notify: Arc<Notify>,
 
     /// Active inbound PUBLISH subscriptions, keyed by PUBLISH request id.
     /// The transport writes Objects into the TrackWriter stored here;
-    /// the application receives the TrackReader from PublishedTrack::ok.
-    published_tracks: Arc<Mutex<HashMap<u64, PublishedTrackRecv>>>,
-
-    /// Map of track alias → PUBLISH request id.
-    /// Track Aliases are session-scoped (§10.1), so both alias maps must be
-    /// checked together when validating incoming alias usage.
-    publish_alias_map: Arc<Mutex<HashMap<u64, u64>>>,
-
-    /// Notify when publish alias map is updated.
-    publish_alias_notify: Arc<Notify>,
+    /// the application receives the TrackReader from PublishReceived::ok.
+    publishes_received: Arc<Mutex<HashMap<u64, PublishReceivedRecv>>>,
 
     /// Queue of inbound PUBLISH events waiting for the application to accept.
-    published_track_queue: Queue<PublishedTrack>,
+    publish_received_queue: Queue<PublishReceived>,
 
     /// Tracks which (namespace, name) pairs this endpoint is subscribed to
     /// (as subscriber role) — covers both outbound SUBSCRIBE and inbound PUBLISH.
     /// Used for §5.1 same-role duplicate-subscription enforcement.
     subscriber_names: Arc<Mutex<HashMap<FullTrackName, u64>>>,
-
-    /// Pending REQUEST_UPDATE messages sent by PublishedTrack::set_forward,
-    /// keyed by the REQUEST_UPDATE's own request id.
-    /// When REQUEST_OK / REQUEST_ERROR arrives for one of these ids, the
-    /// corresponding oneshot sender is notified.
-    pending_publish_updates: Arc<Mutex<HashMap<u64, PendingPublishUpdate>>>,
 
     /// The queue we will write any outbound control messages we want to send, the session run_send task
     /// will process the queue and send the message on the control stream.
@@ -97,11 +85,13 @@ pub struct Subscriber {
     mlog: Option<Arc<Mutex<mlog::MlogWriter>>>,
 }
 
-/// Outcome of resolving a Track Alias: which subscription kind owns it.
+/// Which subscription owns a given Track Alias (draft-16 §10.1).
 ///
-/// Track Aliases are session-scoped (§10.1).  SUBSCRIBE and PUBLISH share the
-/// same alias namespace, so lookup must check both maps.
-enum AliasBinding {
+/// SUBSCRIBE and PUBLISH share one session-scoped alias namespace, so a single
+/// `track_alias_map` keyed by alias resolves inbound streams/datagrams to the
+/// correct receiver.
+#[derive(Clone, Copy, Debug)]
+enum TrackOrigin {
     /// Alias belongs to an outbound SUBSCRIBE; carries the subscribe request id.
     Subscribe(u64),
     /// Alias belongs to an inbound PUBLISH; carries the PUBLISH request id.
@@ -119,14 +109,11 @@ impl Subscriber {
             published_namespace_queue: Default::default(),
             subscribes: Default::default(),
             track_statuses: Default::default(),
-            subscribe_alias_map: Default::default(),
-            subscribe_alias_notify: Arc::new(Notify::new()),
-            published_tracks: Default::default(),
-            publish_alias_map: Default::default(),
-            publish_alias_notify: Arc::new(Notify::new()),
-            published_track_queue: Default::default(),
+            track_alias_map: Default::default(),
+            track_alias_notify: Arc::new(Notify::new()),
+            publishes_received: Default::default(),
+            publish_received_queue: Default::default(),
             subscriber_names: Default::default(),
-            pending_publish_updates: Default::default(),
             outgoing,
             request_id,
             mlog,
@@ -177,17 +164,17 @@ impl Subscriber {
 
     /// Wait for the next inbound PUBLISH from the peer, if any.
     ///
-    /// The returned [`PublishedTrack`] must be accepted with
-    /// [`PublishedTrack::ok`] or dropped to reject.
-    pub async fn published_track(&mut self) -> Option<PublishedTrack> {
-        self.published_track_queue.pop().await
+    /// The returned [`PublishReceived`] must be accepted with
+    /// [`PublishReceived::ok`] or dropped to reject.
+    pub async fn publish_received(&mut self) -> Option<PublishReceived> {
+        self.publish_received_queue.pop().await
     }
 
     /// Take the [`TrackReader`] stored for a PUBLISH request id.
     ///
-    /// Called by [`PublishedTrack::ok`] exactly once per subscription.
-    pub(super) fn take_published_track_reader(&self, request_id: u64) -> Option<TrackReader> {
-        self.published_tracks
+    /// Called by [`PublishReceived::ok`] exactly once per subscription.
+    pub(super) fn take_publish_received_reader(&self, request_id: u64) -> Option<TrackReader> {
+        self.publishes_received
             .lock()
             .ok()?
             .get_mut(&request_id)?
@@ -196,59 +183,22 @@ impl Subscriber {
 
     /// Remove all subscriber-side state for an inbound PUBLISH.
     ///
-    /// Called by `PublishedTrack::drop` when the app did not call `ok()`.
-    pub(super) fn remove_published_track(&self, request_id: u64) {
-        if let Ok(mut tracks) = self.published_tracks.lock() {
-            if let Some(recv) = tracks.remove(&request_id) {
-                // Recover the alias so we can clean up the alias map too.
-                drop(recv);
-            }
+    /// Called by `PublishReceived::drop` when the app did not call `ok()`.
+    pub(super) fn remove_publish_received(&self, request_id: u64) {
+        if let Ok(mut tracks) = self.publishes_received.lock() {
+            tracks.remove(&request_id);
         }
-        // Alias cleanup: scan publish_alias_map for entries pointing at this
-        // request id and remove them.
+        // Alias cleanup: remove the alias entry pointing at this PUBLISH.
         // TODO(itzmanish): maintain a reverse map to make this O(1).
-        if let Ok(mut aliases) = self.publish_alias_map.lock() {
-            aliases.retain(|_alias, id| *id != request_id);
+        if let Ok(mut aliases) = self.track_alias_map.lock() {
+            aliases.retain(
+                |_alias, origin| !matches!(origin, TrackOrigin::Publish(id) if *id == request_id),
+            );
         }
         // Clean up subscriber_names for this request id.
         if let Ok(mut names) = self.subscriber_names.lock() {
             names.retain(|_name, id| *id != request_id);
         }
-    }
-
-    /// Send REQUEST_UPDATE to toggle Forward state on an established PUBLISH
-    /// subscription (draft-16 §9.11), then wait for REQUEST_OK / REQUEST_ERROR.
-    ///
-    /// Called by [`PublishedTrack::set_forward`].
-    pub(super) async fn send_request_update_for_publish(
-        &mut self,
-        publish_request_id: u64,
-        forward: bool,
-    ) -> Result<(), ServeError> {
-        let update_id = self
-            .get_next_request_id()
-            .map_err(|e| ServeError::internal_ctx(format!("request ID limit: {e}")))?;
-
-        let (tx, rx) = tokio::sync::oneshot::channel();
-        {
-            let mut updates = self
-                .pending_publish_updates
-                .lock()
-                .map_err(|_| ServeError::internal_ctx("pending_publish_updates lock poisoned"))?;
-            updates.insert(update_id, PendingPublishUpdate { result_tx: tx });
-        }
-
-        let mut params = crate::coding::KeyValuePairs::default();
-        params.set_forward(forward);
-
-        self.send_message(message::RequestUpdate {
-            id: update_id,
-            existing_request_id: publish_request_id,
-            params,
-        });
-
-        rx.await
-            .unwrap_or(Err(ServeError::internal_ctx("set_forward sender dropped")))
     }
 
     fn add_mlog_event<F>(&self, make_event: F)
@@ -466,30 +416,18 @@ impl Subscriber {
             // must not collide with any alias already bound by a SUBSCRIBE or a
             // PUBLISH subscription.
             {
-                let sub_aliases = self
-                    .subscribe_alias_map
+                let mut aliases = self
+                    .track_alias_map
                     .lock()
                     .map_err(|_| SessionError::Internal)?;
-                let pub_aliases = self
-                    .publish_alias_map
-                    .lock()
-                    .map_err(|_| SessionError::Internal)?;
-                if sub_aliases.contains_key(&msg.track_alias)
-                    || pub_aliases.contains_key(&msg.track_alias)
-                {
+                if aliases.contains_key(&msg.track_alias) {
                     return Err(SessionError::Duplicate);
                 }
+                aliases.insert(msg.track_alias, TrackOrigin::Subscribe(msg.id));
             }
 
-            // Map track alias → subscription id for quick lookup when receiving
-            // streams/datagrams.
-            self.subscribe_alias_map
-                .lock()
-                .map_err(|_| SessionError::Internal)?
-                .insert(msg.track_alias, msg.id);
-
             // Notify waiting tasks that the alias map has been updated.
-            self.subscribe_alias_notify.notify_waiters();
+            self.track_alias_notify.notify_waiters();
 
             // Notify the subscribe of the successful subscription.
             subscribe.ok(msg.track_alias)?;
@@ -503,7 +441,7 @@ impl Subscriber {
         let subscribe = self.subscribes.lock().ok().and_then(|mut s| s.remove(&id));
         if let Some(ref sub) = subscribe {
             if let Some(track_alias) = sub.track_alias() {
-                if let Ok(mut alias_map) = self.subscribe_alias_map.lock() {
+                if let Ok(mut alias_map) = self.track_alias_map.lock() {
                     alias_map.remove(&track_alias);
                 }
             }
@@ -541,20 +479,14 @@ impl Subscriber {
             return Ok(());
         }
 
-        // Track Aliases are session-scoped (§10.1).  Both alias maps share the
-        // namespace, so we must check both for collisions.
+        // Track Aliases are session-scoped (§10.1); the unified alias map covers
+        // both SUBSCRIBE and PUBLISH, so one lookup detects any collision.
         {
-            let sub_aliases = self
-                .subscribe_alias_map
+            let aliases = self
+                .track_alias_map
                 .lock()
                 .map_err(|_| SessionError::Internal)?;
-            let pub_aliases = self
-                .publish_alias_map
-                .lock()
-                .map_err(|_| SessionError::Internal)?;
-            if sub_aliases.contains_key(&msg.track_alias)
-                || pub_aliases.contains_key(&msg.track_alias)
-            {
+            if aliases.contains_key(&msg.track_alias) {
                 // §9.13: duplicate Track Alias closes the session.
                 return Err(SessionError::Duplicate);
             }
@@ -595,12 +527,12 @@ impl Subscriber {
         let largest_location = msg.params.largest_object().map_err(SessionError::Decode)?;
 
         // Allocate the track.  The transport owns the writer; the application
-        // receives the reader via PublishedTrack::ok.
+        // receives the reader via PublishReceived::ok.
         let (writer, reader) =
             crate::serve::Track::new(msg.track_namespace.clone(), msg.track_name.clone()).produce();
 
         // Build both handles sharing the same state.
-        let (published_track, recv) = PublishedTrackRecv::produce(
+        let (publish_received, recv) = PublishReceivedRecv::produce(
             self.clone(),
             msg.id,
             msg.track_alias,
@@ -612,14 +544,14 @@ impl Subscriber {
             reader,
         );
 
-        // Register the alias BEFORE queueing the PublishedTrack so that Object
+        // Register the alias BEFORE queueing the PublishReceived so that Object
         // streams racing the PUBLISH (§5.1 allows pre-PUBLISH_OK delivery) can
         // be resolved immediately.
-        self.publish_alias_map
+        self.track_alias_map
             .lock()
             .map_err(|_| SessionError::Internal)?
-            .insert(msg.track_alias, msg.id);
-        self.publish_alias_notify.notify_waiters();
+            .insert(msg.track_alias, TrackOrigin::Publish(msg.id));
+        self.track_alias_notify.notify_waiters();
 
         // Register subscriber_names so a duplicate SUBSCRIBE or PUBLISH for the
         // same track is rejected with DUPLICATE_SUBSCRIPTION (§5.1).
@@ -629,7 +561,7 @@ impl Subscriber {
             .insert(full_name, msg.id);
 
         // Store the transport recv handle keyed by request id.
-        self.published_tracks
+        self.publishes_received
             .lock()
             .map_err(|_| SessionError::Internal)?
             .insert(msg.id, recv);
@@ -644,15 +576,15 @@ impl Subscriber {
             "received PUBLISH"
         );
 
-        // If the application is no longer listening, drop the PublishedTrack
+        // If the application is no longer listening, drop the PublishReceived
         // which sends REQUEST_ERROR back to the publisher.
-        if self.published_track_queue.push(published_track).is_err() {
+        if self.publish_received_queue.push(publish_received).is_err() {
             // Queue is closed; clean up state we just inserted.
-            self.publish_alias_map
+            self.track_alias_map
                 .lock()
                 .ok()
                 .map(|mut m| m.remove(&msg.track_alias));
-            self.published_tracks
+            self.publishes_received
                 .lock()
                 .ok()
                 .map(|mut m| m.remove(&msg.id));
@@ -681,7 +613,7 @@ impl Subscriber {
 
         // Then check PUBLISH-initiated subscriptions.
         let recv = self
-            .published_tracks
+            .publishes_received
             .lock()
             .map_err(|_| SessionError::Internal)?
             .remove(&msg.id);
@@ -689,8 +621,10 @@ impl Subscriber {
             recv.recv_done(msg.status_code);
             // Clean up alias and name maps.
             // TODO(itzmanish): maintain reverse maps to make these O(1).
-            if let Ok(mut aliases) = self.publish_alias_map.lock() {
-                aliases.retain(|_alias, id| *id != msg.id);
+            if let Ok(mut aliases) = self.track_alias_map.lock() {
+                aliases.retain(
+                    |_alias, origin| !matches!(origin, TrackOrigin::Publish(id) if *id == msg.id),
+                );
             }
             if let Ok(mut names) = self.subscriber_names.lock() {
                 names.retain(|_name, id| *id != msg.id);
@@ -724,27 +658,6 @@ impl Subscriber {
             return Ok(());
         }
 
-        // Check if this is a response to a pending REQUEST_UPDATE from set_forward.
-        let pending = self
-            .pending_publish_updates
-            .lock()
-            .map_err(|_| SessionError::Internal)?
-            .remove(&msg.id);
-
-        if let Some(update) = pending {
-            let request_kind = "request_update";
-            self.log_request_ok_parsed(request_kind, msg);
-            tracing::debug!(
-                target: "moq_transport::control",
-                request_id = msg.id,
-                request_kind,
-                "received REQUEST_OK"
-            );
-            // Wake the set_forward caller with success.
-            let _ = update.result_tx.send(Ok(()));
-            return Ok(());
-        }
-
         let request_kind = "unknown";
         self.log_request_ok_parsed(request_kind, msg);
         tracing::debug!(
@@ -758,8 +671,7 @@ impl Subscriber {
 
     /// Handle REQUEST_ERROR from the publisher (draft-16 §9.8).
     ///
-    /// Routes to: active SUBSCRIBE (by request id), pending REQUEST_UPDATE
-    /// from set_forward, or logs and ignores.
+    /// Routes to an active SUBSCRIBE by request id, otherwise logs and ignores.
     fn recv_request_error(&mut self, msg: &message::RequestError) -> Result<(), SessionError> {
         // Route to a matching SUBSCRIBE if present.
         if let Some(subscribe) = self.remove_subscribe(msg.id) {
@@ -786,29 +698,6 @@ impl Subscriber {
                 reason = %msg.reason.0,
                 "received REQUEST_ERROR"
             );
-            return Ok(());
-        }
-
-        // Route to a pending REQUEST_UPDATE from PublishedTrack::set_forward.
-        let pending = self
-            .pending_publish_updates
-            .lock()
-            .map_err(|_| SessionError::Internal)?
-            .remove(&msg.id);
-        if let Some(update) = pending {
-            self.log_request_error_parsed("request_update", msg);
-            tracing::debug!(
-                target: "moq_transport::control",
-                request_id = msg.id,
-                request_kind = "request_update",
-                error_code = msg.error_code,
-                retry_interval = msg.retry_interval,
-                reason = %msg.reason.0,
-                "received REQUEST_ERROR"
-            );
-            let _ = update
-                .result_tx
-                .send(Err(ServeError::Closed(msg.error_code)));
             return Ok(());
         }
 
@@ -846,88 +735,50 @@ impl Subscriber {
         None
     }
 
-    /// Resolve a Track Alias to the request id and subscription kind.
+    /// Resolve a Track Alias to its owning subscription (draft-16 §10.1).
     ///
-    /// Checks both alias maps in order:
-    ///   1. `subscribe_alias_map` (populated by SUBSCRIBE_OK).
-    ///   2. `publish_alias_map`   (populated eagerly by recv_publish before PUBLISH_OK).
+    /// PUBLISH aliases are registered eagerly in `recv_publish` (before
+    /// PUBLISH_OK), and SUBSCRIBE aliases in `recv_subscribe_ok`. A stream or
+    /// datagram can still race ahead of SUBSCRIBE_OK, so when `timeout_ms` is
+    /// set we wait up to that long for the alias to appear.
     ///
-    /// PUBLISH aliases are registered before PUBLISH_OK so that Object streams
-    /// racing the control message (§5.1 allows pre-PUBLISH_OK delivery) route
-    /// correctly.  The SUBSCRIBE map still uses a wait-with-timeout because
-    /// SUBSCRIBE_OK may arrive after the stream due to buffering.
-    ///
-    /// Returns `None` if the alias is not found within the timeout.
-    async fn resolve_alias(
+    /// Returns `None` if the alias is not found (immediately when `timeout_ms`
+    /// is `None`, or after the timeout otherwise).
+    async fn get_track_origin_by_alias(
         &self,
         track_alias: u64,
         timeout_ms: Option<u64>,
-    ) -> Result<Option<AliasBinding>, SessionError> {
-        // Check the PUBLISH alias map first (no wait needed: inserted eagerly).
+    ) -> Result<Option<TrackOrigin>, SessionError> {
+        // Fast path: already present.
         {
-            let pub_map = self
-                .publish_alias_map
+            let aliases = self
+                .track_alias_map
                 .lock()
                 .map_err(|_| SessionError::Internal)?;
-            if let Some(&req_id) = pub_map.get(&track_alias) {
-                return Ok(Some(AliasBinding::Publish(req_id)));
+            if let Some(origin) = aliases.get(&track_alias).copied() {
+                return Ok(Some(origin));
             }
         }
 
-        // Fall through to the SUBSCRIBE alias map, which may need a brief wait.
         let timeout_ms = match timeout_ms {
             Some(ms) => ms,
-            None => {
-                // Caller does not want to wait — check once and return.
-                return match self.subscribe_alias_map.lock() {
-                    Ok(aliases) => Ok(aliases
-                        .get(&track_alias)
-                        .copied()
-                        .map(AliasBinding::Subscribe)),
-                    Err(_) => {
-                        tracing::error!(
-                            target: "moq_transport::control",
-                            track_alias,
-                            "subscribe_alias_map lock poisoned"
-                        );
-                        Err(SessionError::Internal)
-                    }
-                };
-            }
+            None => return Ok(None),
         };
 
-        // Wait for the alias to appear in the SUBSCRIBE map.
         let timeout_duration = Duration::from_millis(timeout_ms);
         tokio::time::timeout(timeout_duration, async {
             loop {
                 // Register notification before checking to avoid a TOCTOU gap.
-                let notified = self.subscribe_alias_notify.notified();
+                let notified = self.track_alias_notify.notified();
 
-                // Re-check PUBLISH map first in case it was just inserted.
                 {
-                    let pub_map = match self.publish_alias_map.lock() {
-                        Ok(m) => m,
-                        Err(_) => return Err(SessionError::Internal),
-                    };
-                    if let Some(&req_id) = pub_map.get(&track_alias) {
-                        return Ok(Some(AliasBinding::Publish(req_id)));
+                    let aliases = self
+                        .track_alias_map
+                        .lock()
+                        .map_err(|_| SessionError::Internal)?;
+                    if let Some(origin) = aliases.get(&track_alias).copied() {
+                        return Ok(Some(origin));
                     }
-                }
-
-                let sub_id = match self.subscribe_alias_map.lock() {
-                    Ok(aliases) => aliases.get(&track_alias).copied(),
-                    Err(_) => {
-                        tracing::error!(
-                            target: "moq_transport::control",
-                            track_alias,
-                            "subscribe_alias_map lock poisoned"
-                        );
-                        return Err(SessionError::Internal);
-                    }
-                };
-
-                if let Some(id) = sub_id {
-                    return Ok(Some(AliasBinding::Subscribe(id)));
                 }
 
                 notified.await;
@@ -935,19 +786,6 @@ impl Subscriber {
         })
         .await
         .unwrap_or(Ok(None))
-    }
-
-    /// Legacy helper — kept for the error-recovery path in `recv_stream`.
-    /// Returns the SUBSCRIBE request id only.
-    async fn get_subscribe_id_by_alias(
-        &self,
-        track_alias: u64,
-        timeout_ms: Option<u64>,
-    ) -> Result<Option<u64>, SessionError> {
-        match self.resolve_alias(track_alias, timeout_ms).await? {
-            Some(AliasBinding::Subscribe(id)) => Ok(Some(id)),
-            Some(AliasBinding::Publish(_)) | None => Ok(None),
-        }
     }
 
     /// Handle reception of a new stream from the QUIC session.
@@ -1002,7 +840,9 @@ impl Subscriber {
             );
             // The writer is closed, so we should terminate.
             // TODO it would be nice to do this immediately when the Writer is closed.
-            if let Some(subscribe_id) = self.get_subscribe_id_by_alias(track_alias, None).await? {
+            if let Some(TrackOrigin::Subscribe(subscribe_id)) =
+                self.get_track_origin_by_alias(track_alias, None).await?
+            {
                 if let Some(subscribe) = self.remove_subscribe(subscribe_id) {
                     subscribe.error(err.clone())?;
                 }
@@ -1026,44 +866,24 @@ impl Subscriber {
             track_alias
         );
 
-        let binding = self
-            .resolve_alias(track_alias, Some(DEFAULT_ALIAS_WAIT_TIME_MS))
-            .await?;
-
-        match binding {
-            Some(AliasBinding::Subscribe(subscribe_id)) => {
-                tracing::trace!(
-                    "[SUBSCRIBER] recv_stream_inner: receiving subgroup data (SUBSCRIBE)"
-                );
-                self.recv_subgroup(
-                    stream_header_type,
-                    subgroup_header,
-                    subscribe_id,
-                    reader,
-                    mlog,
-                )
-                .await?;
-            }
-            Some(AliasBinding::Publish(publish_id)) => {
-                tracing::trace!(
-                    "[SUBSCRIBER] recv_stream_inner: receiving subgroup data (PUBLISH)"
-                );
-                self.recv_subgroup_publish(
-                    stream_header_type,
-                    subgroup_header,
-                    publish_id,
-                    reader,
-                    mlog,
-                )
-                .await?;
-            }
-            None => {
-                return Err(SessionError::Serve(ServeError::not_found_ctx(format!(
-                    "track_alias={} not found in subscribe or publish maps",
+        let origin = self
+            .get_track_origin_by_alias(track_alias, Some(DEFAULT_ALIAS_WAIT_TIME_MS))
+            .await?
+            .ok_or_else(|| {
+                SessionError::Serve(ServeError::not_found_ctx(format!(
+                    "track_alias={} not found",
                     track_alias
-                ))));
-            }
-        }
+                )))
+            })?;
+
+        self.recv_subgroup(
+            stream_header_type,
+            subgroup_header,
+            origin,
+            reader,
+            mlog,
+        )
+        .await?;
 
         tracing::trace!(
             "[SUBSCRIBER] recv_stream_inner: completed processing stream for track_alias={}",
@@ -1080,7 +900,7 @@ impl Subscriber {
     /// `get_writer` is called once — on the first object in the subgroup — to
     /// obtain a `SubgroupWriter`.  It receives the (possibly updated) subgroup
     /// header and must open the writer against the correct map entry (either
-    /// `subscribes` for outbound SUBSCRIBE, or `published_tracks` for inbound
+    /// `subscribes` for outbound SUBSCRIBE, or `publishes_received` for inbound
     /// PUBLISH).  Keeping this as a closure avoids duplicating ~100 lines of
     /// object decoding, ID tracking, validation, logging, and payload reading.
     async fn recv_subgroup_objects(
@@ -1248,61 +1068,50 @@ impl Subscriber {
         Ok(())
     }
 
-    /// Handle subgroup stream data for a SUBSCRIBE-initiated subscription.
+    /// Handle subgroup stream data, routing the writer through the owning
+    /// subscription (SUBSCRIBE or PUBLISH) identified by `origin`.
+    ///
+    /// The shared object loop (`recv_subgroup_objects`) opens the writer lazily
+    /// on the first object via the closure, which preserves the case where the
+    /// subgroup id is derived from the first object id.
     async fn recv_subgroup(
         &mut self,
         stream_header_type: data::StreamHeaderType,
         subgroup_header: data::SubgroupHeader,
-        subscribe_id: u64,
+        origin: TrackOrigin,
         reader: Reader,
         mlog: Option<Arc<Mutex<mlog::MlogWriter>>>,
     ) -> Result<(), SessionError> {
         let subscribes = self.subscribes.clone();
+        let publishes_received = self.publishes_received.clone();
         Self::recv_subgroup_objects(
             stream_header_type,
             subgroup_header,
             reader,
             mlog,
-            move |header| {
-                let mut map = subscribes.lock().map_err(|_| SessionError::Internal)?;
-                let recv = map.get_mut(&subscribe_id).ok_or_else(|| {
-                    SessionError::Serve(ServeError::not_found_ctx(format!(
-                        "subscribe_id={} not found for track_alias={}",
-                        subscribe_id, header.track_alias
-                    )))
-                })?;
-                Ok(recv.subgroup(header)?)
-            },
-        )
-        .await
-    }
-
-    /// Handle subgroup stream data for a PUBLISH-initiated subscription.
-    async fn recv_subgroup_publish(
-        &mut self,
-        stream_header_type: data::StreamHeaderType,
-        subgroup_header: data::SubgroupHeader,
-        publish_id: u64,
-        reader: Reader,
-        mlog: Option<Arc<Mutex<mlog::MlogWriter>>>,
-    ) -> Result<(), SessionError> {
-        let published_tracks = self.published_tracks.clone();
-        Self::recv_subgroup_objects(
-            stream_header_type,
-            subgroup_header,
-            reader,
-            mlog,
-            move |header| {
-                let mut map = published_tracks
-                    .lock()
-                    .map_err(|_| SessionError::Internal)?;
-                let recv = map.get_mut(&publish_id).ok_or_else(|| {
-                    SessionError::Serve(ServeError::not_found_ctx(format!(
-                        "publish_id={} not found for track_alias={}",
-                        publish_id, header.track_alias
-                    )))
-                })?;
-                Ok(recv.subgroup(header)?)
+            move |header| match origin {
+                TrackOrigin::Subscribe(subscribe_id) => {
+                    let mut map = subscribes.lock().map_err(|_| SessionError::Internal)?;
+                    let recv = map.get_mut(&subscribe_id).ok_or_else(|| {
+                        SessionError::Serve(ServeError::not_found_ctx(format!(
+                            "subscribe_id={} not found for track_alias={}",
+                            subscribe_id, header.track_alias
+                        )))
+                    })?;
+                    Ok(recv.subgroup(header)?)
+                }
+                TrackOrigin::Publish(publish_id) => {
+                    let mut map = publishes_received
+                        .lock()
+                        .map_err(|_| SessionError::Internal)?;
+                    let recv = map.get_mut(&publish_id).ok_or_else(|| {
+                        SessionError::Serve(ServeError::not_found_ctx(format!(
+                            "publish_id={} not found for track_alias={}",
+                            publish_id, header.track_alias
+                        )))
+                    })?;
+                    Ok(recv.subgroup(header)?)
+                }
             },
         )
         .await
@@ -1359,12 +1168,12 @@ impl Subscriber {
         }
 
         let track_alias = datagram.track_alias;
-        let binding = self
-            .resolve_alias(track_alias, Some(DEFAULT_ALIAS_WAIT_TIME_MS))
+        let origin = self
+            .get_track_origin_by_alias(track_alias, Some(DEFAULT_ALIAS_WAIT_TIME_MS))
             .await?;
 
-        match binding {
-            Some(AliasBinding::Subscribe(subscribe_id)) => {
+        match origin {
+            Some(TrackOrigin::Subscribe(subscribe_id)) => {
                 if let Some(subscribe) = self
                     .subscribes
                     .lock()
@@ -1381,9 +1190,9 @@ impl Subscriber {
                     subscribe.datagram(datagram)?;
                 }
             }
-            Some(AliasBinding::Publish(publish_id)) => {
+            Some(TrackOrigin::Publish(publish_id)) => {
                 if let Some(recv) = self
-                    .published_tracks
+                    .publishes_received
                     .lock()
                     .ok()
                     .as_mut()
@@ -1478,7 +1287,7 @@ mod tests {
         }
 
         assert!(observer.subscribes.lock().unwrap().is_empty());
-        assert!(observer.subscribe_alias_map.lock().unwrap().is_empty());
+        assert!(observer.track_alias_map.lock().unwrap().is_empty());
     }
 
     #[tokio::test]
@@ -1511,19 +1320,14 @@ mod tests {
         };
 
         assert_eq!(observer.subscribes.lock().unwrap().len(), 1);
-        assert_eq!(
-            observer
-                .subscribe_alias_map
-                .lock()
-                .unwrap()
-                .get(&10)
-                .copied(),
-            Some(0)
-        );
+        assert!(matches!(
+            observer.track_alias_map.lock().unwrap().get(&10),
+            Some(TrackOrigin::Subscribe(0))
+        ));
 
         drop(subscribe);
 
         assert!(observer.subscribes.lock().unwrap().is_empty());
-        assert!(observer.subscribe_alias_map.lock().unwrap().is_empty());
+        assert!(observer.track_alias_map.lock().unwrap().is_empty());
     }
 }

--- a/moq-transport/src/watch/queue.rs
+++ b/moq-transport/src/watch/queue.rs
@@ -21,6 +21,20 @@ impl<T> Queue<T> {
         Ok(())
     }
 
+    /// Push an item without panicking if the queue lock is poisoned.
+    pub fn try_push(&mut self, item: T) -> Result<(), T> {
+        match self.state.try_lock_mut() {
+            Ok(Some(mut state)) => state.push_back((item, None)),
+            Ok(None) => return Err(item),
+            Err(()) => {
+                tracing::error!("queue lock poisoned while pushing item");
+                return Err(item);
+            }
+        };
+
+        Ok(())
+    }
+
     /// Pop an item from the queue, waiting if necessary.
     pub async fn pop(&mut self) -> Option<T> {
         loop {

--- a/moq-transport/src/watch/queue.rs
+++ b/moq-transport/src/watch/queue.rs
@@ -26,7 +26,7 @@ impl<T> Queue<T> {
         match self.state.try_lock_mut() {
             Ok(Some(mut state)) => state.push_back((item, None)),
             Ok(None) => return Err(item),
-            Err(()) => {
+            Err(_) => {
                 tracing::error!("queue lock poisoned while pushing item");
                 return Err(item);
             }

--- a/moq-transport/src/watch/state.rs
+++ b/moq-transport/src/watch/state.rs
@@ -76,6 +76,15 @@ impl<T> State<T> {
         }
     }
 
+    pub fn try_lock(&self) -> Result<StateRef<'_, T>, ()> {
+        let lock = self.state.lock().map_err(|_| ())?;
+        Ok(StateRef {
+            state: self.state.clone(),
+            drop: self.drop.clone(),
+            lock,
+        })
+    }
+
     pub fn lock_mut(&self) -> Option<StateMut<'_, T>> {
         let lock = self.state.lock().unwrap();
         lock.dropped?;
@@ -83,6 +92,18 @@ impl<T> State<T> {
             lock,
             _drop: self.drop.clone(),
         })
+    }
+
+    pub fn try_lock_mut(&self) -> Result<Option<StateMut<'_, T>>, ()> {
+        let lock = self.state.lock().map_err(|_| ())?;
+        if lock.dropped.is_none() {
+            return Ok(None);
+        }
+
+        Ok(Some(StateMut {
+            lock,
+            _drop: self.drop.clone(),
+        }))
     }
 
     pub fn downgrade(&self) -> StateWeak<T> {
@@ -251,7 +272,10 @@ struct StateDrop<T> {
 
 impl<T> Drop for StateDrop<T> {
     fn drop(&mut self) {
-        let mut state = self.state.lock().unwrap();
+        let Ok(mut state) = self.state.lock() else {
+            tracing::error!("watch state lock poisoned while dropping state");
+            return;
+        };
         state.dropped = None;
         state.notify();
     }

--- a/moq-transport/src/watch/state.rs
+++ b/moq-transport/src/watch/state.rs
@@ -58,6 +58,11 @@ pub struct State<T> {
     drop: Arc<StateDrop<T>>,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum StateError {
+    Poisoned,
+}
+
 impl<T> State<T> {
     pub fn new(initial: T) -> Self {
         let state = Arc::new(Mutex::new(StateInner::new(initial)));
@@ -76,8 +81,8 @@ impl<T> State<T> {
         }
     }
 
-    pub fn try_lock(&self) -> Result<StateRef<'_, T>, ()> {
-        let lock = self.state.lock().map_err(|_| ())?;
+    pub fn try_lock(&self) -> Result<StateRef<'_, T>, StateError> {
+        let lock = self.state.lock().map_err(|_| StateError::Poisoned)?;
         Ok(StateRef {
             state: self.state.clone(),
             drop: self.drop.clone(),
@@ -94,8 +99,8 @@ impl<T> State<T> {
         })
     }
 
-    pub fn try_lock_mut(&self) -> Result<Option<StateMut<'_, T>>, ()> {
-        let lock = self.state.lock().map_err(|_| ())?;
+    pub fn try_lock_mut(&self) -> Result<Option<StateMut<'_, T>>, StateError> {
+        let lock = self.state.lock().map_err(|_| StateError::Poisoned)?;
         if lock.dropped.is_none() {
             return Ok(None);
         }


### PR DESCRIPTION
**Summary**

Adds draft-16 PUBLISH support for track-level publishing.
This separates namespace metadata from actual media tracks:
- PUBLISH_NAMESPACE remains namespace-level routing metadata for pull-based track requests.
- PUBLISH now carries actual media tracks for a specific Full Track Name.
The relay can now accept PUBLISH-origin tracks, serve downstream SUBSCRIBE requests from them, and route exact tracks across relays.

Changes
moq-transport
- Adds inbound PUBLISH handling with PublishReceived.
- Adds outbound PUBLISH handling with Published.
- Sends and handles PUBLISH_OK, REQUEST_ERROR, and PUBLISH_DONE.
- Uses a unified TrackOrigin alias map for SUBSCRIBE and PUBLISH object routing.
- Shares the subgroup receive path across SUBSCRIBE and PUBLISH.
- Reuses the existing Subscribed serving path for outbound PUBLISH data delivery.
- Rejects post-establishment REQUEST_UPDATE with NOT_SUPPORTED for now.
moq-relay-ietf
- Stores actual media tracks by FullTrackName -> TrackReader.
- Treats PUBLISH_NAMESPACE as namespace route metadata, not a media track container.
- Accepts inbound PUBLISH and registers the resulting exact track locally.
- Registers PUBLISH-origin tracks with the coordinator.
- Adds Coordinator::lookup_track, which resolves exact track registrations first and falls back to namespace lookup.
- Updates RemoteManager to use lookup_track.
- Extends FileCoordinator to persist exact track registrations.
- Rejects inbound PUBLISH when publish permissions are disabled.
moq-pub
- Adds --publish.
- Sends PUBLISH for tracks as they are created.
- Keeps sending PUBLISH_NAMESPACE for namespace route metadata.