### PR TITLE
feat: forward local accept IP to the connection tagger

### DIFF
--- a/moq-native-ietf/src/quic.rs
+++ b/moq-native-ietf/src/quic.rs
@@ -385,6 +385,17 @@ pub struct ConnInfo {
     /// Peer socket address.
     pub remote_address: net::SocketAddr,
 
+    /// Local IP the peer connected to: the destination IP the peer's packets
+    /// targeted (the port is always our fixed listening port, so it is omitted).
+    ///
+    /// On a wildcard bind (`0.0.0.0` / `[::]`) this identifies which local
+    /// address/interface (e.g. an anycast VIP) actually received the
+    /// connection — something neither [`remote_address`](Self::remote_address)
+    /// nor the wildcard [`Server::local_addr`] can tell you. `None` when the
+    /// platform does not expose the destination address (see
+    /// `quinn::Connection::local_ip`).
+    pub local_ip: Option<IpAddr>,
+
     /// TLS SNI server name sent by the peer, if any.
     pub server_name: Option<String>,
 }
@@ -489,11 +500,17 @@ impl Server {
         // the connection interface (public client vs internal relay peer).
         let remote_address = conn.remote_address();
 
+        // The destination IP the peer targeted, which differs from the wildcard
+        // bind address on multi-homed / anycast hosts. `None` if the platform
+        // does not expose it.
+        let local_ip = conn.local_ip();
+
         tracing::debug!(
-            "established QUIC connection: cid={} stable_id={} ip={} alpn={} server={}",
+            "established QUIC connection: cid={} stable_id={} ip={} local_ip={:?} alpn={} server={}",
             connection_id_hex,
             conn.stable_id(),
             remote_address,
+            local_ip,
             alpn,
             server_name,
         );
@@ -537,6 +554,7 @@ impl Server {
             id: connection_id_hex,
             transport,
             remote_address,
+            local_ip,
             // An empty SNI means the peer sent no server name.
             server_name: (!server_name.is_empty()).then_some(server_name),
         };

--- a/moq-relay-ietf/src/relay.rs
+++ b/moq-relay-ietf/src/relay.rs
@@ -287,6 +287,10 @@ impl Relay {
                             id: connection_id,
                             transport,
                             remote_address: remote_addr,
+                            // The local IP the connection was accepted on
+                            // (destination IP the peer targeted); forwarded to the
+                            // connection tagger for inbound-interface classification.
+                            local_ip,
                             server_name,
                         } = info;
 
@@ -371,7 +375,8 @@ impl Relay {
                                         Some(remote_addr),
                                         server_name,
                                         moq_session.connection_path().map(str::to_string),
-                                    );
+                                    )
+                                    .with_local_ip(local_ip);
                                     let tags = tagger.tag(&meta);
                                     SessionContext::from_tags(scope, &tags, Some(remote_addr))
                                 }

--- a/moq-relay-ietf/src/session.rs
+++ b/moq-relay-ietf/src/session.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use std::collections::BTreeMap;
-use std::net::SocketAddr;
+use std::net::{IpAddr, SocketAddr};
 
 use futures::{stream::FuturesUnordered, FutureExt, StreamExt};
 use moq_transport::session::{Publisher, SessionError, Subscriber};
@@ -95,6 +95,15 @@ pub struct ConnectionMeta {
     /// Remote socket address of the peer, when known.
     pub remote_addr: Option<SocketAddr>,
 
+    /// Local IP the connection was accepted on: the destination IP the peer
+    /// targeted, when known.
+    ///
+    /// On a wildcard bind (`0.0.0.0` / `[::]`) this identifies which local
+    /// address/interface (e.g. an anycast VIP) actually received the
+    /// connection, letting a tagger classify by inbound interface. `None` when
+    /// the platform does not expose the destination address.
+    pub local_ip: Option<IpAddr>,
+
     /// TLS SNI (Server Name Indication) the client requested, when present.
     ///
     /// Available for both WebTransport and raw MoQT connections, so this is the
@@ -108,6 +117,9 @@ pub struct ConnectionMeta {
 
 impl ConnectionMeta {
     /// Create connection metadata from a remote address, TLS SNI, and path.
+    ///
+    /// Use [`with_local_ip`](Self::with_local_ip) to attach the local IP the
+    /// connection was accepted on.
     pub fn new(
         remote_addr: Option<SocketAddr>,
         server_name: Option<String>,
@@ -115,9 +127,18 @@ impl ConnectionMeta {
     ) -> Self {
         Self {
             remote_addr,
+            local_ip: None,
             server_name,
             path,
         }
+    }
+
+    /// Attach the local IP the connection was accepted on (the destination IP
+    /// the peer targeted, from `ConnInfo::local_ip`). Returns `self` for
+    /// builder-style chaining. See [`local_ip`](Self::local_ip).
+    pub fn with_local_ip(mut self, local_ip: Option<IpAddr>) -> Self {
+        self.local_ip = local_ip;
+        self
     }
 }
 
@@ -155,6 +176,9 @@ impl ConnectionMeta {
 ///
 /// * [`ConnectionMeta::remote_addr`] — the dialer's source IP/port (e.g. match
 ///   an internal subnet or allowlist).
+/// * [`ConnectionMeta::local_ip`] — the local IP/interface the connection was
+///   accepted on (e.g. match an internal-facing VIP on a multi-homed or
+///   anycast host).
 /// * [`ConnectionMeta::server_name`] — the TLS SNI the dialer presents, derived
 ///   from the host of the URL it dialed, so relays that dial an internal
 ///   hostname can be matched here.
@@ -544,6 +568,11 @@ mod tests {
         assert_eq!(meta.remote_addr, Some(addr));
         assert_eq!(meta.server_name.as_deref(), Some("relay.example.com"));
         assert_eq!(meta.path.as_deref(), Some("/tenant/stream"));
+        // local_ip is opt-in and defaults to None.
+        assert_eq!(meta.local_ip, None);
+
+        let local: IpAddr = "10.0.0.1".parse().unwrap();
+        assert_eq!(meta.with_local_ip(Some(local)).local_ip, Some(local));
     }
 
     /// Example tagger that marks connections internal when they arrive on a
@@ -587,5 +616,46 @@ mod tests {
         // Missing SNI (e.g. no server name) defaults to public.
         let no_sni = tagger.tag(&ConnectionMeta::new(None, None, None));
         assert_eq!(no_sni.interface(), SessionInterface::Public);
+    }
+
+    /// Example tagger that marks connections internal when accepted on a known
+    /// internal-facing local IP (e.g. a private VIP), otherwise public.
+    /// Exercises the `local_ip` plumbing all the way to a tagger.
+    struct LocalIpTagger {
+        internal_local_ip: IpAddr,
+    }
+
+    impl ConnectionTagger for LocalIpTagger {
+        fn tag(&self, meta: &ConnectionMeta) -> ConnectionTags {
+            match meta.local_ip {
+                Some(ip) if ip == self.internal_local_ip => {
+                    ConnectionTags::new().with_interface(SessionInterface::Internal)
+                }
+                _ => ConnectionTags::new(),
+            }
+        }
+    }
+
+    #[test]
+    fn connection_tagger_classifies_by_local_ip() {
+        let internal_vip: IpAddr = "10.0.0.9".parse().unwrap();
+        let public_vip: IpAddr = "203.0.113.9".parse().unwrap();
+        let tagger = LocalIpTagger {
+            internal_local_ip: internal_vip,
+        };
+
+        // Accepted on the internal VIP -> internal.
+        let internal =
+            tagger.tag(&ConnectionMeta::new(None, None, None).with_local_ip(Some(internal_vip)));
+        assert_eq!(internal.interface(), SessionInterface::Internal);
+
+        // Accepted on a public VIP -> public.
+        let public =
+            tagger.tag(&ConnectionMeta::new(None, None, None).with_local_ip(Some(public_vip)));
+        assert_eq!(public.interface(), SessionInterface::Public);
+
+        // Unknown local IP defaults to public.
+        let unknown = tagger.tag(&ConnectionMeta::new(None, None, None));
+        assert_eq!(unknown.interface(), SessionInterface::Public);
     }
 }


### PR DESCRIPTION
Expose the local IP a connection was accepted on and pass it to the relay's ConnectionTagger, so embedders can classify by inbound interface (e.g. an internal-facing VIP) even on a wildcard/anycast bind. The local port is always our fixed listening port, so only the destination IP the peer targeted is carried.

moq-native-ietf: add ConnInfo::local_ip, set from
quinn::Connection::local_ip() (the destination IP the establishing datagram arrived on). None when the platform does not expose it.

moq-relay-ietf: add ConnectionMeta::local_ip with a with_local_ip() builder and forward ConnInfo::local_ip into ConnectionTagger::tag.