### PR TITLE
fix: send log output to stderr instead of stdout

### DIFF
--- a/moq-api/src/main.rs
+++ b/moq-api/src/main.rs
@@ -11,7 +11,10 @@ use server::{Server, ServerConfig};
 #[tokio::main]
 async fn main() -> Result<(), ApiError> {
     // Initialize tracing with env filter (respects RUST_LOG environment variable)
+    //
+    // Logs go to stderr, per convention and to keep stdout clean.
     tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
                 .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),

--- a/moq-clock-ietf/src/main.rs
+++ b/moq-clock-ietf/src/main.rs
@@ -22,7 +22,11 @@ use moq_transport::{
 async fn main() -> anyhow::Result<()> {
     // Initialize tracing with env filter (respects RUST_LOG environment variable)
     // Default to info level, but suppress quinn's verbose output
+    //
+    // Logs go to stderr so they stay separate from the clock values this
+    // binary prints to stdout.
     tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
                 .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info,quinn=warn")),

--- a/moq-pub/src/main.rs
+++ b/moq-pub/src/main.rs
@@ -57,7 +57,10 @@ pub struct Cli {
 async fn main() -> anyhow::Result<()> {
     // Initialize tracing with env filter (respects RUST_LOG environment variable)
     // Default to info level, but suppress quinn's verbose output
+    //
+    // Logs go to stderr, per convention and to keep stdout clean.
     tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
                 .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info,quinn=warn")),

--- a/moq-relay-ietf/src/bin/moq-relay-ietf/main.rs
+++ b/moq-relay-ietf/src/bin/moq-relay-ietf/main.rs
@@ -97,7 +97,10 @@ pub struct Cli {
 async fn main() -> anyhow::Result<()> {
     // Initialize tracing with env filter (respects RUST_LOG environment variable)
     // Default to info level, but suppress quinn's verbose output
+    //
+    // Logs go to stderr, per convention and to keep stdout clean.
     tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
                 .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info,quinn=warn")),

--- a/moq-sub/src/main.rs
+++ b/moq-sub/src/main.rs
@@ -16,7 +16,11 @@ use moq_transport::{coding::TrackNamespace, serve::Tracks};
 async fn main() -> anyhow::Result<()> {
     // Initialize tracing with env filter (respects RUST_LOG environment variable)
     // Default to info level, but suppress quinn's verbose output
+    //
+    // Logs go to stderr so they can't corrupt the fMP4 byte stream this
+    // binary writes to stdout (e.g. `moq-sub ... | ffplay -`).
     tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
                 .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info,quinn=warn")),

--- a/moq-test-client/src/main.rs
+++ b/moq-test-client/src/main.rs
@@ -229,7 +229,11 @@ fn print_tap_result(test_number: usize, result: &TestResult, verbose: bool) {
 async fn main() -> Result<()> {
     // Initialize tracing with env filter (respects RUST_LOG environment variable)
     // Default to info level, but suppress quinn's verbose output
+    //
+    // Logs go to stderr so they can't corrupt the TAP report this binary
+    // writes to stdout.
     tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
                 .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info,quinn=warn")),


### PR DESCRIPTION
## Problem

`tracing_subscriber::fmt()` writes to stdout unless a writer is explicitly set. Since the migration off the `log` crate (`ea287acf`), every binary has been logging to stdout — which breaks the binaries that use stdout as a data channel.

`moq-sub` writes the fMP4 stream to stdout, so this fails immediately:

```console
$ cargo run --bin moq-sub -- --name my-namespace "https://..." | ffplay -
fd:: Invalid data found when processing input
[tracing-subscriber] Unable to write an event to the Writer for this Subscriber! Error: Broken pipe (os error 32)
[tracing-subscriber] Unable to write an event to the Writer for this Subscriber! Error: Broken pipe (os error 32)
... (repeats)
```

The first bytes ffplay receives are an ANSI-colored log line rather than `ftyp`:

```
00000000: 1b5b 326d 3230 3236 2d30 372d 3239 5431  .[2m2026-07-29T1
00000020: 5b30 6d20 1b5b 3332 6d20 494e 464f 1b5b  [0m .[32m INFO.[
00000110: 5b30 6d20 636f 6e6e 6563 7465 6420 7769  [0m connected wi
00000120: 7468 2043 4944 3a20 3432 3761 6131 6461  th CID: 427aa1da
```

ffplay then exits and closes the pipe, which is what produces the `Broken pipe` flood — that's tracing failing to write to a dead stdout, a symptom rather than the cause. Log lines also land on object boundaries mid-stream, corrupting whichever fMP4 fragment follows.

The workaround until now has been `RUST_LOG=off`, which means giving up the logs — including the connection ID needed to look up qlog/mlog on the server.

Two other binaries are affected the same way:

- `moq-test-client` emits its TAP report on stdout, so interleaved log lines corrupt the report.
- `moq-clock-ietf` prints clock values to stdout.

## Fix

Add `.with_writer(std::io::stderr)` to all six binaries.

This restores the behavior from before the tracing migration: every one of these binaries previously called `env_logger::init()`, which writes to **stderr**. `ea287acf` moved all six from stderr to stdout, so this is a restoration rather than a new convention — and it matches the usual practice of reserving stdout for program output.

Applied to all six rather than only the three with active collisions, so the invariant is simply "logs go to stderr" and no future stdout output can silently reintroduce this.

| binary | stdout used for |
|---|---|
| `moq-sub` | fMP4 stream — actively broken |
| `moq-test-client` | TAP report — latent corruption |
| `moq-clock-ietf` | clock values |
| `moq-pub`, `moq-relay-ietf`, `moq-api` | nothing today; restores prior behavior |

No logic changes; +21 lines across 6 files.

## Verification

`cargo fmt --check`, `cargo clippy --no-deps`, `cargo test`, and `cargo machete` all pass.

Tested against a live draft-16 stream with **no** `RUST_LOG` set. stdout now starts with `ftyp` and contains no log text:

```
00000000: 0000 0024 6674 7970 6973 6f6d 0000 0200  ...$ftypisom....
00000010: 6973 6f6d 6973 6f36 6973 6f32 6176 6331  isomiso6iso2avc1
```

Logs remain visible on stderr:

```
INFO moq_sub: connected with CID: 533a69594f93389a6bd6a7a31d311894 (use this to look up qlog/mlog on server)
INFO moq_sub::media: using 1.m4s for video
INFO moq_sub::media: using 2.m4s for audio
```

`ffprobe` on the captured stdout reports the expected streams:

```
Stream #0:0: Video: h264 (High) (avc1), yuv420p, 1280x720, 24 fps
Stream #0:1: Audio: aac (LC) (mp4a), 44100 Hz, stereo
```

`moq-sub ... | ffplay -` now works without `RUST_LOG=off`.

## Note on behavior change

Anyone capturing logs via shell redirection from these binaries will need `2>` instead of `>` (or `2>&1`). For the server binaries under systemd/journald both streams are captured either way, so no practical impact there.
