### PR TITLE
fix(draft-18): encode byte-valued message parameters as raw uint8

### DIFF
--- a/moq-transport/src/coding/kvp.rs
+++ b/moq-transport/src/coding/kvp.rs
@@ -92,6 +92,21 @@ impl KeyValuePair {
         r: &mut R,
         prev: u64,
     ) -> Result<(Self, u64), DecodeError> {
+        Self::decode_with_prev_typed(r, prev, &[])
+    }
+
+    /// Like [`decode_with_prev`](KeyValuePair::decode_with_prev), but the
+    /// absolute types listed in `u8_value_types` carry a single raw `uint8`
+    /// value instead of the default varint. Draft-17 (§10.2) replaced the
+    /// generic even=varint rule for certain message parameters (e.g.
+    /// SUBSCRIBER_PRIORITY, whose implicit default 128 does not fit in one
+    /// varint byte) with a fixed one-byte value; see
+    /// [`crate::message::U8_VALUE_PARAMETER_TYPES`].
+    pub(crate) fn decode_with_prev_typed<R: bytes::Buf>(
+        r: &mut R,
+        prev: u64,
+        u8_value_types: &[u64],
+    ) -> Result<(Self, u64), DecodeError> {
         let delta = u64::decode(r)?;
 
         // Draft-16 §1.4.2: prev + delta MUST NOT overflow u64.
@@ -99,7 +114,11 @@ impl KeyValuePair {
             .checked_add(delta)
             .ok_or(DecodeError::KvpTypeOverflow)?;
 
-        let pair = if abs_type % 2 == 0 {
+        let pair = if u8_value_types.contains(&abs_type) {
+            // Draft-17+ typed parameter → single raw uint8 value.
+            let value = u8::decode(r)?;
+            KeyValuePair::new_int(abs_type, value.into())
+        } else if abs_type % 2 == 0 {
             // Even type → varint value.
             let value = u64::decode(r)?;
             KeyValuePair::new_int(abs_type, value)
@@ -126,6 +145,21 @@ impl KeyValuePair {
         w: &mut W,
         prev: u64,
     ) -> Result<u64, EncodeError> {
+        self.encode_with_prev_typed(w, prev, &[])
+    }
+
+    /// Like [`encode_with_prev`](KeyValuePair::encode_with_prev), but the keys
+    /// listed in `u8_value_types` are written as a single raw `uint8` value
+    /// instead of the default varint. Values exceeding 255 for such a key are
+    /// rejected. See
+    /// [`decode_with_prev_typed`](KeyValuePair::decode_with_prev_typed) and
+    /// [`crate::message::U8_VALUE_PARAMETER_TYPES`].
+    pub(crate) fn encode_with_prev_typed<W: bytes::BufMut>(
+        &self,
+        w: &mut W,
+        prev: u64,
+        u8_value_types: &[u64],
+    ) -> Result<u64, EncodeError> {
         // Keys must be consistent with their value parity.
         match &self.value {
             Value::IntValue(_) if !self.key.is_multiple_of(2) => {
@@ -143,7 +177,13 @@ impl KeyValuePair {
 
         match &self.value {
             Value::IntValue(v) => {
-                (*v).encode(w)?;
+                if u8_value_types.contains(&self.key) {
+                    // Draft-17+ typed parameter → single raw uint8 value.
+                    let byte = u8::try_from(*v).map_err(|_| EncodeError::InvalidValue)?;
+                    byte.encode(w)?;
+                } else {
+                    (*v).encode(w)?;
+                }
             }
             Value::BytesValue(v) => {
                 if v.len() > MAX_BYTES_VALUE_LEN {
@@ -216,8 +256,15 @@ impl KeyValuePairs {
     }
 }
 
-impl Decode for KeyValuePairs {
-    fn decode<R: bytes::Buf>(r: &mut R) -> Result<Self, DecodeError> {
+impl KeyValuePairs {
+    /// Decode a count-prefixed KVP sequence, treating the absolute types listed
+    /// in `u8_value_types` as single raw `uint8` values (draft-17+ typed message
+    /// parameters). Pass `&[]` for the generic draft-16 even=varint behaviour;
+    /// the [`Decode`] impl does exactly that.
+    pub fn decode_with_u8_types<R: bytes::Buf>(
+        r: &mut R,
+        u8_value_types: &[u64],
+    ) -> Result<Self, DecodeError> {
         let count = u64::decode(r)?;
 
         // `count` is peer-controlled, so do not allocate directly from it.
@@ -230,17 +277,23 @@ impl Decode for KeyValuePairs {
         let mut prev = 0u64;
 
         for _ in 0..count {
-            let (pair, new_prev) = KeyValuePair::decode_with_prev(r, prev)?;
+            let (pair, new_prev) = KeyValuePair::decode_with_prev_typed(r, prev, u8_value_types)?;
             prev = new_prev;
             kvps.push(pair);
         }
 
         Ok(KeyValuePairs(kvps))
     }
-}
 
-impl Encode for KeyValuePairs {
-    fn encode<W: bytes::BufMut>(&self, w: &mut W) -> Result<(), EncodeError> {
+    /// Encode a count-prefixed KVP sequence, writing the keys listed in
+    /// `u8_value_types` as single raw `uint8` values (draft-17+ typed message
+    /// parameters). Pass `&[]` for the generic draft-16 even=varint behaviour;
+    /// the [`Encode`] impl does exactly that.
+    pub fn encode_with_u8_types<W: bytes::BufMut>(
+        &self,
+        w: &mut W,
+        u8_value_types: &[u64],
+    ) -> Result<(), EncodeError> {
         // Sort a working copy by ascending key before encoding so the delta is
         // always non-negative.  The internal Vec is not required to be sorted.
         let mut sorted: Vec<&KeyValuePair> = self.0.iter().collect();
@@ -250,10 +303,22 @@ impl Encode for KeyValuePairs {
 
         let mut prev = 0u64;
         for kvp in &sorted {
-            prev = kvp.encode_with_prev(w, prev)?;
+            prev = kvp.encode_with_prev_typed(w, prev, u8_value_types)?;
         }
 
         Ok(())
+    }
+}
+
+impl Decode for KeyValuePairs {
+    fn decode<R: bytes::Buf>(r: &mut R) -> Result<Self, DecodeError> {
+        Self::decode_with_u8_types(r, &[])
+    }
+}
+
+impl Encode for KeyValuePairs {
+    fn encode<W: bytes::BufMut>(&self, w: &mut W) -> Result<(), EncodeError> {
+        self.encode_with_u8_types(w, &[])
     }
 }
 
@@ -537,6 +602,64 @@ mod tests {
             decoded.get(1).unwrap().value,
             Value::BytesValue(vec![0x01, 0x02, 0x03, 0x04, 0x05])
         );
+    }
+
+    // ── draft-17+ typed uint8 values ──────────────────────────────────────────
+
+    #[test]
+    fn u8_typed_value_encodes_as_single_byte() {
+        // Even type 0x20 with value 200 (≥ 64): the generic even=varint rule
+        // needs two bytes, but the u8-typed override must emit exactly one.
+        let u8_types: &[u64] = &[0x20];
+        let kvps = KeyValuePairs(vec![KeyValuePair::new_int(0x20, 200)]);
+
+        let mut typed = BytesMut::new();
+        kvps.encode_with_u8_types(&mut typed, u8_types).unwrap();
+        // count=1, delta=0x20, value=0xC8 (single byte)
+        assert_eq!(typed.to_vec(), vec![0x01, 0x20, 0xC8]);
+
+        let decoded = KeyValuePairs::decode_with_u8_types(&mut typed, u8_types).unwrap();
+        assert_eq!(decoded, kvps);
+    }
+
+    #[test]
+    fn u8_typed_value_rejects_out_of_range() {
+        let u8_types: &[u64] = &[0x20];
+        let kvps = KeyValuePairs(vec![KeyValuePair::new_int(0x20, 256)]);
+        let mut buf = BytesMut::new();
+        assert!(matches!(
+            kvps.encode_with_u8_types(&mut buf, u8_types).unwrap_err(),
+            EncodeError::InvalidValue
+        ));
+    }
+
+    #[test]
+    fn generic_kvp_still_varint_for_even_types() {
+        // Without a u8-type override, even type 0x20 = 200 must use the two-byte
+        // varint form (unchanged draft-16 behaviour, e.g. SETUP parameters).
+        let kvps = KeyValuePairs(vec![KeyValuePair::new_int(0x20, 200)]);
+        let mut buf = BytesMut::new();
+        kvps.encode(&mut buf).unwrap();
+        // count=1, delta=0x20, draft-17 leading-1-bits varint(200)=0x80 0xC8
+        assert_eq!(buf.to_vec(), vec![0x01, 0x20, 0x80, 0xC8]);
+        let decoded = KeyValuePairs::decode(&mut buf).unwrap();
+        assert_eq!(decoded, kvps);
+    }
+
+    #[test]
+    fn empty_u8_types_matches_generic_for_mixed_content() {
+        let kvps = KeyValuePairs(vec![
+            KeyValuePair::new_int(0, 5),
+            KeyValuePair::new_bytes(1, vec![0xAA]),
+            KeyValuePair::new_int(2, 300),
+        ]);
+        let mut buf = BytesMut::new();
+        kvps.encode(&mut buf).unwrap();
+
+        let via_typed = KeyValuePairs::decode_with_u8_types(&mut buf.clone(), &[]).unwrap();
+        let via_generic = KeyValuePairs::decode(&mut buf).unwrap();
+        assert_eq!(via_typed, via_generic);
+        assert_eq!(via_typed, kvps);
     }
 }
 

--- a/moq-transport/src/message/fetch.rs
+++ b/moq-transport/src/message/fetch.rs
@@ -109,7 +109,7 @@ impl Decode for Fetch {
             }
         };
 
-        let params = KeyValuePairs::decode(r)?;
+        let params = KeyValuePairs::decode_message_params(r)?;
 
         Ok(Self {
             id,
@@ -145,7 +145,7 @@ impl Encode for Fetch {
             }
         };
 
-        self.params.encode(w)?;
+        self.params.encode_message_params(w)?;
 
         Ok(())
     }

--- a/moq-transport/src/message/fetch_ok.rs
+++ b/moq-transport/src/message/fetch_ok.rs
@@ -28,7 +28,7 @@ impl Decode for FetchOk {
         let id = u64::decode(r)?;
         let end_of_track = bool::decode(r)?;
         let end_location = Location::decode(r)?;
-        let params = KeyValuePairs::decode(r)?;
+        let params = KeyValuePairs::decode_message_params(r)?;
         let track_extensions = TrackExtensions::decode(r)?;
 
         Ok(Self {
@@ -46,7 +46,7 @@ impl Encode for FetchOk {
         self.id.encode(w)?;
         self.end_of_track.encode(w)?;
         self.end_location.encode(w)?;
-        self.params.encode(w)?;
+        self.params.encode_message_params(w)?;
         self.track_extensions.encode(w)?;
 
         Ok(())

--- a/moq-transport/src/message/params.rs
+++ b/moq-transport/src/message/params.rs
@@ -21,6 +21,23 @@ pub mod parameter_type {
     pub const NEW_GROUP_REQUEST: u64 = 0x32;
 }
 
+/// Message-parameter type IDs whose value is a single raw `uint8` byte rather
+/// than a varint (draft-18 §10.2).
+///
+/// Draft-17 replaced the generic even=varint / odd=length-prefixed KVP rule for
+/// message parameters with per-parameter value kinds. These three are the
+/// byte-valued parameters carried by SUBSCRIBE / FETCH. Notably
+/// SUBSCRIBER_PRIORITY defaults to 128, which a varint encodes in two bytes —
+/// desynchronising the parameter block for peers (imquic, moq-go) that expect a
+/// single byte. SUBSCRIPTION_FILTER (0x21) stays length-prefixed bytes and the
+/// varint-valued parameters (timeouts, EXPIRES, NEW_GROUP_REQUEST) are
+/// unaffected, so they are intentionally absent here.
+pub const U8_VALUE_PARAMETER_TYPES: &[u64] = &[
+    parameter_type::FORWARD,             // 0x10
+    parameter_type::SUBSCRIBER_PRIORITY, // 0x20
+    parameter_type::GROUP_ORDER,         // 0x22
+];
+
 /// Draft-16 extension-header type IDs.
 pub mod extension_type {
     pub const DELIVERY_TIMEOUT: u64 = 0x02;
@@ -251,6 +268,24 @@ fn get_kvp_u8(pairs: &[KeyValuePair], key: u64) -> Result<Option<u8>, DecodeErro
 }
 
 impl KeyValuePairs {
+    /// Decode a draft-18 §10.2 message-parameter block (SUBSCRIBE, FETCH,
+    /// PUBLISH, PUBLISH_OK, REQUEST_OK, REQUEST_UPDATE, …).
+    ///
+    /// This is the count-prefixed KVP decode with the draft-17 byte-valued
+    /// parameter kinds applied uniformly (see [`U8_VALUE_PARAMETER_TYPES`]).
+    /// Every message carrying §10.2 parameters MUST use this rather than the
+    /// generic [`KeyValuePairs::decode`], otherwise a peer's single-byte
+    /// SUBSCRIBER_PRIORITY (default 128) desynchronises the whole block.
+    pub fn decode_message_params<R: bytes::Buf>(r: &mut R) -> Result<Self, DecodeError> {
+        Self::decode_with_u8_types(r, U8_VALUE_PARAMETER_TYPES)
+    }
+
+    /// Encode a draft-18 §10.2 message-parameter block. Counterpart to
+    /// [`decode_message_params`](KeyValuePairs::decode_message_params).
+    pub fn encode_message_params<W: bytes::BufMut>(&self, w: &mut W) -> Result<(), EncodeError> {
+        self.encode_with_u8_types(w, U8_VALUE_PARAMETER_TYPES)
+    }
+
     fn int_parameter(&self, key: u64) -> Result<Option<u64>, DecodeError> {
         get_kvp_int(&self.0, key)
     }

--- a/moq-transport/src/message/publish.rs
+++ b/moq-transport/src/message/publish.rs
@@ -33,7 +33,7 @@ impl Decode for Publish {
         let track_name = TrackName::decode(r)?;
         validate_full_track_name(&track_namespace, track_name.as_bytes())?;
         let track_alias = u64::decode(r)?;
-        let params = KeyValuePairs::decode(r)?;
+        let params = KeyValuePairs::decode_message_params(r)?;
         let track_extensions = TrackExtensions::decode(r)?;
 
         Ok(Self {
@@ -54,7 +54,7 @@ impl Encode for Publish {
         self.track_namespace.encode(w)?;
         self.track_name.encode(w)?;
         self.track_alias.encode(w)?;
-        self.params.encode(w)?;
+        self.params.encode_message_params(w)?;
         self.track_extensions.encode(w)?;
 
         Ok(())

--- a/moq-transport/src/message/publish_namespace.rs
+++ b/moq-transport/src/message/publish_namespace.rs
@@ -20,7 +20,7 @@ impl Decode for PublishNamespace {
     fn decode<R: bytes::Buf>(r: &mut R) -> Result<Self, DecodeError> {
         let id = u64::decode(r)?;
         let track_namespace = TrackNamespace::decode(r)?;
-        let params = KeyValuePairs::decode(r)?;
+        let params = KeyValuePairs::decode_message_params(r)?;
 
         Ok(Self {
             id,
@@ -34,7 +34,7 @@ impl Encode for PublishNamespace {
     fn encode<W: bytes::BufMut>(&self, w: &mut W) -> Result<(), EncodeError> {
         self.id.encode(w)?;
         self.track_namespace.encode(w)?;
-        self.params.encode(w)?;
+        self.params.encode_message_params(w)?;
 
         Ok(())
     }

--- a/moq-transport/src/message/publish_ok.rs
+++ b/moq-transport/src/message/publish_ok.rs
@@ -18,7 +18,7 @@ pub struct PublishOk {
 impl Decode for PublishOk {
     fn decode<R: bytes::Buf>(r: &mut R) -> Result<Self, DecodeError> {
         let id = u64::decode(r)?;
-        let params = KeyValuePairs::decode(r)?;
+        let params = KeyValuePairs::decode_message_params(r)?;
 
         Ok(Self { id, params })
     }
@@ -27,7 +27,7 @@ impl Decode for PublishOk {
 impl Encode for PublishOk {
     fn encode<W: bytes::BufMut>(&self, w: &mut W) -> Result<(), EncodeError> {
         self.id.encode(w)?;
-        self.params.encode(w)?;
+        self.params.encode_message_params(w)?;
 
         Ok(())
     }

--- a/moq-transport/src/message/request_ok.rs
+++ b/moq-transport/src/message/request_ok.rs
@@ -22,7 +22,7 @@ pub struct RequestOk {
 impl Decode for RequestOk {
     fn decode<R: bytes::Buf>(r: &mut R) -> Result<Self, DecodeError> {
         let id = u64::decode(r)?;
-        let params = KeyValuePairs::decode(r)?;
+        let params = KeyValuePairs::decode_message_params(r)?;
         Ok(Self { id, params })
     }
 }
@@ -30,7 +30,7 @@ impl Decode for RequestOk {
 impl Encode for RequestOk {
     fn encode<W: bytes::BufMut>(&self, w: &mut W) -> Result<(), EncodeError> {
         self.id.encode(w)?;
-        self.params.encode(w)?;
+        self.params.encode_message_params(w)?;
         Ok(())
     }
 }

--- a/moq-transport/src/message/request_update.rs
+++ b/moq-transport/src/message/request_update.rs
@@ -26,7 +26,7 @@ impl Decode for RequestUpdate {
     fn decode<R: bytes::Buf>(r: &mut R) -> Result<Self, DecodeError> {
         let id = u64::decode(r)?;
         let existing_request_id = u64::decode(r)?;
-        let params = KeyValuePairs::decode(r)?;
+        let params = KeyValuePairs::decode_message_params(r)?;
         Ok(Self {
             id,
             existing_request_id,
@@ -39,7 +39,7 @@ impl Encode for RequestUpdate {
     fn encode<W: bytes::BufMut>(&self, w: &mut W) -> Result<(), EncodeError> {
         self.id.encode(w)?;
         self.existing_request_id.encode(w)?;
-        self.params.encode(w)?;
+        self.params.encode_message_params(w)?;
         Ok(())
     }
 }
@@ -75,5 +75,28 @@ mod tests {
         msg.encode(&mut buf).unwrap();
         let decoded = RequestUpdate::decode(&mut buf).unwrap();
         assert_eq!(decoded, msg);
+    }
+
+    #[test]
+    fn subscriber_priority_128_encodes_as_single_byte() {
+        // REQUEST_UPDATE shares the §10.2 message-parameter code space with
+        // SUBSCRIBE, so SUBSCRIBER_PRIORITY must be a single raw uint8 here too
+        // (default 128 = 0x80), not a two-byte varint that would desync a peer.
+        let mut params = KeyValuePairs::new();
+        params.set_subscriber_priority(128);
+        let msg = RequestUpdate {
+            id: 4,
+            existing_request_id: 2,
+            params,
+        };
+
+        let mut buf = BytesMut::new();
+        msg.encode(&mut buf).unwrap();
+        // id=0x04, existing=0x02, count=0x01, delta=0x20, value=0x80 (single byte)
+        assert_eq!(buf.to_vec(), vec![0x04, 0x02, 0x01, 0x20, 0x80]);
+
+        let decoded = RequestUpdate::decode(&mut buf).unwrap();
+        assert_eq!(decoded, msg);
+        assert_eq!(decoded.params.subscriber_priority().unwrap(), Some(128));
     }
 }

--- a/moq-transport/src/message/subscribe.rs
+++ b/moq-transport/src/message/subscribe.rs
@@ -31,7 +31,7 @@ impl Decode for Subscribe {
         let track_name = TrackName::decode(r)?;
         validate_full_track_name(&track_namespace, track_name.as_bytes())?;
 
-        let params = KeyValuePairs::decode(r)?;
+        let params = KeyValuePairs::decode_message_params(r)?;
 
         Ok(Self {
             id,
@@ -49,7 +49,7 @@ impl Encode for Subscribe {
         self.track_namespace.encode(w)?;
         self.track_name.encode(w)?;
 
-        self.params.encode(w)?;
+        self.params.encode_message_params(w)?;
 
         Ok(())
     }
@@ -58,6 +58,7 @@ impl Encode for Subscribe {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::message::{GroupOrder, U8_VALUE_PARAMETER_TYPES};
     use bytes::BytesMut;
 
     #[test]
@@ -124,5 +125,82 @@ mod tests {
         msg.encode(&mut buf).unwrap();
         let decoded = Subscribe::decode(&mut buf).unwrap();
         assert_eq!(decoded, msg);
+    }
+
+    // ── draft-18 typed-parameter wire format ──────────────────────────────────
+    // Draft-17 §10.2 changed SUBSCRIBER_PRIORITY (0x20), GROUP_ORDER (0x22) and
+    // FORWARD (0x10) from a varint value to a single raw uint8. The default
+    // SUBSCRIBER_PRIORITY of 128 is the value that breaks the older varint form:
+    // as a draft-17 leading-1-bits varint it is two bytes (0x80 0x80),
+    // desynchronising the whole parameter block for imquic / moq-go peers that
+    // read exactly one byte. These vectors pin the byte layout against those
+    // reference implementations.
+
+    #[test]
+    fn subscribe_params_encode_typed_values_as_single_bytes() {
+        let mut params = KeyValuePairs::new();
+        params.set_forward(true); // 0x10 → 0x01
+        params.set_subscriber_priority(128); // 0x20 → 0x80 (single byte)
+        params.set_group_order(GroupOrder::Descending); // 0x22 → 0x02
+
+        let mut buf = BytesMut::new();
+        params
+            .encode_with_u8_types(&mut buf, U8_VALUE_PARAMETER_TYPES)
+            .unwrap();
+
+        // count=3; then delta-encoded (delta, value) pairs sorted by type:
+        //   FORWARD             delta 0x10, value 0x01
+        //   SUBSCRIBER_PRIORITY delta 0x10, value 0x80  ← single byte, not 0x80 0x80
+        //   GROUP_ORDER         delta 0x02, value 0x02
+        assert_eq!(buf.to_vec(), vec![0x03, 0x10, 0x01, 0x10, 0x80, 0x02, 0x02]);
+
+        let decoded =
+            KeyValuePairs::decode_with_u8_types(&mut buf, U8_VALUE_PARAMETER_TYPES).unwrap();
+        assert_eq!(decoded.forward().unwrap(), Some(true));
+        assert_eq!(decoded.subscriber_priority().unwrap(), Some(128));
+        assert_eq!(decoded.group_order().unwrap(), Some(GroupOrder::Descending));
+    }
+
+    #[test]
+    fn typed_encoding_avoids_two_byte_varint_priority() {
+        // Guard the fix boundary: the *generic* KVP encoding (even=varint) emits
+        // the desyncing two-byte 0x80 0x80 for priority 128, whereas the u8-typed
+        // encoding used by SUBSCRIBE must emit a single 0x80.
+        let mut params = KeyValuePairs::new();
+        params.set_subscriber_priority(128); // 0x20 = 128
+
+        let mut generic = BytesMut::new();
+        params.encode(&mut generic).unwrap();
+        assert_eq!(generic.to_vec(), vec![0x01, 0x20, 0x80, 0x80]);
+
+        let mut typed = BytesMut::new();
+        params
+            .encode_with_u8_types(&mut typed, U8_VALUE_PARAMETER_TYPES)
+            .unwrap();
+        assert_eq!(typed.to_vec(), vec![0x01, 0x20, 0x80]);
+    }
+
+    #[test]
+    fn subscribe_round_trips_default_priority_128() {
+        // Insert in ascending key order (FORWARD 0x10, SUBSCRIBER_PRIORITY 0x20,
+        // GROUP_ORDER 0x22) so this Vec matches the sorted order that decode
+        // reconstructs — KeyValuePairs equality is order-sensitive.
+        let mut params = KeyValuePairs::new();
+        params.set_forward(true);
+        params.set_subscriber_priority(128);
+        params.set_group_order(GroupOrder::Ascending);
+
+        let msg = Subscribe {
+            id: 7,
+            track_namespace: TrackNamespace::from_utf8_path("ns/v"),
+            track_name: "track".into(),
+            params,
+        };
+
+        let mut buf = BytesMut::new();
+        msg.encode(&mut buf).unwrap();
+        let decoded = Subscribe::decode(&mut buf).unwrap();
+        assert_eq!(decoded, msg);
+        assert_eq!(decoded.params.subscriber_priority().unwrap(), Some(128));
     }
 }

--- a/moq-transport/src/message/subscribe_namespace.rs
+++ b/moq-transport/src/message/subscribe_namespace.rs
@@ -55,7 +55,7 @@ impl Decode for SubscribeNamespace {
         let id = u64::decode(r)?;
         let track_namespace_prefix = TrackNamespacePrefix::decode(r)?;
         let subscribe_options = SubscribeOptions::decode(r)?;
-        let params = KeyValuePairs::decode(r)?;
+        let params = KeyValuePairs::decode_message_params(r)?;
 
         Ok(Self {
             id,
@@ -71,7 +71,7 @@ impl Encode for SubscribeNamespace {
         self.id.encode(w)?;
         self.track_namespace_prefix.encode(w)?;
         self.subscribe_options.encode(w)?;
-        self.params.encode(w)?;
+        self.params.encode_message_params(w)?;
 
         Ok(())
     }

--- a/moq-transport/src/message/subscribe_ok.rs
+++ b/moq-transport/src/message/subscribe_ok.rs
@@ -25,7 +25,7 @@ impl Decode for SubscribeOk {
     fn decode<R: bytes::Buf>(r: &mut R) -> Result<Self, DecodeError> {
         let id = u64::decode(r)?;
         let track_alias = u64::decode(r)?;
-        let params = KeyValuePairs::decode(r)?;
+        let params = KeyValuePairs::decode_message_params(r)?;
         let track_extensions = TrackExtensions::decode(r)?;
 
         Ok(Self {
@@ -41,7 +41,7 @@ impl Encode for SubscribeOk {
     fn encode<W: bytes::BufMut>(&self, w: &mut W) -> Result<(), EncodeError> {
         self.id.encode(w)?;
         self.track_alias.encode(w)?;
-        self.params.encode(w)?;
+        self.params.encode_message_params(w)?;
         self.track_extensions.encode(w)?;
 
         Ok(())

--- a/moq-transport/src/message/track_status.rs
+++ b/moq-transport/src/message/track_status.rs
@@ -29,7 +29,7 @@ impl Decode for TrackStatus {
         let track_name = TrackName::decode(r)?;
         validate_full_track_name(&track_namespace, track_name.as_bytes())?;
 
-        let params = KeyValuePairs::decode(r)?;
+        let params = KeyValuePairs::decode_message_params(r)?;
 
         Ok(Self {
             id,
@@ -47,7 +47,7 @@ impl Encode for TrackStatus {
         self.track_namespace.encode(w)?;
         self.track_name.encode(w)?;
 
-        self.params.encode(w)?;
+        self.params.encode_message_params(w)?;
 
         Ok(())
     }

--- a/moq-transport/src/session/mod.rs
+++ b/moq-transport/src/session/mod.rs
@@ -828,7 +828,17 @@ impl Session {
         // cannot pin a concurrency slot indefinitely.
         let msg: Message =
             match tokio::time::timeout(Self::BIDI_REQUEST_TIMEOUT, reader.decode()).await {
-                Ok(decoded) => decoded?,
+                Ok(Ok(msg)) => msg,
+                Ok(Err(e)) => {
+                    // A conformant peer always sends a decodable request as the
+                    // first message on a bidi stream. A decode failure here means
+                    // a malformed or wire-incompatible request (e.g. a parameter
+                    // value-encoding mismatch) that would otherwise be dropped
+                    // invisibly at debug level — surface it at warn so this class
+                    // of interop break is observable in production.
+                    tracing::warn!(error = %e, "failed to decode inbound request; dropping stream");
+                    return Err(e);
+                }
                 Err(_) => {
                     tracing::debug!("bidi request read timed out; reclaiming slot");
                     return Ok(());


### PR DESCRIPTION
**Problem.** Draft-17 §10.2 replaced the generic KVP value rule (even type = varint, odd = length-prefixed bytes) with per-parameter value kinds. Three message parameters carry a single raw \`uint8\`: FORWARD (0x10), SUBSCRIBER_PRIORITY (0x20), GROUP_ORDER (0x22). moq-rs still encoded/decoded them as varints. \`SUBSCRIBER_PRIORITY\` defaults to **128** — two bytes as a varint (\`0x80 0x80\`), one byte as \`uint8\` (\`0x80\`) — so an inbound SUBSCRIBE from imquic or moq-go desynced moq-rs's parameter decoder and the request was dropped invisibly. (FORWARD 0/1 and GROUP_ORDER 1/2 coincide between the two encodings, so only priority actually broke in practice.)

**Fix.** Model the whole §10.2 message-parameter code space with the same per-type registry moq-go (\`paramKinds\`) and imquic (version-gated \`uint8\` reads) use:
- \`coding/kvp\`: thread an optional uint8-value type set through the per-pair codec; \`decode_with_prev\`/\`encode_with_prev\` delegate with an empty set, so SETUP params, extension headers, and track extensions keep the generic rule.
- \`message/params\`: \`U8_VALUE_PARAMETER_TYPES\` + \`decode_message_params\`/\`encode_message_params\`; every message carrying §10.2 params routes through them.
- \`session\`: inbound request decode failures now log at \`warn!\` (were \`debug!\`) so this class of interop break is observable, not silent.

**Tests.** Wire-vector tests pin priority-128 → single \`0x80\` for SUBSCRIBE and REQUEST_UPDATE against moq-go/imquic byte layout; coding tests confirm the generic KVP path still uses varints. 228 tests pass.

**Impact.** This is the live-breaking bug causing all SUBSCRIBE requests to be silently dropped against every real draft-18 peer (imquic, moqtopus, moq-go). PUBLISH_NAMESPACE was unaffected because its params happened to use values < 64 where varint and uint8 are identical.

**Follow-ups (out of scope):** LARGEST_OBJECT (0x09, two bare varints) and TRACK_NAMESPACE_PREFIX (0x34, KindBytes) remain on the generic path.