### PR TITLE
fix(draft-18): correct SUBSCRIBE_NAMESPACE message type 0x11 -> 0x50

### DIFF
--- a/moq-transport/src/message/mod.rs
+++ b/moq-transport/src/message/mod.rs
@@ -246,8 +246,8 @@ message_types! {
     FetchCancel     = 0x17,
     FetchOk         = 0x18,
 
-    // ── SUBSCRIBE_NAMESPACE (bidi stream; §9.25) ──────────────────────────────
-    SubscribeNamespace = 0x11,
+    // ── SUBSCRIBE_NAMESPACE (bidi stream; §10.18) ────────────────────────────
+    SubscribeNamespace = 0x50,
 
     // ── Session management ────────────────────────────────────────────────────
     GoAway          = 0x10,
@@ -408,7 +408,7 @@ mod tests {
     }
 
     #[test]
-    fn draft16_wire_layouts_for_changed_control_messages() {
+    fn draft18_wire_layouts_for_control_messages() {
         fn encoded(msg: Message) -> Vec<u8> {
             let mut buf = bytes::BytesMut::new();
             msg.encode(&mut buf).unwrap();
@@ -505,7 +505,7 @@ mod tests {
                 subscribe_options: SubscribeOptions::Both,
                 params: KeyValuePairs::default(),
             })),
-            vec![0x11, 0x00, 0x04, 0x00, 0x00, 0x02, 0x00]
+            vec![0x50, 0x00, 0x04, 0x00, 0x00, 0x02, 0x00]
         );
     }
 }


### PR DESCRIPTION
draft-18 spec Table 5 assigns `0x50` to SUBSCRIBE\_NAMESPACE. Our code had `0x11`, which is not a message type in draft-18 at all (`0x11` is an error code: `INVALID\_RANGE` / `CONTROL\_MESSAGE\_TIMEOUT`).

This caused peers sending SUBSCRIBE\_NAMESPACE with the correct type byte to have their messages silently rejected as `InvalidMessage(80)`. Observed in interop runner logs as moq-dev-rs clients hitting `InvalidMessage(80)` against our relay.

Also updates a stale wire-format test name and expected byte.