### PR TITLE
fix: release upstream subscriptions for idle cached tracks, and stop FIN-ing subgroup streams mid-object

### DIFF
--- a/moq-relay-ietf/Cargo.toml
+++ b/moq-relay-ietf/Cargo.toml
@@ -70,6 +70,11 @@ thiserror = "2.0.17"
 metrics = "0.24"
 metrics-exporter-prometheus = { version = "0.16", optional = true }
 
+[dev-dependencies]
+# test-util provides the paused-clock runtime used to test idle timeouts without
+# sleeping for real.
+tokio = { version = "1", features = ["full", "test-util"] }
+
 [features]
 default = []
 metrics-prometheus = ["dep:metrics-exporter-prometheus"]

--- a/moq-relay-ietf/src/bin/moq-relay-ietf/main.rs
+++ b/moq-relay-ietf/src/bin/moq-relay-ietf/main.rs
@@ -13,6 +13,7 @@ use url::Url;
 use api_coordinator::{ApiCoordinator, ApiCoordinatorConfig};
 use file_coordinator::FileCoordinator;
 use moq_relay_ietf::{Coordinator, Relay, RelayConfig, SessionConfig, Web, WebConfig};
+use std::time::Duration;
 
 #[derive(Parser, Clone)]
 pub struct Cli {
@@ -35,6 +36,12 @@ pub struct Cli {
     /// Maximum request ID plus one advertised in MoQT setup.
     #[arg(long, default_value_t = 100)]
     pub max_request_id: u64,
+
+    /// Seconds to keep a cached track with no subscribers before releasing its
+    /// upstream subscription. 0 disables eviction, holding upstream
+    /// subscriptions for the lifetime of the upstream session.
+    #[arg(long, default_value_t = 30)]
+    pub cache_idle_timeout: u64,
 
     /// Forward all PUBLISH_NAMESPACE messages to the provided server for auth/routing.
     /// If not provided, the relay accepts every unique namespace publish.
@@ -188,23 +195,26 @@ async fn main() -> anyhow::Result<()> {
     };
 
     // Create a QUIC server for media.
-    let relay = Relay::new(RelayConfig {
-        tls: tls.clone(),
-        bind: Some(cli.bind),
-        endpoints: vec![],
-        qlog_dir: qlog_dir_for_relay,
-        mlog_dir: mlog_dir_for_relay,
-        node: cli.node,
-        announce: cli.announce,
-        coordinator,
-        session: SessionConfig {
-            max_request_id: cli.max_request_id,
+    let relay = Relay::new_with_cache_idle_timeout(
+        RelayConfig {
+            tls: tls.clone(),
+            bind: Some(cli.bind),
+            endpoints: vec![],
+            qlog_dir: qlog_dir_for_relay,
+            mlog_dir: mlog_dir_for_relay,
+            node: cli.node,
+            announce: cli.announce,
+            coordinator,
+            session: SessionConfig {
+                max_request_id: cli.max_request_id,
+            },
+            // No connection tagger: the default binary treats every inbound
+            // connection as a public client. Embedders that run relay-to-relay
+            // meshes supply a tagger to mark internal peers.
+            connection_tagger: None,
         },
-        // No connection tagger: the default binary treats every inbound
-        // connection as a public client. Embedders that run relay-to-relay
-        // meshes supply a tagger to mark internal peers.
-        connection_tagger: None,
-    })?;
+        Duration::from_secs(cli.cache_idle_timeout),
+    )?;
 
     if cli.dev {
         // Create a web server too.

--- a/moq-relay-ietf/src/consumer.rs
+++ b/moq-relay-ietf/src/consumer.rs
@@ -386,13 +386,13 @@ impl Consumer {
         }
 
         tracing::debug!(
-            namespace = %namespace.to_utf8_path(),
+            namespace = %namespace,
             track = %track_name,
             "PUBLISH registered as exact local track"
         );
 
         publish.closed().await?;
-        tracing::info!(namespace = %namespace.to_utf8_path(), track = %track_name, "PUBLISH closed");
+        tracing::info!(namespace = %namespace, track = %track_name, "PUBLISH closed");
 
         Ok(())
     }

--- a/moq-relay-ietf/src/consumer.rs
+++ b/moq-relay-ietf/src/consumer.rs
@@ -12,7 +12,9 @@ use moq_transport::{
 };
 use tokio::sync::Semaphore;
 
-use crate::{metrics::GaugeGuard, Coordinator, Locals, Producer, RemoteManager, SessionContext};
+use crate::{
+    metrics::GaugeGuard, Coordinator, Locals, Producer, RemoteManager, SessionContext, TrackRequest,
+};
 
 const MAX_INBOUND_PUBLISH_TRACKS_PER_SESSION: usize = 1024;
 
@@ -254,11 +256,11 @@ impl Consumer {
                     tracing::info!(namespace = %ns, "PUBLISH_NAMESPACE closed");
                     return Ok(());
                 },
-                Some(track) = requests.recv() => {
+                Some(TrackRequest { writer, lease }) = requests.recv() => {
                     let mut subscriber = self.subscriber.clone();
 
                     tasks.push(async move {
-                        let info = track.clone();
+                        let info = writer.info.clone();
                         let namespace = info.namespace.to_utf8_path();
                         let track_name = info.name.clone();
                         tracing::info!(
@@ -267,14 +269,46 @@ impl Consumer {
                             "forwarding subscribe: {:?}", info
                         );
 
-                        if let Err(err) = subscriber.subscribe(track).await {
-                            tracing::warn!(
-                                namespace = %namespace,
-                                track = %track_name,
-                                error = %err,
-                                "failed forwarding subscribe: {:?}", info
-                            )
+                        // Hold the subscription explicitly rather than using
+                        // `subscribe()`, so it can be dropped — sending
+                        // UNSUBSCRIBE — once downstream interest goes away.
+                        let subscribe = match subscriber.subscribe_open(writer).await {
+                            Ok(subscribe) => subscribe,
+                            Err(err) => {
+                                tracing::warn!(
+                                    namespace = %namespace,
+                                    track = %track_name,
+                                    error = %err,
+                                    "failed forwarding subscribe: {:?}", info
+                                );
+                                return Ok(());
+                            }
+                        };
+
+                        tokio::select! {
+                            res = subscribe.closed() => {
+                                if let Err(err) = res {
+                                    tracing::warn!(
+                                        namespace = %namespace,
+                                        track = %track_name,
+                                        error = %err,
+                                        "failed forwarding subscribe: {:?}", info
+                                    )
+                                }
+                            }
+                            // The cached track went unwatched long enough to be
+                            // evicted, so stop pulling it. Dropping `subscribe`
+                            // below sends UNSUBSCRIBE upstream.
+                            _ = lease.released() => {
+                                tracing::info!(
+                                    namespace = %namespace,
+                                    track = %track_name,
+                                    "releasing upstream subscription for idle cached track"
+                                );
+                            }
                         }
+
+                        drop(subscribe);
 
                         Ok(())
                     }.boxed());

--- a/moq-relay-ietf/src/interest.rs
+++ b/moq-relay-ietf/src/interest.rs
@@ -1,0 +1,254 @@
+// SPDX-FileCopyrightText: 2024-2026 Cloudflare Inc., Luke Curley, Mike English and contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Downstream interest tracking for pull-through cache entries.
+//!
+//! When a relay serves a track it does not publish itself, it subscribes
+//! upstream and caches the resulting reader so later subscribers can share it.
+//! Nothing previously counted how many downstream subscribers were actually
+//! using that cached reader, so the upstream subscription lived until the
+//! upstream session died — the relay kept pulling bytes for a track nobody was
+//! watching.
+//!
+//! [`TrackInterest`] is a reference count with the ability to await "nobody has
+//! held a guard for a while". Each downstream subscriber holds a
+//! [`TrackInterestGuard`] for as long as it is being served, so the count is
+//! maintained by RAII and a cancelled subscriber cannot leak a reference.
+//!
+//! Guards hold a strong reference to the counter itself rather than a cache key.
+//! If a cache entry is evicted and a replacement is created for the same track
+//! name, an outstanding guard from the old entry decrements the old counter
+//! instead of making the new entry look busy.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::watch;
+
+/// Shared interest counter for one cache entry.
+#[derive(Clone, Debug)]
+pub struct TrackInterest {
+    inner: Arc<InterestInner>,
+}
+
+#[derive(Debug)]
+struct InterestInner {
+    /// Number of live guards. The count lives in the watch value so that
+    /// mutations and change notifications cannot get out of step.
+    count: watch::Sender<usize>,
+}
+
+impl Default for TrackInterest {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TrackInterest {
+    pub fn new() -> Self {
+        let (count, _) = watch::channel(0);
+        Self {
+            inner: Arc::new(InterestInner { count }),
+        }
+    }
+
+    /// Register a downstream subscriber, releasing the interest on drop.
+    ///
+    /// Callers must create the guard while holding the same cache lock that
+    /// [`TrackInterest::is_idle`] is checked under, so a subscriber arriving
+    /// concurrently with eviction is either counted or gets a fresh entry.
+    pub fn guard(&self) -> TrackInterestGuard {
+        self.inner.count.send_modify(|count| *count += 1);
+        TrackInterestGuard {
+            inner: self.inner.clone(),
+        }
+    }
+
+    /// Current number of downstream subscribers.
+    pub fn count(&self) -> usize {
+        *self.inner.count.borrow()
+    }
+
+    /// True when no downstream subscriber is being served from this entry.
+    pub fn is_idle(&self) -> bool {
+        self.count() == 0
+    }
+
+    /// True when both handles refer to the same counter, i.e. the same cache
+    /// entry generation.
+    pub fn same_generation(&self, other: &TrackInterest) -> bool {
+        Arc::ptr_eq(&self.inner, &other.inner)
+    }
+
+    /// Resolve once the count has been continuously zero for `grace`.
+    ///
+    /// The timer restarts whenever a subscriber appears, so a track that keeps
+    /// picking up new subscribers is never considered idle. A zero `grace`
+    /// resolves as soon as the count reaches zero.
+    pub async fn idle_for(&self, grace: Duration) {
+        let mut rx = self.inner.count.subscribe();
+
+        loop {
+            // Scoped so the borrow is released before the awaits below.
+            let busy = { *rx.borrow_and_update() > 0 };
+
+            if busy {
+                // Wait for the count to change at all before re-checking.
+                if rx.changed().await.is_err() {
+                    // Sender gone, so the entry is unreachable; treat as idle.
+                    return;
+                }
+                continue;
+            }
+
+            if grace.is_zero() {
+                return;
+            }
+
+            tokio::select! {
+                _ = tokio::time::sleep(grace) => return,
+                // A subscriber arrived (or another change landed) inside the
+                // grace period; go around again and restart the timer.
+                res = rx.changed() => {
+                    if res.is_err() {
+                        return;
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Held for as long as a downstream subscriber is served from a cache entry.
+#[derive(Debug)]
+pub struct TrackInterestGuard {
+    inner: Arc<InterestInner>,
+}
+
+impl Drop for TrackInterestGuard {
+    fn drop(&mut self) {
+        self.inner.count.send_modify(|count| {
+            // Saturating because an underflow here would make a busy track look
+            // permanently busy, pinning the upstream subscription forever.
+            *count = count.saturating_sub(1);
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use tokio::time::Instant;
+
+    const GRACE: Duration = Duration::from_millis(50);
+
+    #[test]
+    fn guards_count_subscribers() {
+        let interest = TrackInterest::new();
+        assert_eq!(interest.count(), 0);
+        assert!(interest.is_idle());
+
+        let first = interest.guard();
+        assert_eq!(interest.count(), 1);
+        assert!(!interest.is_idle());
+
+        let second = interest.guard();
+        assert_eq!(interest.count(), 2);
+
+        drop(first);
+        assert_eq!(interest.count(), 1);
+
+        drop(second);
+        assert_eq!(interest.count(), 0);
+        assert!(interest.is_idle());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn idle_for_resolves_when_nobody_subscribes() {
+        let interest = TrackInterest::new();
+        let start = Instant::now();
+
+        interest.idle_for(GRACE).await;
+
+        assert!(start.elapsed() >= GRACE);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn idle_for_waits_for_the_last_subscriber_to_leave() {
+        let interest = TrackInterest::new();
+        let guard = interest.guard();
+
+        let idle = interest.idle_for(GRACE);
+        tokio::pin!(idle);
+
+        // Busy: must not resolve no matter how long we wait.
+        tokio::select! {
+            _ = &mut idle => panic!("a busy track must never look idle"),
+            _ = tokio::time::sleep(GRACE * 10) => {}
+        }
+
+        drop(guard);
+        idle.await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn a_new_subscriber_restarts_the_grace_period() {
+        let interest = TrackInterest::new();
+
+        let idle = interest.idle_for(GRACE);
+        tokio::pin!(idle);
+
+        // Part-way through the grace period a subscriber arrives, so the entry
+        // must stop looking idle rather than being evicted out from under it.
+        tokio::select! {
+            _ = &mut idle => panic!("resolved before the grace period elapsed"),
+            _ = tokio::time::sleep(GRACE / 2) => {}
+        }
+
+        let guard = interest.guard();
+
+        tokio::select! {
+            _ = &mut idle => panic!("resolved while a subscriber was present"),
+            _ = tokio::time::sleep(GRACE * 10) => {}
+        }
+
+        // Once it leaves, a full grace period must pass again.
+        drop(guard);
+        let after_drop = Instant::now();
+        idle.await;
+        assert!(after_drop.elapsed() >= GRACE);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn zero_grace_resolves_immediately_when_idle() {
+        let interest = TrackInterest::new();
+        interest.idle_for(Duration::ZERO).await;
+    }
+
+    #[test]
+    fn generations_are_distinguished_by_identity() {
+        let interest = TrackInterest::new();
+        let clone = interest.clone();
+        let replacement = TrackInterest::new();
+
+        assert!(interest.same_generation(&clone));
+        assert!(!interest.same_generation(&replacement));
+    }
+
+    #[test]
+    fn a_stale_guard_does_not_make_a_replacement_look_busy() {
+        // A subscriber served by an evicted entry can outlive that entry. Its
+        // guard must decrement the old counter, not the new one.
+        let old = TrackInterest::new();
+        let stale_guard = old.guard();
+
+        let new = TrackInterest::new();
+        assert!(new.is_idle());
+
+        drop(stale_guard);
+
+        assert_eq!(old.count(), 0);
+        assert!(new.is_idle(), "replacement entry should still be idle");
+    }
+}

--- a/moq-relay-ietf/src/lib.rs
+++ b/moq-relay-ietf/src/lib.rs
@@ -37,6 +37,7 @@ mod api;
 mod consumer;
 mod coordinator;
 mod covering_prefix_set;
+mod interest;
 mod local;
 pub mod metrics;
 mod producer;

--- a/moq-relay-ietf/src/local.rs
+++ b/moq-relay-ietf/src/local.rs
@@ -4,6 +4,7 @@
 use std::collections::hash_map;
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock, Weak};
+use std::time::Duration;
 
 use moq_transport::{
     coding::{TrackNamespace, TrackNamespacePrefix},
@@ -11,6 +12,7 @@ use moq_transport::{
 };
 use tokio::sync::{broadcast, mpsc};
 
+use crate::interest::{TrackInterest, TrackInterestGuard};
 use crate::metrics::GaugeGuard;
 
 /// Scope key for the outer level of the two-level registry.
@@ -26,6 +28,15 @@ const UNSCOPED: &str = "";
 
 const NAMESPACE_REQUEST_CHANNEL_CAPACITY: usize = 1024;
 
+/// How long a pull-through cache entry with no downstream subscribers is kept
+/// before the upstream subscription is released.
+///
+/// The grace period keeps the common case cheap: a subscriber reconnecting, or a
+/// player switching between renditions, reuses the warm cache entry instead of
+/// paying a fresh upstream SUBSCRIBE round trip. Past that we stop paying to
+/// receive a track nobody is watching.
+pub const DEFAULT_CACHE_IDLE_TIMEOUT: Duration = Duration::from_secs(30);
+
 /// Capacity of the namespace add/remove notification broadcast channel used by
 /// SUBSCRIBE_NAMESPACE handlers.
 const NAMESPACE_CHANGE_CHANNEL_CAPACITY: usize = 1024;
@@ -36,7 +47,68 @@ const TRACK_CHANGE_CHANNEL_CAPACITY: usize = 1024;
 
 #[derive(Clone)]
 struct NamespaceSource {
-    requests: mpsc::Sender<TrackWriter>,
+    requests: mpsc::Sender<TrackRequest>,
+}
+
+/// A request for a track that is not cached yet, sent to the session that
+/// advertised the namespace so it can SUBSCRIBE upstream.
+pub struct TrackRequest {
+    /// Writer the upstream subscription should fill.
+    pub writer: TrackWriter,
+
+    /// Lease on the pull-through cache entry backing this request.
+    ///
+    /// The requester should hold the upstream subscription open until
+    /// [`CacheLease::released`] resolves, then drop it to send UNSUBSCRIBE.
+    pub lease: CacheLease,
+}
+
+/// Ties an upstream subscription to downstream interest in its cache entry.
+///
+/// Handed to whichever session owns the upstream subscription so it can tell when
+/// the cached track has gone unwatched and stop paying for it.
+pub struct CacheLease {
+    locals: Locals,
+    scope_key: ScopeKey,
+    full_name: FullTrackName,
+    interest: TrackInterest,
+}
+
+impl CacheLease {
+    /// Resolve once the cache entry has been evicted for lack of interest.
+    ///
+    /// The caller should drop its upstream subscription when this returns, which
+    /// sends UNSUBSCRIBE. Eviction happens first so that a subscriber arriving
+    /// afterwards misses the cache and triggers a fresh upstream SUBSCRIBE,
+    /// rather than attaching to a reader that is about to stop being fed.
+    ///
+    /// Never resolves when the idle timeout is disabled, preserving the previous
+    /// behaviour of holding the upstream subscription for the session's lifetime.
+    pub async fn released(&self) {
+        let timeout = self.locals.cache_idle_timeout;
+        if timeout.is_zero() {
+            std::future::pending::<()>().await;
+        }
+
+        loop {
+            self.interest.idle_for(timeout).await;
+
+            if self
+                .locals
+                .evict_idle_cache_entry(&self.scope_key, &self.full_name, &self.interest)
+            {
+                return;
+            }
+
+            // A subscriber arrived between the timer firing and the eviction
+            // taking the lock, so the entry is busy again. Go back to waiting.
+            tracing::trace!(
+                namespace = %self.full_name.namespace.to_utf8_path(),
+                track = %self.full_name.name,
+                "cache eviction abandoned; downstream interest returned"
+            );
+        }
+    }
 }
 
 struct NamespaceEntry {
@@ -53,6 +125,12 @@ struct RemoteNamespaceSource {
 struct TrackEntry {
     reader: TrackReader,
     source: TrackSource,
+
+    /// Downstream interest in this entry, for [`TrackSource::Cache`] entries only.
+    ///
+    /// Locally published tracks have no upstream subscription to release, so
+    /// there is nothing to count.
+    interest: Option<TrackInterest>,
 }
 
 #[derive(Clone, Copy, Eq, PartialEq)]
@@ -100,6 +178,10 @@ pub struct Locals {
 
     /// Actual PUBLISH track add/remove notifications for Publish/Both fan-out.
     track_changes: broadcast::Sender<TrackChange>,
+
+    /// How long an unwatched pull-through cache entry is retained before its
+    /// upstream subscription is released. Zero disables eviction.
+    cache_idle_timeout: Duration,
 }
 
 impl Default for Locals {
@@ -110,6 +192,14 @@ impl Default for Locals {
 
 impl Locals {
     pub fn new() -> Self {
+        Self::with_cache_idle_timeout(DEFAULT_CACHE_IDLE_TIMEOUT)
+    }
+
+    /// Build a registry with a custom pull-through cache idle timeout.
+    ///
+    /// A zero timeout disables idle eviction, holding upstream subscriptions for
+    /// as long as the upstream session lives.
+    pub fn with_cache_idle_timeout(cache_idle_timeout: Duration) -> Self {
         let (namespace_changes, _) = broadcast::channel(NAMESPACE_CHANGE_CHANNEL_CAPACITY);
         let (track_changes, _) = broadcast::channel(TRACK_CHANGE_CHANNEL_CAPACITY);
         Self {
@@ -117,6 +207,7 @@ impl Locals {
             namespaces: Default::default(),
             namespace_changes,
             track_changes,
+            cache_idle_timeout,
         }
     }
 
@@ -220,7 +311,7 @@ impl Locals {
         &mut self,
         scope: Option<&str>,
         namespace: TrackNamespace,
-    ) -> anyhow::Result<(LocalNamespaceRegistration, mpsc::Receiver<TrackWriter>)> {
+    ) -> anyhow::Result<(LocalNamespaceRegistration, mpsc::Receiver<TrackRequest>)> {
         let scope_key = scope.unwrap_or(UNSCOPED).to_string();
         let (tx, rx) = mpsc::channel(NAMESPACE_REQUEST_CHANNEL_CAPACITY);
 
@@ -352,6 +443,9 @@ impl Locals {
             hash_map::Entry::Vacant(entry) => entry.insert(TrackEntry {
                 reader: track.clone(),
                 source: TrackSource::Published,
+                // A locally published track has no upstream subscription to
+                // release, so there is nothing to count interest against.
+                interest: None,
             }),
             hash_map::Entry::Occupied(_) => return Err(ServeError::Duplicate.into()),
         };
@@ -394,6 +488,69 @@ impl Locals {
         None
     }
 
+    /// Remove an unwatched pull-through cache entry.
+    ///
+    /// Returns false, leaving the entry in place, if interest returned before the
+    /// write lock was acquired, or if the entry has since been replaced by a
+    /// different generation or by a locally published track.
+    ///
+    /// The idle check happens under the same lock that guards are created under,
+    /// so a subscriber racing eviction either gets counted here (and eviction is
+    /// abandoned) or misses the cache entirely and requests a fresh one.
+    fn evict_idle_cache_entry(
+        &self,
+        scope_key: &str,
+        full_name: &FullTrackName,
+        interest: &TrackInterest,
+    ) -> bool {
+        let Ok(mut tracks) = self.tracks.write() else {
+            // A poisoned registry means we can no longer reason about the entry;
+            // release the upstream subscription rather than pinning it forever.
+            return true;
+        };
+
+        let Some(bucket) = tracks.get_mut(scope_key) else {
+            return true;
+        };
+
+        match bucket.get(full_name) {
+            Some(entry) => {
+                // Only evict the generation this lease belongs to. A replacement
+                // entry has its own lease and its own idle timer.
+                let ours = entry
+                    .interest
+                    .as_ref()
+                    .is_some_and(|current| current.same_generation(interest));
+
+                if !ours {
+                    return true;
+                }
+
+                if !interest.is_idle() {
+                    return false;
+                }
+
+                bucket.remove(full_name);
+            }
+            // Already gone (e.g. pruned as closed), so the upstream subscription
+            // is no longer serving anything.
+            None => return true,
+        }
+
+        if bucket.is_empty() {
+            tracks.remove(scope_key);
+        }
+
+        tracing::debug!(
+            namespace = %full_name.namespace.to_utf8_path(),
+            track = %full_name.name,
+            "evicting idle cached track and releasing upstream subscription"
+        );
+        metrics::counter!("moq_relay_cache_idle_evictions_total", "source" => "local").increment(1);
+
+        true
+    }
+
     /// Return the best namespace route source for a requested namespace.
     fn route_namespace(
         &self,
@@ -433,20 +590,24 @@ impl Locals {
     /// This replaces the old `TracksReader::subscribe` relay registry behavior:
     /// the actual track reader is stored in `tracks`, while PUBLISH_NAMESPACE is
     /// only a source to ask when a track is missing.
+    /// Returns the reader plus, for pull-through cache entries, a guard the caller
+    /// must hold for as long as it is serving that reader. Dropping the guard is
+    /// what eventually lets the upstream subscription be released.
     pub async fn get_or_request_track(
         &mut self,
         scope: Option<&str>,
         namespace: TrackNamespace,
         track_name: impl Into<moq_transport::coding::TrackName>,
-    ) -> Option<TrackReader> {
+    ) -> Option<(TrackReader, Option<TrackInterestGuard>)> {
         let track_name = track_name.into();
         let full_name = FullTrackName {
             namespace: namespace.clone(),
             name: track_name.clone(),
         };
+        let scope_key = scope.unwrap_or(UNSCOPED).to_string();
 
-        if let Some(track) = self.retrieve_track(scope, &full_name) {
-            return Some(track);
+        if let Some(hit) = self.retrieve_track_with_interest(&scope_key, &full_name) {
+            return Some(hit);
         }
 
         let source = self.route_namespace(scope, &namespace)?;
@@ -456,40 +617,116 @@ impl Locals {
         // that finds no live entry claims the slot with a freshly produced track and
         // owns requesting it from the source; concurrent callers share the reserved
         // reader instead of racing to insert and failing with a spurious `None`.
-        let (writer, reader) = {
+        let (writer, reader, interest, guard) = {
             let mut tracks = self.tracks.write().ok()?;
-            let bucket = tracks
-                .entry(scope.unwrap_or(UNSCOPED).to_string())
-                .or_default();
+            let bucket = tracks.entry(scope_key.clone()).or_default();
 
             if let Some(entry) = bucket.get(&full_name) {
                 if !entry.reader.is_closed() {
-                    return Some(entry.reader.clone());
+                    let guard = entry.interest.as_ref().map(TrackInterest::guard);
+                    return Some((entry.reader.clone(), guard));
                 }
             }
 
             // Vacant slot (or a stale, closed reader): claim it with a fresh track.
             let (writer, reader) = Track::new(namespace, track_name).produce();
+            let interest = TrackInterest::new();
+
+            // Take this caller's guard before the entry is visible to anyone
+            // else, so the entry can never be seen as idle while we are still
+            // setting up the upstream subscription.
+            let guard = interest.guard();
+
             bucket.insert(
                 full_name.clone(),
                 TrackEntry {
                     reader: reader.clone(),
                     source: TrackSource::Cache,
+                    interest: Some(interest.clone()),
                 },
             );
-            (writer, reader)
+            (writer, reader, interest, guard)
         };
 
-        if source.requests.send(writer).await.is_err() {
-            if let Ok(mut tracks) = self.tracks.write() {
-                if let Some(bucket) = tracks.get_mut(scope.unwrap_or(UNSCOPED)) {
-                    bucket.remove(&full_name);
-                }
-            }
+        let lease = CacheLease {
+            locals: self.clone(),
+            scope_key: scope_key.clone(),
+            full_name: full_name.clone(),
+            interest: interest.clone(),
+        };
+
+        if source
+            .requests
+            .send(TrackRequest { writer, lease })
+            .await
+            .is_err()
+        {
+            // The source is gone, so nothing will ever fill this reader. Remove
+            // the slot we claimed, but only if it is still ours: a concurrent
+            // caller may already have replaced it with a live generation.
+            self.remove_cache_generation(&scope_key, &full_name, &interest);
             return None;
         }
 
-        Some(reader)
+        Some((reader, Some(guard)))
+    }
+
+    /// Remove a cache entry if it is still the given generation, regardless of
+    /// whether anyone is currently interested in it.
+    fn remove_cache_generation(
+        &self,
+        scope_key: &str,
+        full_name: &FullTrackName,
+        interest: &TrackInterest,
+    ) {
+        let Ok(mut tracks) = self.tracks.write() else {
+            return;
+        };
+        let Some(bucket) = tracks.get_mut(scope_key) else {
+            return;
+        };
+
+        let ours = bucket.get(full_name).is_some_and(|entry| {
+            entry
+                .interest
+                .as_ref()
+                .is_some_and(|current| current.same_generation(interest))
+        });
+
+        if ours {
+            bucket.remove(full_name);
+        }
+
+        if bucket.is_empty() {
+            tracks.remove(scope_key);
+        }
+    }
+
+    /// Cache lookup that also registers interest, under a single lock.
+    ///
+    /// Interest must be registered while the lock is held: taking the guard after
+    /// releasing it would leave a window where eviction sees an idle entry and
+    /// removes the reader this caller is about to serve.
+    fn retrieve_track_with_interest(
+        &self,
+        scope_key: &str,
+        full_name: &FullTrackName,
+    ) -> Option<(TrackReader, Option<TrackInterestGuard>)> {
+        {
+            let tracks = self.tracks.read().ok()?;
+            let bucket = tracks.get(scope_key)?;
+            match bucket.get(full_name) {
+                Some(entry) if !entry.reader.is_closed() => {
+                    let guard = entry.interest.as_ref().map(TrackInterest::guard);
+                    return Some((entry.reader.clone(), guard));
+                }
+                Some(_) => {} // closed: fall through to prune under the write lock
+                None => return None,
+            }
+        }
+
+        self.prune_closed_tracks(scope_key, std::slice::from_ref(full_name));
+        None
     }
 }
 
@@ -823,17 +1060,21 @@ mod tests {
             .await
             .expect("namespace source should register");
 
-        let reader = locals
+        let (reader, guard) = locals
             .get_or_request_track(None, namespace.clone(), "video")
             .await
             .expect("missing track should be requested from namespace source");
+        assert!(
+            guard.is_some(),
+            "a cached track should hand back an interest guard"
+        );
 
         let requested = requests
             .recv()
             .await
-            .expect("source should get TrackWriter");
-        assert_eq!(requested.namespace, namespace);
-        assert_eq!(requested.name, TrackName::from("video"));
+            .expect("source should get TrackRequest");
+        assert_eq!(requested.writer.namespace, namespace);
+        assert_eq!(requested.writer.name, TrackName::from("video"));
 
         let key = full(&namespace, "video");
         let cached = locals
@@ -842,7 +1083,7 @@ mod tests {
         assert_eq!(cached.namespace, reader.namespace);
         assert_eq!(cached.name, reader.name);
 
-        let reader_again = locals
+        let (reader_again, _guard_again) = locals
             .get_or_request_track(None, namespace.clone(), "video")
             .await
             .expect("cached track should be returned");
@@ -873,8 +1114,9 @@ mod tests {
             second.get_or_request_track(None, namespace.clone(), "video"),
         );
 
-        let first_reader = first_reader.expect("first request should get a reader");
-        let second_reader = second_reader.expect("second request should get cached reader");
+        let (first_reader, _first_guard) = first_reader.expect("first request should get a reader");
+        let (second_reader, _second_guard) =
+            second_reader.expect("second request should get cached reader");
         assert_eq!(first_reader.namespace, namespace);
         assert_eq!(second_reader.namespace, namespace);
         assert_eq!(first_reader.name, TrackName::from("video"));
@@ -883,7 +1125,7 @@ mod tests {
         requests
             .recv()
             .await
-            .expect("source should receive one TrackWriter");
+            .expect("source should receive one TrackRequest");
         let no_second_request =
             tokio::time::timeout(std::time::Duration::from_millis(50), requests.recv()).await;
         assert!(
@@ -925,8 +1167,8 @@ mod tests {
             let first = requests
                 .recv()
                 .await
-                .expect("source should receive exactly one TrackWriter");
-            assert_eq!(first.namespace, namespace);
+                .expect("source should receive exactly one TrackRequest");
+            assert_eq!(first.writer.namespace, namespace);
             let extra =
                 tokio::time::timeout(std::time::Duration::from_millis(50), requests.recv()).await;
             assert!(
@@ -949,7 +1191,7 @@ mod tests {
             .expect("long prefix should register");
 
         let requested_ns = ns("room/123/camera");
-        let reader = locals
+        let (reader, _guard) = locals
             .get_or_request_track(None, requested_ns.clone(), "video")
             .await
             .expect("track should be requested from longest prefix");
@@ -959,8 +1201,8 @@ mod tests {
             .recv()
             .await
             .expect("longest prefix should receive the request");
-        assert_eq!(long_request.namespace, ns("room/123/camera"));
-        assert_eq!(long_request.name, TrackName::from("video"));
+        assert_eq!(long_request.writer.namespace, ns("room/123/camera"));
+        assert_eq!(long_request.writer.name, TrackName::from("video"));
 
         let no_short_request =
             tokio::time::timeout(std::time::Duration::from_millis(50), short_requests.recv()).await;
@@ -1203,5 +1445,216 @@ mod tests {
             }
             TrackChange::Added { .. } => panic!("expected removed event"),
         }
+    }
+    /// The core fix: once the last downstream subscriber leaves, the cache entry
+    /// is evicted and the lease resolves so the upstream subscription can be
+    /// dropped (sending UNSUBSCRIBE).
+    #[tokio::test(start_paused = true)]
+    async fn idle_cached_track_is_evicted_and_lease_released() {
+        let idle = Duration::from_secs(30);
+        let mut locals = Locals::with_cache_idle_timeout(idle);
+        let namespace = ns("room/123");
+        let (_registration, mut requests) = locals
+            .register_namespace(None, namespace.clone())
+            .await
+            .expect("namespace source should register");
+
+        let (_reader, guard) = locals
+            .get_or_request_track(None, namespace.clone(), "video")
+            .await
+            .expect("missing track should be requested");
+        let guard = guard.expect("cached track should hand back a guard");
+
+        let request = requests.recv().await.expect("source should get a request");
+        let key = full(&namespace, "video");
+
+        // While a subscriber is being served the entry must stay put.
+        let released = request.lease.released();
+        tokio::pin!(released);
+        tokio::select! {
+            _ = &mut released => panic!("evicted a track that still has a subscriber"),
+            _ = tokio::time::sleep(idle * 4) => {}
+        }
+        assert!(locals.retrieve_track(None, &key).is_some());
+
+        // Last subscriber leaves: the entry lingers for the grace period, then goes.
+        drop(guard);
+        tokio::select! {
+            _ = &mut released => panic!("evicted before the grace period elapsed"),
+            _ = tokio::time::sleep(idle / 2) => {}
+        }
+        assert!(
+            locals.retrieve_track(None, &key).is_some(),
+            "a warm cache entry should survive a brief gap between subscribers"
+        );
+
+        released.await;
+        assert!(
+            locals.retrieve_track(None, &key).is_none(),
+            "idle entry should be evicted so the next subscriber re-requests upstream"
+        );
+    }
+
+    /// A subscriber arriving during the grace period keeps the warm entry, and no
+    /// second upstream request is made.
+    #[tokio::test(start_paused = true)]
+    async fn subscriber_returning_within_grace_period_reuses_the_entry() {
+        let idle = Duration::from_secs(30);
+        let mut locals = Locals::with_cache_idle_timeout(idle);
+        let namespace = ns("room/123");
+        let (_registration, mut requests) = locals
+            .register_namespace(None, namespace.clone())
+            .await
+            .expect("namespace source should register");
+
+        let (_reader, guard) = locals
+            .get_or_request_track(None, namespace.clone(), "video")
+            .await
+            .expect("missing track should be requested");
+        let request = requests.recv().await.expect("source should get a request");
+
+        let released = request.lease.released();
+        tokio::pin!(released);
+
+        drop(guard.expect("cached track should hand back a guard"));
+
+        tokio::select! {
+            _ = &mut released => panic!("evicted before the grace period elapsed"),
+            _ = tokio::time::sleep(idle / 2) => {}
+        }
+
+        // New subscriber inside the grace period: served from cache, no new request.
+        let (_reader, guard) = locals
+            .get_or_request_track(None, namespace.clone(), "video")
+            .await
+            .expect("warm entry should still be served");
+        let guard = guard.expect("cached track should hand back a guard");
+
+        tokio::select! {
+            _ = &mut released => panic!("evicted while a subscriber was present"),
+            _ = tokio::time::sleep(idle * 4) => {}
+        }
+
+        assert!(
+            requests.try_recv().is_err(),
+            "reusing the warm entry must not trigger a second upstream SUBSCRIBE"
+        );
+
+        // And it still gets evicted once that subscriber leaves too.
+        drop(guard);
+        released.await;
+        assert!(locals
+            .retrieve_track(None, &full(&namespace, "video"))
+            .is_none());
+    }
+
+    /// A subscriber that gives up before the upstream subscription is even set up
+    /// must not pin the entry forever.
+    #[tokio::test(start_paused = true)]
+    async fn cancelled_requester_does_not_pin_the_upstream_subscription() {
+        let idle = Duration::from_secs(30);
+        let mut locals = Locals::with_cache_idle_timeout(idle);
+        let namespace = ns("room/123");
+        let (_registration, mut requests) = locals
+            .register_namespace(None, namespace.clone())
+            .await
+            .expect("namespace source should register");
+
+        let (_reader, guard) = locals
+            .get_or_request_track(None, namespace.clone(), "video")
+            .await
+            .expect("missing track should be requested");
+
+        // The subscriber goes away before the source has even picked up the
+        // request, which is what a cancelled SUBSCRIBE looks like.
+        drop(guard);
+
+        let request = requests.recv().await.expect("source should get a request");
+        request.lease.released().await;
+
+        assert!(
+            locals
+                .retrieve_track(None, &full(&namespace, "video"))
+                .is_none(),
+            "an abandoned request must not leave a permanently leased entry"
+        );
+    }
+
+    /// A zero timeout preserves the old behaviour: the upstream subscription is
+    /// held for as long as the session lives.
+    #[tokio::test(start_paused = true)]
+    async fn zero_idle_timeout_disables_eviction() {
+        let mut locals = Locals::with_cache_idle_timeout(Duration::ZERO);
+        let namespace = ns("room/123");
+        let (_registration, mut requests) = locals
+            .register_namespace(None, namespace.clone())
+            .await
+            .expect("namespace source should register");
+
+        let (_reader, guard) = locals
+            .get_or_request_track(None, namespace.clone(), "video")
+            .await
+            .expect("missing track should be requested");
+        let request = requests.recv().await.expect("source should get a request");
+
+        drop(guard);
+
+        tokio::select! {
+            _ = request.lease.released() => panic!("eviction should be disabled"),
+            _ = tokio::time::sleep(Duration::from_secs(3600)) => {}
+        }
+
+        assert!(locals
+            .retrieve_track(None, &full(&namespace, "video"))
+            .is_some());
+    }
+
+    /// A guard from an evicted generation must not keep a replacement entry alive.
+    #[tokio::test(start_paused = true)]
+    async fn stale_guard_does_not_block_eviction_of_a_replacement() {
+        let idle = Duration::from_secs(30);
+        let mut locals = Locals::with_cache_idle_timeout(idle);
+        let namespace = ns("room/123");
+        let (_registration, mut requests) = locals
+            .register_namespace(None, namespace.clone())
+            .await
+            .expect("namespace source should register");
+
+        let (_reader, first_guard) = locals
+            .get_or_request_track(None, namespace.clone(), "video")
+            .await
+            .expect("first request");
+        let first_request = requests.recv().await.expect("first request received");
+
+        // Drop the first generation's entry while deliberately keeping its guard
+        // alive, modelling a slow subscriber that outlives its cache entry.
+        let stale_guard = first_guard.expect("guard");
+        let key = full(&namespace, "video");
+        locals
+            .tracks
+            .write()
+            .unwrap()
+            .get_mut(UNSCOPED)
+            .unwrap()
+            .remove(&key);
+        drop(first_request);
+
+        // A second subscriber creates a fresh generation.
+        let (_reader, second_guard) = locals
+            .get_or_request_track(None, namespace.clone(), "video")
+            .await
+            .expect("second request");
+        let second_request = requests.recv().await.expect("second request received");
+        drop(second_guard.expect("guard"));
+
+        // The stale guard belongs to the old counter, so it must not make the new
+        // entry look busy.
+        let _ = &stale_guard;
+        second_request.lease.released().await;
+
+        assert!(
+            locals.retrieve_track(None, &key).is_none(),
+            "a stale guard must not pin a replacement entry"
+        );
     }
 }

--- a/moq-relay-ietf/src/local.rs
+++ b/moq-relay-ietf/src/local.rs
@@ -103,7 +103,7 @@ impl CacheLease {
             // A subscriber arrived between the timer firing and the eviction
             // taking the lock, so the entry is busy again. Go back to waiting.
             tracing::trace!(
-                namespace = %self.full_name.namespace.to_utf8_path(),
+                namespace = %self.full_name.namespace,
                 track = %self.full_name.name,
                 "cache eviction abandoned; downstream interest returned"
             );
@@ -542,7 +542,7 @@ impl Locals {
         }
 
         tracing::debug!(
-            namespace = %full_name.namespace.to_utf8_path(),
+            namespace = %full_name.namespace,
             track = %full_name.name,
             "evicting idle cached track and releasing upstream subscription"
         );

--- a/moq-relay-ietf/src/metrics.rs
+++ b/moq-relay-ietf/src/metrics.rs
@@ -31,6 +31,9 @@
 //! | `moq_relay_subscribe_route_errors_total` | - | Infrastructure failure when routing to remote |
 //! | `moq_relay_upstream_errors_total` | `stage` | Upstream connection failures (stage: connect, session) |
 //! | `moq_relay_namespace_transition_timeouts_total` | - | Namespace pull streams reset after graceful transition timeout |
+//! | `moq_relay_cache_idle_evictions_total` | `source` | Unwatched cache entries evicted, releasing an upstream subscription (source: local, remote) |
+//! | `moq_relay_change_channel_lagged_total` | `channel` | Change notifications skipped by a lagging receiver, forcing a resync (channel: namespace, track) |
+//! | `moq_relay_lease_registry_lock_poisoned_total` | `operation` | Upstream namespace lease registry lock found poisoned (operation: acquire, release) |
 //!
 //! ## Gauges
 //!
@@ -112,6 +115,18 @@ pub fn describe_metrics() {
     describe_counter!(
         "moq_relay_namespace_transition_timeouts_total",
         "Namespace pull streams reset after graceful transition timeout"
+    );
+    describe_counter!(
+        "moq_relay_cache_idle_evictions_total",
+        "Unwatched cache entries evicted, releasing an upstream subscription, by source (local, remote)"
+    );
+    describe_counter!(
+        "moq_relay_change_channel_lagged_total",
+        "Change notifications skipped by a lagging receiver, forcing a resync, by channel (namespace, track)"
+    );
+    describe_counter!(
+        "moq_relay_lease_registry_lock_poisoned_total",
+        "Upstream namespace lease registry lock found poisoned by operation (acquire, release)"
     );
 
     // Gauges

--- a/moq-relay-ietf/src/producer.rs
+++ b/moq-relay-ietf/src/producer.rs
@@ -305,7 +305,13 @@ impl Producer {
                         Ok(change) => {
                             self.apply_namespace_change(&mut subscribed_namespace, &mut known_namespaces, change)?;
                         }
-                        Err(broadcast::error::RecvError::Lagged(_)) => {
+                        Err(broadcast::error::RecvError::Lagged(skipped)) => {
+                            // Recoverable: a full resync reconstructs the state the
+                            // skipped events would have produced. Counted so that
+                            // sustained churn outgrowing the channel capacity is
+                            // visible before it shows up as latency.
+                            metrics::counter!("moq_relay_change_channel_lagged_total", "channel" => "namespace")
+                                .increment(skipped);
                             self.resync_namespaces(&mut subscribed_namespace, &mut known_namespaces)?;
                         }
                         Err(broadcast::error::RecvError::Closed) => return Ok(()),
@@ -316,7 +322,9 @@ impl Producer {
                         Ok(change) => {
                             self.apply_track_change(&subscribed_namespace, &mut known_tracks, &mut publish_tasks, change).await?;
                         }
-                        Err(broadcast::error::RecvError::Lagged(_)) => {
+                        Err(broadcast::error::RecvError::Lagged(skipped)) => {
+                            metrics::counter!("moq_relay_change_channel_lagged_total", "channel" => "track")
+                                .increment(skipped);
                             self.resync_publish_tracks(&subscribed_namespace, &mut known_tracks, &mut publish_tasks).await?;
                         }
                         Err(broadcast::error::RecvError::Closed) => return Ok(()),

--- a/moq-relay-ietf/src/producer.rs
+++ b/moq-relay-ietf/src/producer.rs
@@ -239,7 +239,7 @@ impl Producer {
                 Ok(lease) => Some(lease),
                 Err(error) => {
                     tracing::error!(
-                        prefix = %subscribed_namespace.namespace_prefix.to_utf8_path(),
+                        prefix = %subscribed_namespace.namespace_prefix,
                         error = %error,
                         "failed to acquire shared upstream namespace lease; serving local state only"
                     );

--- a/moq-relay-ietf/src/producer.rs
+++ b/moq-relay-ietf/src/producer.rs
@@ -154,7 +154,7 @@ impl Producer {
         // 1. actual FullTrackName -> TrackReader media cache
         // 2. PUBLISH_NAMESPACE route source, which triggers upstream SUBSCRIBE
         let mut locals = self.locals.clone();
-        if let Some(track) = locals
+        if let Some((track, interest_guard)) = locals
             .get_or_request_track(self.context.scope(), namespace.clone(), &track_name)
             .await
         {
@@ -162,6 +162,9 @@ impl Producer {
             tracing::info!(namespace = %ns, track = %track_name, source = "local", "serving subscribe from local: {:?}", track.info);
             timing_guard.set_label("source", "local");
             let _track_guard = GaugeGuard::new("moq_relay_active_tracks");
+            // Held until serving finishes. Once the last guard for a cached track
+            // drops, its upstream subscription becomes eligible for release.
+            let _interest_guard = interest_guard;
             return Ok(subscribed.serve(track).await?);
         }
 
@@ -172,13 +175,16 @@ impl Producer {
             .await
         {
             Ok(track) => {
-                if let Some(track) = track {
+                if let Some((track, interest_guard)) = track {
                     let ns = namespace.to_utf8_path();
                     tracing::info!(namespace = %ns, track = %track_name, source = "remote", "serving subscribe from remote: {:?}", track.info);
                     // Update label to indicate remote source, timing recorded on drop
                     timing_guard.set_label("source", "remote");
                     // Track active tracks - decrements when serve completes
                     let _track_guard = GaugeGuard::new("moq_relay_active_tracks");
+                    // Held until serving finishes; the cross-relay subscription is
+                    // released once the last guard for this track drops.
+                    let _interest_guard = interest_guard;
                     return Ok(subscribed.serve(track).await?);
                 }
             }

--- a/moq-relay-ietf/src/relay.rs
+++ b/moq-relay-ietf/src/relay.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2024-2026 Cloudflare Inc., Luke Curley, Mike English and contributors
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use std::{future::Future, net, path::PathBuf, pin::Pin, sync::Arc};
+use std::{future::Future, net, path::PathBuf, pin::Pin, sync::Arc, time::Duration};
 
 use anyhow::Context;
 
@@ -13,7 +13,7 @@ use url::Url;
 use crate::upstream_namespaces::{UpstreamNamespaces, UpstreamNamespacesRunner};
 use crate::{
     metrics::GaugeGuard, ConnectionMeta, ConnectionTagger, Consumer, Coordinator, Locals, Producer,
-    RelayInfo, RemoteManager, Session, SessionContext,
+    RelayInfo, RemoteManager, Session, SessionContext, DEFAULT_CACHE_IDLE_TIMEOUT,
 };
 
 // A type alias for boxed future
@@ -74,6 +74,18 @@ impl RelayConfig {
     pub fn build(self) -> anyhow::Result<Relay> {
         Relay::new(self)
     }
+
+    /// Build a relay with a custom pull-through cache idle timeout.
+    ///
+    /// See [`Relay::new_with_cache_idle_timeout`]. This is a separate
+    /// constructor rather than a `RelayConfig` field so that adding it does not
+    /// break existing struct-literal construction of [`RelayConfig`].
+    pub fn build_with_cache_idle_timeout(
+        self,
+        cache_idle_timeout: Duration,
+    ) -> anyhow::Result<Relay> {
+        Relay::new_with_cache_idle_timeout(self, cache_idle_timeout)
+    }
 }
 
 /// MoQ Relay server.
@@ -86,7 +98,21 @@ pub struct Relay {
 }
 
 impl Relay {
-    pub fn new(mut config: RelayConfig) -> anyhow::Result<Self> {
+    pub fn new(config: RelayConfig) -> anyhow::Result<Self> {
+        Self::new_with_cache_idle_timeout(config, DEFAULT_CACHE_IDLE_TIMEOUT)
+    }
+
+    /// Create a relay that releases upstream subscriptions for cached tracks that
+    /// have had no downstream subscribers for `cache_idle_timeout`.
+    ///
+    /// The relay caches tracks it does not publish itself so multiple downstream
+    /// subscribers can share one upstream subscription. Without a timeout that
+    /// subscription outlives the last subscriber and the relay keeps receiving a
+    /// track nobody is watching. A zero timeout restores that behaviour.
+    pub fn new_with_cache_idle_timeout(
+        mut config: RelayConfig,
+        cache_idle_timeout: Duration,
+    ) -> anyhow::Result<Self> {
         if config.bind.is_some() && !config.endpoints.is_empty() {
             anyhow::bail!("cannot specify both bind and endpoints");
         }
@@ -115,7 +141,7 @@ impl Relay {
             tracing::info!("mlog output enabled: {}", mlog_dir.display());
         }
 
-        let locals = Locals::new();
+        let locals = Locals::with_cache_idle_timeout(cache_idle_timeout);
 
         // FIXME(itzmanish): have a generic filter to find endpoints for forward, remote etc.
         let remote_clients = config
@@ -129,7 +155,8 @@ impl Relay {
             config.coordinator.clone(),
             remote_clients,
             config.session,
-        );
+        )
+        .with_cache_idle_timeout(cache_idle_timeout);
         let (upstream_namespaces, upstream_namespaces_runner) =
             UpstreamNamespaces::new(locals.clone(), remotes.clone(), config.coordinator.clone());
 

--- a/moq-relay-ietf/src/remote.rs
+++ b/moq-relay-ietf/src/remote.rs
@@ -5,6 +5,7 @@ use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Weak};
+use std::time::Duration;
 
 use moq_native_ietf::quic;
 use moq_transport::coding::{KeyValuePairs, TrackName, TrackNamespace, TrackNamespacePrefix};
@@ -15,6 +16,8 @@ use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
 use url::Url;
 
+use crate::interest::{TrackInterest, TrackInterestGuard};
+use crate::local::DEFAULT_CACHE_IDLE_TIMEOUT;
 use crate::{metrics::GaugeGuard, Coordinator, CoordinatorError, RelayInfo, SessionContext};
 
 /// Cache key for upstream relay-to-relay connections.
@@ -24,7 +27,17 @@ use crate::{metrics::GaugeGuard, Coordinator, CoordinatorError, RelayInfo, Sessi
 type RemoteCacheKey = (Url, Option<SocketAddr>);
 type RemoteSlot = Arc<Mutex<Option<Remote>>>;
 type TrackCacheKey = (TrackNamespace, TrackName);
-type TrackSlot = Arc<Mutex<Option<TrackReader>>>;
+type TrackSlot = Arc<Mutex<Option<CachedTrack>>>;
+
+/// A cached cross-relay track reader plus the downstream interest in it.
+#[derive(Clone)]
+struct CachedTrack {
+    reader: TrackReader,
+
+    /// Interest in this cached reader. When it goes idle for the configured
+    /// grace period the upstream subscription to the peer relay is released.
+    interest: TrackInterest,
+}
 
 /// Manages connections to remote relays.
 ///
@@ -37,6 +50,10 @@ pub struct RemoteManager {
     clients: Vec<quic::Client>,
     session_config: SessionConfig,
     remotes: Arc<Mutex<HashMap<RemoteCacheKey, RemoteSlot>>>,
+
+    /// How long an unwatched cross-relay cache entry is retained before its
+    /// upstream subscription is released. Zero disables eviction.
+    cache_idle_timeout: Duration,
 }
 
 #[cfg(test)]
@@ -146,6 +163,95 @@ mod tests {
             "unexpected error: {err}"
         );
     }
+
+    fn cached_track() -> (TrackSlot, TrackInterest) {
+        let (_writer, reader) = moq_transport::serve::Track::new(
+            TrackNamespace::from_utf8_path("example.com"),
+            "video",
+        )
+        .produce();
+        let interest = TrackInterest::new();
+        let slot: TrackSlot = Arc::new(Mutex::new(Some(CachedTrack {
+            reader,
+            interest: interest.clone(),
+        })));
+        (slot, interest)
+    }
+
+    const GRACE: Duration = Duration::from_secs(30);
+
+    /// The slot must be cleared before the caller drops its peer subscription, so
+    /// a later subscriber re-subscribes instead of attaching to a dying reader.
+    #[tokio::test(start_paused = true)]
+    async fn evict_when_idle_clears_the_slot_once_unwatched() {
+        let (slot, interest) = cached_track();
+
+        evict_when_idle(&slot, &interest, GRACE).await;
+
+        assert!(
+            slot.lock().await.is_none(),
+            "slot must be cleared before the subscription is released"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn evict_when_idle_waits_for_the_last_subscriber() {
+        let (slot, interest) = cached_track();
+        let guard = interest.guard();
+
+        let evict = evict_when_idle(&slot, &interest, GRACE);
+        tokio::pin!(evict);
+
+        tokio::select! {
+            _ = &mut evict => panic!("evicted a track that still has a subscriber"),
+            _ = tokio::time::sleep(GRACE * 4) => {}
+        }
+        assert!(slot.lock().await.is_some());
+
+        drop(guard);
+        evict.await;
+        assert!(slot.lock().await.is_none());
+    }
+
+    /// A replacement generation owns the slot now, so this subscription is stale:
+    /// it should be released without disturbing the new entry.
+    #[tokio::test(start_paused = true)]
+    async fn evict_when_idle_leaves_a_replacement_generation_alone() {
+        let (slot, interest) = cached_track();
+        let (_replacement_slot, replacement_interest) = cached_track();
+
+        {
+            let mut cached = slot.lock().await;
+            let reader = cached.as_ref().unwrap().reader.clone();
+            *cached = Some(CachedTrack {
+                reader,
+                interest: replacement_interest.clone(),
+            });
+        }
+
+        // Resolves (so the stale subscription is dropped) but must not clear the
+        // slot the replacement is using.
+        evict_when_idle(&slot, &interest, GRACE).await;
+
+        assert!(
+            slot.lock().await.is_some(),
+            "a stale lease must not evict the replacement entry"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn evict_when_idle_is_disabled_by_a_zero_timeout() {
+        let (slot, interest) = cached_track();
+
+        tokio::select! {
+            _ = evict_when_idle(&slot, &interest, Duration::ZERO) => {
+                panic!("a zero timeout must disable eviction")
+            }
+            _ = tokio::time::sleep(Duration::from_secs(3600)) => {}
+        }
+
+        assert!(slot.lock().await.is_some());
+    }
 }
 
 impl RemoteManager {
@@ -165,7 +271,18 @@ impl RemoteManager {
             clients,
             session_config,
             remotes: Arc::new(Mutex::new(HashMap::new())),
+            cache_idle_timeout: DEFAULT_CACHE_IDLE_TIMEOUT,
         }
+    }
+
+    /// Override how long an unwatched cross-relay cache entry is retained before
+    /// its upstream subscription is released.
+    ///
+    /// A zero timeout disables idle eviction, holding subscriptions to peer
+    /// relays for as long as the peer session lives.
+    pub fn with_cache_idle_timeout(mut self, cache_idle_timeout: Duration) -> Self {
+        self.cache_idle_timeout = cache_idle_timeout;
+        self
     }
 
     /// Subscribe to a track from a remote relay.
@@ -179,7 +296,7 @@ impl RemoteManager {
         scope: Option<&str>,
         namespace: &TrackNamespace,
         track_name: impl Into<TrackName>,
-    ) -> anyhow::Result<Option<TrackReader>> {
+    ) -> anyhow::Result<Option<(TrackReader, TrackInterestGuard)>> {
         let track_name = track_name.into();
 
         // Coordinator::lookup_track is the ergonomic routing entry point: it
@@ -337,9 +454,12 @@ impl RemoteManager {
                 cache_key.1,
                 client,
                 self.session_config,
-                Arc::downgrade(&self.remotes),
-                cache_key.clone(),
-                Arc::downgrade(&slot),
+                self.cache_idle_timeout,
+                RemoteCacheHandle {
+                    remotes: Arc::downgrade(&self.remotes),
+                    key: cache_key.clone(),
+                    slot: Arc::downgrade(&slot),
+                },
             )
             .await
             {
@@ -411,6 +531,52 @@ async fn remove_empty_remote_slot(
     }
 }
 
+/// Clear a cached cross-relay track once it has been unwatched for `timeout`.
+///
+/// Resolving means the caller should drop its subscription to the peer relay. The
+/// slot is cleared *before* returning, while the lock is still held, so a
+/// subscriber arriving afterwards misses the cache and re-subscribes instead of
+/// attaching to a reader whose upstream subscription is being torn down.
+///
+/// The idle re-check happens under the slot lock, which is also where interest
+/// guards are created, so a subscriber racing eviction is either counted here
+/// (and we keep waiting) or misses the slot entirely.
+///
+/// Never resolves when `timeout` is zero, preserving the previous behaviour of
+/// holding the subscription for as long as the peer session lives.
+async fn evict_when_idle(slot: &TrackSlot, interest: &TrackInterest, timeout: Duration) {
+    if timeout.is_zero() {
+        // Idle eviction disabled.
+        std::future::pending::<()>().await;
+    }
+
+    loop {
+        interest.idle_for(timeout).await;
+
+        let mut cached = slot.lock().await;
+
+        // A different generation now owns the slot; it has its own idle timer, so
+        // this subscription is no longer serving anything and must not clear it.
+        let ours = matches!(
+            cached.as_ref(),
+            Some(current) if current.interest.same_generation(interest)
+        );
+
+        if !ours {
+            return;
+        }
+
+        if interest.is_idle() {
+            cached.take();
+            return;
+        }
+
+        // Interest returned between the timer firing and taking the lock, so keep
+        // serving and start waiting again.
+        drop(cached);
+    }
+}
+
 async fn remove_empty_track_slot(
     tracks: &Arc<Mutex<HashMap<TrackCacheKey, TrackSlot>>>,
     key: &TrackCacheKey,
@@ -443,6 +609,16 @@ struct Remote {
     connected: Arc<AtomicBool>,
     /// Cancellation token for the session task.
     cancel: CancellationToken,
+    /// Idle timeout applied to this peer's cached track readers.
+    cache_idle_timeout: Duration,
+}
+
+/// Where a connection caches itself, so the session task can evict its own slot
+/// from the pool once the connection closes.
+struct RemoteCacheHandle {
+    remotes: Weak<Mutex<HashMap<RemoteCacheKey, RemoteSlot>>>,
+    key: RemoteCacheKey,
+    slot: Weak<Mutex<Option<Remote>>>,
 }
 
 impl Remote {
@@ -452,10 +628,14 @@ impl Remote {
         addr: Option<SocketAddr>,
         client: &quic::Client,
         session_config: SessionConfig,
-        remotes: Weak<Mutex<HashMap<RemoteCacheKey, RemoteSlot>>>,
-        cache_key: RemoteCacheKey,
-        cache_slot: Weak<Mutex<Option<Remote>>>,
+        cache_idle_timeout: Duration,
+        cache: RemoteCacheHandle,
     ) -> anyhow::Result<Self> {
+        let RemoteCacheHandle {
+            remotes,
+            key: cache_key,
+            slot: cache_slot,
+        } = cache;
         let (session, _quic_client_initial_cid, transport) = match client.connect(&url, addr).await
         {
             Ok(session) => session,
@@ -541,6 +721,7 @@ impl Remote {
             tracks: Arc::new(Mutex::new(HashMap::new())),
             connected,
             cancel,
+            cache_idle_timeout,
         })
     }
 
@@ -589,7 +770,7 @@ impl Remote {
         &self,
         namespace: TrackNamespace,
         track_name: TrackName,
-    ) -> anyhow::Result<Option<TrackReader>> {
+    ) -> anyhow::Result<Option<(TrackReader, TrackInterestGuard)>> {
         let key = (namespace.clone(), track_name.clone());
 
         loop {
@@ -616,9 +797,11 @@ impl Remote {
                 continue;
             }
 
-            if let Some(reader) = cached.as_ref() {
-                if !reader.is_closed() {
-                    return Ok(Some(reader.clone()));
+            if let Some(entry) = cached.as_ref() {
+                if !entry.reader.is_closed() {
+                    // Register interest while still holding the slot lock, which
+                    // is the same lock idle eviction re-checks under.
+                    return Ok(Some((entry.reader.clone(), entry.interest.guard())));
                 }
 
                 tracing::debug!(remote_url = %self.url, namespace = %key.0, track = %key.1, "removing closed remote track from cache");
@@ -658,12 +841,22 @@ impl Remote {
                 anyhow::bail!("remote connection to {} is closed", self.url);
             }
 
-            *cached = Some(reader.clone());
+            let interest = TrackInterest::new();
+
+            // Take this caller's guard before the entry becomes visible, so the
+            // cleanup task cannot see a brand new entry as idle.
+            let guard = interest.guard();
+
+            *cached = Some(CachedTrack {
+                reader: reader.clone(),
+                interest: interest.clone(),
+            });
             drop(cached);
 
             let cleanup_key = key.clone();
             let cleanup_reader = reader.clone();
             let cleanup_slot = slot.clone();
+            let idle_timeout = self.cache_idle_timeout;
             tokio::spawn(async move {
                 tokio::select! {
                     result = subscribe.closed() => {
@@ -679,11 +872,23 @@ impl Remote {
                     _ = cancel.cancelled() => {
                         tracing::debug!(remote_url = %url, namespace = %cleanup_key.0, track = %cleanup_key.1, "remote track subscription cancelled");
                     }
+                    // Nobody downstream is watching this cross-relay track any
+                    // more, so stop pulling it from the peer relay. The slot is
+                    // already cleared by the time this resolves, so a later
+                    // subscriber re-subscribes rather than attaching to a reader
+                    // that is about to go silent.
+                    _ = evict_when_idle(&cleanup_slot, &interest, idle_timeout) => {
+                        tracing::info!(remote_url = %url, namespace = %cleanup_key.0, track = %cleanup_key.1, "releasing idle remote track subscription");
+                        metrics::counter!("moq_relay_cache_idle_evictions_total", "source" => "remote").increment(1);
+                    }
                 }
+
+                // Sends UNSUBSCRIBE to the peer relay if it is still open.
+                drop(subscribe);
 
                 if let Some(tracks) = tracks.upgrade() {
                     let mut cached = cleanup_slot.lock().await;
-                    if matches!(cached.as_ref(), Some(current) if Arc::ptr_eq(&current.info, &cleanup_reader.info))
+                    if matches!(cached.as_ref(), Some(current) if Arc::ptr_eq(&current.reader.info, &cleanup_reader.info))
                     {
                         cached.take();
                     }
@@ -693,7 +898,7 @@ impl Remote {
                 }
             });
 
-            return Ok(Some(reader));
+            return Ok(Some((reader, guard)));
         }
     }
 

--- a/moq-relay-ietf/src/remote.rs
+++ b/moq-relay-ietf/src/remote.rs
@@ -922,7 +922,7 @@ impl Remote {
             anyhow::bail!("remote connection to {} is closed", self.url);
         }
 
-        tracing::info!(remote_url = %self.url, prefix = %prefix.to_utf8_path(), "forwarding SUBSCRIBE_NAMESPACE to remote relay");
+        tracing::info!(remote_url = %self.url, prefix = %prefix, "forwarding SUBSCRIBE_NAMESPACE to remote relay");
 
         let mut subscriber = self.subscriber.clone();
         let subscribe_namespace = tokio::select! {
@@ -947,7 +947,7 @@ impl Remote {
             anyhow::bail!("remote connection to {} is closed", self.url);
         }
 
-        tracing::info!(remote_url = %self.url, namespace = %tracks.namespace.to_utf8_path(), "forwarding PUBLISH_NAMESPACE to remote relay");
+        tracing::info!(remote_url = %self.url, namespace = %tracks.namespace, "forwarding PUBLISH_NAMESPACE to remote relay");
 
         let mut publisher = self.publisher.clone();
         tokio::select! {

--- a/moq-relay-ietf/src/upstream_namespaces.rs
+++ b/moq-relay-ietf/src/upstream_namespaces.rs
@@ -518,7 +518,7 @@ impl UpstreamNamespacesRunner {
             Err(error) => {
                 tracing::error!(
                     scope = key.group.scope.as_deref().unwrap_or("<unscoped>"),
-                    prefix = %key.prefix.to_utf8_path(),
+                    prefix = %key.prefix,
                     error = %error,
                     "failed to register shared upstream namespace interest"
                 );
@@ -611,7 +611,7 @@ impl UpstreamNamespacesRunner {
                     }
                     Err(error) => {
                         tracing::error!(
-                            namespace = %namespace.to_utf8_path(),
+                            namespace = %namespace,
                             error = %error,
                             "failed to register upstream namespace source"
                         );

--- a/moq-relay-ietf/src/upstream_namespaces.rs
+++ b/moq-relay-ietf/src/upstream_namespaces.rs
@@ -83,6 +83,17 @@ impl Drop for PrefixInterest {
             return;
         };
         let Ok(mut slots) = registry.slots.lock() else {
+            // Poisoning means a panic happened while holding the lock, so this
+            // lease can no longer be retired: the upstream namespace pull it
+            // owns leaks for the lifetime of the process. Surface it as a
+            // counter rather than only a log line, since the visible symptom
+            // (upstream subscriptions that never go away) is otherwise hard to
+            // trace back to here.
+            metrics::counter!(
+                "moq_relay_lease_registry_lock_poisoned_total",
+                "operation" => "release"
+            )
+            .increment(1);
             tracing::error!("upstream namespace lease registry lock poisoned");
             return;
         };
@@ -161,11 +172,14 @@ impl UpstreamNamespaces {
             },
             prefix,
         };
-        let mut slots = self
-            .registry
-            .slots
-            .lock()
-            .map_err(|_| anyhow::anyhow!("upstream namespace lease registry lock poisoned"))?;
+        let mut slots = self.registry.slots.lock().map_err(|_| {
+            metrics::counter!(
+                "moq_relay_lease_registry_lock_poisoned_total",
+                "operation" => "acquire"
+            )
+            .increment(1);
+            anyhow::anyhow!("upstream namespace lease registry lock poisoned")
+        })?;
 
         if let Some(interest) = slots.get(&key).and_then(|slot| slot.interest.upgrade()) {
             return Ok(PrefixLease {

--- a/moq-transport/src/coding/track_namespace.rs
+++ b/moq-transport/src/coding/track_namespace.rs
@@ -27,13 +27,19 @@ fn namespace_fields_byte_len(fields: &[TupleField]) -> usize {
     fields.iter().map(|f| f.value.len()).sum()
 }
 
-fn namespace_path(fields: &[TupleField]) -> String {
-    let mut path = String::new();
+/// Stream a `/`-separated namespace path straight into a formatter.
+///
+/// Writing through the formatter keeps `Display` allocation-free, which matters
+/// because namespaces are used as `tracing` fields on hot relay paths: with `%ns`
+/// the path is only rendered when the subscriber actually records the event, and
+/// even then nothing is allocated. `String::from_utf8_lossy` borrows for valid
+/// UTF-8, so only genuinely invalid fields allocate a replacement string.
+fn write_namespace_path(fields: &[TupleField], f: &mut fmt::Formatter<'_>) -> fmt::Result {
     for field in fields {
-        path.push('/');
-        path.push_str(&String::from_utf8_lossy(&field.value));
+        f.write_str("/")?;
+        f.write_str(&String::from_utf8_lossy(&field.value))?;
     }
-    path
+    Ok(())
 }
 
 fn decode_namespace_fields<R: bytes::Buf>(
@@ -268,8 +274,12 @@ impl TrackNamespace {
         ns
     }
 
+    /// Render as a `/`-separated UTF-8 path.
+    ///
+    /// Allocates. Prefer the [`fmt::Display`] impl (e.g. `%namespace` in a
+    /// `tracing` field) when a `String` is not actually needed.
     pub fn to_utf8_path(&self) -> String {
-        namespace_path(&self.fields)
+        self.to_string()
     }
 
     /// Sum of all field lengths. Used for full-track-name limit calculation.
@@ -332,7 +342,7 @@ impl fmt::Debug for TrackNamespace {
 
 impl fmt::Display for TrackNamespace {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{0}", namespace_path(&self.fields))
+        write_namespace_path(&self.fields, f)
     }
 }
 
@@ -417,8 +427,12 @@ impl TrackNamespacePrefix {
         prefix
     }
 
+    /// Render as a `/`-separated UTF-8 path.
+    ///
+    /// Allocates. Prefer the [`fmt::Display`] impl (e.g. `%prefix` in a
+    /// `tracing` field) when a `String` is not actually needed.
     pub fn to_utf8_path(&self) -> String {
-        namespace_path(&self.fields)
+        self.to_string()
     }
 
     /// Return true when this prefix matches the beginning of `namespace`.
@@ -479,7 +493,7 @@ impl fmt::Debug for TrackNamespacePrefix {
 
 impl fmt::Display for TrackNamespacePrefix {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{0}", namespace_path(&self.fields))
+        write_namespace_path(&self.fields, f)
     }
 }
 
@@ -889,6 +903,50 @@ mod tests {
             err,
             TrackNamespaceError::NamespaceTooLarge(4097, MAX_FULL_TRACK_NAME_LEN)
         ));
+    }
+
+    // ── Display / to_utf8_path equivalence ────────────────────────────────────
+
+    /// `to_utf8_path` delegates to `Display`, which streams into the formatter
+    /// rather than building a `String`. Both must keep producing the same path,
+    /// including for fields that are not valid UTF-8 (rendered lossily).
+    #[test]
+    fn display_matches_to_utf8_path() {
+        let namespace = TrackNamespace::from_utf8_path("example.com/meeting=123");
+        assert_eq!(namespace.to_string(), namespace.to_utf8_path());
+        assert_eq!(namespace.to_utf8_path(), "/example.com/meeting=123");
+
+        let prefix = TrackNamespacePrefix::from_utf8_path("example.com");
+        assert_eq!(prefix.to_string(), prefix.to_utf8_path());
+        assert_eq!(prefix.to_utf8_path(), "/example.com");
+
+        let empty = TrackNamespacePrefix::new();
+        assert_eq!(empty.to_string(), empty.to_utf8_path());
+        assert_eq!(empty.to_utf8_path(), "");
+    }
+
+    #[test]
+    fn display_renders_non_utf8_fields_lossily() {
+        let namespace = TrackNamespace {
+            fields: vec![
+                TupleField { value: vec![0xff] },
+                TupleField::from_utf8("ok"),
+            ],
+        };
+
+        assert_eq!(namespace.to_string(), namespace.to_utf8_path());
+        assert_eq!(namespace.to_utf8_path(), "/\u{fffd}/ok");
+    }
+
+    /// `Debug` is written in terms of `Display`, so it must not regress into
+    /// printing the raw field vector.
+    #[test]
+    fn debug_matches_display() {
+        let namespace = TrackNamespace::from_utf8_path("a/b");
+        assert_eq!(format!("{namespace:?}"), format!("{namespace}"));
+
+        let prefix = TrackNamespacePrefix::from_utf8_path("a/b");
+        assert_eq!(format!("{prefix:?}"), format!("{prefix}"));
     }
 
     // ── full_track_name_len ───────────────────────────────────────────────────

--- a/moq-transport/src/data/mod.rs
+++ b/moq-transport/src/data/mod.rs
@@ -7,6 +7,7 @@ mod extension_headers;
 mod fetch;
 mod header;
 mod object_status;
+mod reset_code;
 mod subgroup;
 
 pub use datagram::*;
@@ -14,4 +15,5 @@ pub use extension_headers::*;
 pub use fetch::*;
 pub use header::*;
 pub use object_status::*;
+pub use reset_code::*;
 pub use subgroup::*;

--- a/moq-transport/src/data/reset_code.rs
+++ b/moq-transport/src/data/reset_code.rs
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: 2024-2026 Cloudflare Inc., Luke Curley, Mike English and contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+/// Draft-16 §13.4.4 Data Stream Reset Error Codes.
+///
+/// Sent as the QUIC/WebTransport `RESET_STREAM` application error code when a
+/// data stream is terminated before all of its objects have been delivered.
+///
+/// Draft-16 §10.4.3 requires a FIN only when every object in the subgroup has
+/// been written to the stream; any earlier termination MUST be a `RESET_STREAM`.
+/// Truncating an object and then sending FIN instead tells the receiver the
+/// subgroup ended cleanly at a byte offset that lands in the middle of an
+/// object whose length it was already promised, which is a protocol violation.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum DataStreamResetCode {
+    /// An implementation specific error occurred.
+    InternalError = 0x0,
+    /// The stream was cancelled: the subscription ended early (for example an
+    /// UNSUBSCRIBE, or a publisher deciding to stop serving it).
+    Cancelled = 0x1,
+    /// An object in the subgroup exceeded its delivery timeout.
+    DeliveryTimeout = 0x2,
+    /// The session is going away.
+    SessionClosed = 0x3,
+    /// An object had a status the sender could not represent.
+    UnknownObjectStatus = 0x4,
+    /// The track was detected to be malformed.
+    MalformedTrack = 0x12,
+}
+
+impl From<DataStreamResetCode> for u32 {
+    fn from(value: DataStreamResetCode) -> Self {
+        value as u32
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn codes_match_the_registry() {
+        // Draft-16 §13.4.4. These go on the wire as RESET_STREAM error codes,
+        // so the values are normative rather than internal labels.
+        assert_eq!(u32::from(DataStreamResetCode::InternalError), 0x0);
+        assert_eq!(u32::from(DataStreamResetCode::Cancelled), 0x1);
+        assert_eq!(u32::from(DataStreamResetCode::DeliveryTimeout), 0x2);
+        assert_eq!(u32::from(DataStreamResetCode::SessionClosed), 0x3);
+        assert_eq!(u32::from(DataStreamResetCode::UnknownObjectStatus), 0x4);
+        assert_eq!(u32::from(DataStreamResetCode::MalformedTrack), 0x12);
+    }
+}

--- a/moq-transport/src/serve/track.rs
+++ b/moq-transport/src/serve/track.rs
@@ -94,7 +94,7 @@ impl TrackWriter {
         // Lock state to modify it
         let mut state = self.state.lock_mut().ok_or_else(|| {
             tracing::debug!(
-                namespace = %self.info.namespace.to_utf8_path(),
+                namespace = %self.info.namespace,
                 track = %self.info.name,
                 "track state dropped (Cancel) in stream()"
             );
@@ -117,7 +117,7 @@ impl TrackWriter {
         // Lock state to modify it
         let mut state = self.state.lock_mut().ok_or_else(|| {
             tracing::debug!(
-                namespace = %self.info.namespace.to_utf8_path(),
+                namespace = %self.info.namespace,
                 track = %self.info.name,
                 "track state dropped (Cancel) in subgroups()"
             );
@@ -138,7 +138,7 @@ impl TrackWriter {
         // Lock state to modify it
         let mut state = self.state.lock_mut().ok_or_else(|| {
             tracing::debug!(
-                namespace = %self.info.namespace.to_utf8_path(),
+                namespace = %self.info.namespace,
                 track = %self.info.name,
                 "track state dropped (Cancel) in datagrams()"
             );
@@ -153,7 +153,7 @@ impl TrackWriter {
     /// Close the track with an error.
     pub fn close(self, err: ServeError) -> Result<(), ServeError> {
         tracing::debug!(
-            namespace = %self.info.namespace.to_utf8_path(),
+            namespace = %self.info.namespace,
             track = %self.info.name,
             error = %err,
             "track closing"
@@ -163,7 +163,7 @@ impl TrackWriter {
 
         let mut state = state.into_mut().ok_or_else(|| {
             tracing::debug!(
-                namespace = %self.info.namespace.to_utf8_path(),
+                namespace = %self.info.namespace,
                 track = %self.info.name,
                 "track state already dropped during close"
             );

--- a/moq-transport/src/serve/tracks.rs
+++ b/moq-transport/src/serve/tracks.rs
@@ -148,7 +148,7 @@ impl Drop for TracksRequest {
         if !pending_tracks.is_empty() {
             tracing::debug!(
                 target: "moq_transport::tracks",
-                namespace = %self.info.namespace.to_utf8_path(),
+                namespace = %self.info.namespace,
                 count = pending_tracks.len(),
                 "TracksRequest dropped with pending track requests"
             );
@@ -220,7 +220,7 @@ impl TracksReader {
                 // Track is still active, return the cached reader
                 tracing::debug!(
                     target: "moq_transport::tracks",
-                    namespace = %namespace.to_utf8_path(),
+                    namespace = %namespace,
                     track = %track_name,
                     "track cache hit (active)"
                 );
@@ -229,7 +229,7 @@ impl TracksReader {
             // Track is closed/stale, fall through to create a new one
             tracing::debug!(
                 target: "moq_transport::tracks",
-                namespace = %namespace.to_utf8_path(),
+                namespace = %namespace,
                 track = %track_name,
                 "track cache hit but stale, will evict and re-request"
             );
@@ -249,7 +249,7 @@ impl TracksReader {
         if self.queue.push(track_writer_reader.0).is_err() {
             tracing::debug!(
                 target: "moq_transport::tracks",
-                namespace = %namespace.to_utf8_path(),
+                namespace = %namespace,
                 track = %track_name,
                 "track request queue closed"
             );
@@ -263,7 +263,7 @@ impl TracksReader {
 
         tracing::debug!(
             target: "moq_transport::tracks",
-            namespace = %namespace.to_utf8_path(),
+            namespace = %namespace,
             track = %track_name,
             "track cache miss, requested from upstream"
         );

--- a/moq-transport/src/session/subscribed.rs
+++ b/moq-transport/src/session/subscribed.rs
@@ -9,6 +9,7 @@ use futures::stream::FuturesUnordered;
 use futures::StreamExt;
 
 use crate::coding::{Encode, KeyValuePairs, Location, ReasonPhrase};
+use crate::data::DataStreamResetCode;
 use crate::message::RequestErrorCode;
 use crate::mlog;
 use crate::serve::{ServeError, TrackReaderMode};
@@ -159,18 +160,116 @@ impl ObjectForwarder {
     }
 }
 
-enum SubgroupOutput {
-    Stream(Writer),
+/// A subgroup data stream that is reset unless it is explicitly finished.
+///
+/// Draft-16 §10.4.3: a FIN means "every object in this subgroup was delivered".
+/// Any earlier termination MUST be a `RESET_STREAM`, and the listed causes
+/// include early termination due to UNSUBSCRIBE and a publisher ending the
+/// subscription early — exactly the paths a relay hits when downstream interest
+/// disappears or an upstream track dies mid-object.
+///
+/// `quinn::SendStream::drop` implicitly calls `finish()`, so simply dropping the
+/// writer on a cancelled or failed forwarding task FINs the stream wherever it
+/// happened to stop. If that is mid-object the receiver has already been
+/// promised a payload length it will never get, and treats the truncated
+/// subgroup as a malformed track. This wrapper inverts that default: the stream
+/// is reset on drop unless [`SubgroupStream::finish`] ran, so the safe outcome
+/// is the automatic one.
+struct SubgroupStream {
+    writer: Writer,
+    /// Set once the stream has been explicitly finished or reset, after which
+    /// `Drop` must not touch it again.
+    terminated: bool,
+}
+
+impl SubgroupStream {
+    fn new(writer: Writer) -> Self {
+        Self {
+            writer,
+            terminated: false,
+        }
+    }
+
+    fn finish(&mut self) -> Result<(), SessionError> {
+        if self.terminated {
+            return Ok(());
+        }
+        self.terminated = true;
+        self.writer.finish()
+    }
+
+    fn reset(&mut self, code: DataStreamResetCode) {
+        if self.terminated {
+            return;
+        }
+        self.terminated = true;
+        self.writer.reset(code.into());
+    }
+}
+
+impl Drop for SubgroupStream {
+    fn drop(&mut self) {
+        // Covers async cancellation, where no error path gets a chance to run:
+        // dropping the forwarding future must not leave quinn to implicitly FIN
+        // a partially written subgroup. `Cancelled` is the right default because
+        // a dropped forwarding task means the subscription ended early.
+        self.reset(DataStreamResetCode::Cancelled);
+    }
+}
+
+/// How a subgroup stream was terminated. Recorded by the test sink so tests can
+/// assert FIN-vs-RESET behaviour without a real QUIC connection.
+#[cfg(test)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SubgroupTermination {
+    Fin,
+    Reset(DataStreamResetCode),
+}
+
+enum SubgroupSink {
+    Stream(SubgroupStream),
     #[cfg(test)]
-    Buffer(bytes::BytesMut),
+    Buffer {
+        buffer: bytes::BytesMut,
+        termination: Option<SubgroupTermination>,
+    },
+}
+
+/// Writes a subgroup to a sink while tracking whether we are mid-object.
+///
+/// The accounting lives here rather than in the sink so there is exactly one
+/// place that knows whether a FIN is currently legal.
+struct SubgroupOutput {
+    sink: SubgroupSink,
+    /// Payload bytes still owed for the object whose header we already wrote.
+    /// Non-zero means we are mid-object and MUST NOT FIN.
+    owed: usize,
 }
 
 impl SubgroupOutput {
+    fn stream(writer: Writer) -> Self {
+        Self {
+            sink: SubgroupSink::Stream(SubgroupStream::new(writer)),
+            owed: 0,
+        }
+    }
+
+    #[cfg(test)]
+    fn buffer() -> Self {
+        Self {
+            sink: SubgroupSink::Buffer {
+                buffer: bytes::BytesMut::new(),
+                termination: None,
+            },
+            owed: 0,
+        }
+    }
+
     async fn encode<T: Encode>(&mut self, msg: &T) -> Result<(), SessionError> {
-        match self {
-            Self::Stream(writer) => writer.encode(msg).await,
+        match &mut self.sink {
+            SubgroupSink::Stream(stream) => stream.writer.encode(msg).await,
             #[cfg(test)]
-            Self::Buffer(buffer) => {
+            SubgroupSink::Buffer { buffer, .. } => {
                 msg.encode(buffer)?;
                 Ok(())
             }
@@ -178,21 +277,69 @@ impl SubgroupOutput {
     }
 
     async fn write(&mut self, buf: &[u8]) -> Result<(), SessionError> {
-        match self {
-            Self::Stream(writer) => writer.write(buf).await,
+        match &mut self.sink {
+            SubgroupSink::Stream(stream) => stream.writer.write(buf).await?,
             #[cfg(test)]
-            Self::Buffer(buffer) => {
-                buffer.extend_from_slice(buf);
+            SubgroupSink::Buffer { buffer, .. } => buffer.extend_from_slice(buf),
+        }
+
+        self.owed = self.owed.saturating_sub(buf.len());
+        Ok(())
+    }
+
+    /// Record that an object header promising `len` payload bytes was written.
+    fn begin_object(&mut self, len: usize) {
+        self.owed = len;
+    }
+
+    /// True when every promised payload byte has been written.
+    fn at_object_boundary(&self) -> bool {
+        self.owed == 0
+    }
+
+    /// FIN the stream, asserting the whole subgroup was delivered.
+    ///
+    /// Only legal at an object boundary; finishing while payload bytes are still
+    /// owed is the truncation this type exists to prevent, so it resets instead.
+    fn finish(&mut self) -> Result<(), SessionError> {
+        if !self.at_object_boundary() {
+            tracing::warn!(
+                owed = self.owed,
+                "refusing to FIN a subgroup stream mid-object; resetting instead"
+            );
+            self.reset(DataStreamResetCode::InternalError);
+            return Err(ServeError::Size.into());
+        }
+
+        match &mut self.sink {
+            SubgroupSink::Stream(stream) => stream.finish(),
+            #[cfg(test)]
+            SubgroupSink::Buffer { termination, .. } => {
+                termination.get_or_insert(SubgroupTermination::Fin);
                 Ok(())
             }
         }
     }
 
+    /// RESET the stream, signalling an incomplete subgroup.
+    fn reset(&mut self, code: DataStreamResetCode) {
+        match &mut self.sink {
+            SubgroupSink::Stream(stream) => stream.reset(code),
+            #[cfg(test)]
+            SubgroupSink::Buffer { termination, .. } => {
+                termination.get_or_insert(SubgroupTermination::Reset(code));
+            }
+        }
+    }
+
     #[cfg(test)]
-    fn into_buffer(self) -> bytes::BytesMut {
-        match self {
-            Self::Buffer(buffer) => buffer,
-            Self::Stream(_) => unreachable!("test output should use a buffer"),
+    fn into_parts(self) -> (bytes::BytesMut, Option<SubgroupTermination>) {
+        match self.sink {
+            SubgroupSink::Buffer {
+                buffer,
+                termination,
+            } => (buffer, termination),
+            SubgroupSink::Stream(_) => unreachable!("test output should use a buffer"),
         }
     }
 }
@@ -419,8 +566,8 @@ impl ObjectForwarder {
         // TODO figure out u32 vs u64 priority
         send_stream.set_priority(subgroup_reader.priority as i32);
 
-        let mut output = SubgroupOutput::Stream(Writer::new(send_stream));
-        Self::serve_subgroup_objects(
+        let mut output = SubgroupOutput::stream(Writer::new(send_stream));
+        let res = Self::serve_subgroup_objects(
             header,
             subgroup_reader,
             first_object,
@@ -429,7 +576,35 @@ impl ObjectForwarder {
             mlog,
             delivery_filter,
         )
-        .await
+        .await;
+
+        // Draft-16 §10.4.3: FIN only if the whole subgroup was delivered,
+        // otherwise RESET_STREAM. Without this the `Writer` would be dropped and
+        // quinn would implicitly FIN wherever we stopped, which silently
+        // truncates the in-flight object.
+        match res {
+            Ok(()) => output.finish(),
+            Err(err) => {
+                output.reset(Self::reset_code_for(&err));
+                Err(err)
+            }
+        }
+    }
+
+    /// Map a forwarding failure onto a draft-16 §13.4.4 reset code.
+    fn reset_code_for(err: &SessionError) -> DataStreamResetCode {
+        match err {
+            // The subscriber went away (UNSUBSCRIBE) or the track was cancelled;
+            // §10.4.3 calls out UNSUBSCRIBE as a reset case explicitly.
+            SessionError::Serve(ServeError::Done | ServeError::Cancel) => {
+                DataStreamResetCode::Cancelled
+            }
+            // Upstream delivered fewer payload bytes than its object header
+            // promised, so the track itself is malformed.
+            SessionError::Serve(ServeError::Size) => DataStreamResetCode::MalformedTrack,
+            SessionError::Serve(ServeError::Closed(_)) => DataStreamResetCode::SessionClosed,
+            _ => DataStreamResetCode::InternalError,
+        }
     }
 
     async fn next_allowed_object(
@@ -519,7 +694,24 @@ impl ObjectForwarder {
                 subgroup_object.extension_headers
             );
 
+            // Check the subscription is still live and the location is valid
+            // *before* writing the object header. The header promises
+            // `payload_length` bytes, so bailing out after writing it leaves the
+            // receiver waiting on payload we will never send. Previously this
+            // check ran after the encode, so a downstream UNSUBSCRIBE landing
+            // here truncated the object.
+            state
+                .lock_mut()
+                .ok_or(ServeError::Done)?
+                .update_largest_location(
+                    subgroup_reader.group_id,
+                    subgroup_object_reader.object_id,
+                )?;
+
             output.encode(&subgroup_object).await?;
+            // From here until the payload is fully written we are mid-object and
+            // must not FIN.
+            output.begin_object(subgroup_object.payload_length);
 
             // Log subgroup object created/sent
             if let Some(ref mlog) = mlog {
@@ -537,14 +729,6 @@ impl ObjectForwarder {
                     let _ = mlog_guard.add_event(event);
                 }
             }
-
-            state
-                .lock_mut()
-                .ok_or(ServeError::Done)?
-                .update_largest_location(
-                    subgroup_reader.group_id,
-                    subgroup_object_reader.object_id,
-                )?;
 
             let mut chunks_sent = 0;
             let mut bytes_sent = 0;
@@ -566,6 +750,21 @@ impl ObjectForwarder {
                 chunks_sent,
                 bytes_sent
             );
+
+            // The reader ran out of chunks before satisfying the length we already
+            // promised. Surface it as an error so the stream is reset rather than
+            // FINed at a byte offset the receiver will read as a partial object.
+            if !output.at_object_boundary() {
+                tracing::warn!(
+                    group_id = subgroup_reader.group_id,
+                    object_id = subgroup_object_reader.object_id,
+                    promised = subgroup_object.payload_length,
+                    sent = bytes_sent,
+                    "upstream object ended short of its declared payload length"
+                );
+                return Err(ServeError::Size.into());
+            }
+
             object_count += 1;
         }
 
@@ -582,23 +781,43 @@ impl ObjectForwarder {
     #[cfg(test)]
     async fn serve_subgroup_to_buffer(
         header: data::SubgroupHeader,
-        mut subgroup_reader: serve::SubgroupReader,
+        subgroup_reader: serve::SubgroupReader,
         state: State<ObjectForwarderState>,
         delivery_filter: DeliveryFilter,
     ) -> Result<bytes::BytesMut, SessionError> {
-        let Some(first_object) =
-            Self::next_allowed_object(&mut subgroup_reader, delivery_filter).await?
-        else {
-            return Ok(bytes::BytesMut::new());
-        };
+        let (buffer, res, _) =
+            Self::serve_subgroup_to_parts(header, subgroup_reader, state, delivery_filter).await;
+        res?;
+        Ok(buffer)
+    }
 
-        state
-            .lock_mut()
-            .ok_or(ServeError::Done)?
-            .record_stream_opened();
+    /// Test helper mirroring [`Self::serve_subgroup`]'s termination logic so tests
+    /// can assert whether the stream would have been FINed or reset.
+    #[cfg(test)]
+    async fn serve_subgroup_to_parts(
+        header: data::SubgroupHeader,
+        mut subgroup_reader: serve::SubgroupReader,
+        state: State<ObjectForwarderState>,
+        delivery_filter: DeliveryFilter,
+    ) -> (
+        bytes::BytesMut,
+        Result<(), SessionError>,
+        Option<SubgroupTermination>,
+    ) {
+        let first_object =
+            match Self::next_allowed_object(&mut subgroup_reader, delivery_filter).await {
+                Ok(Some(first_object)) => first_object,
+                Ok(None) => return (bytes::BytesMut::new(), Ok(()), None),
+                Err(err) => return (bytes::BytesMut::new(), Err(err.into()), None),
+            };
 
-        let mut output = SubgroupOutput::Buffer(bytes::BytesMut::new());
-        Self::serve_subgroup_objects(
+        match state.lock_mut() {
+            Some(mut state) => state.record_stream_opened(),
+            None => return (bytes::BytesMut::new(), Err(ServeError::Done.into()), None),
+        }
+
+        let mut output = SubgroupOutput::buffer();
+        let res = Self::serve_subgroup_objects(
             header,
             subgroup_reader,
             first_object,
@@ -607,9 +826,18 @@ impl ObjectForwarder {
             None,
             delivery_filter,
         )
-        .await?;
+        .await;
 
-        Ok(output.into_buffer())
+        let res = match res {
+            Ok(()) => output.finish(),
+            Err(err) => {
+                output.reset(Self::reset_code_for(&err));
+                Err(err)
+            }
+        };
+
+        let (buffer, termination) = output.into_parts();
+        (buffer, res, termination)
     }
 
     async fn serve_datagrams(
@@ -824,6 +1052,223 @@ mod tests {
         let payload = output.copy_to_bytes(object.payload_length);
         assert_eq!(&payload[..], b"hello");
         assert!(!output.has_remaining());
+    }
+
+    /// Build a single-subgroup track reader carrying one complete object.
+    #[cfg(test)]
+    async fn subgroup_with_one_object() -> (serve::SubgroupReader, data::SubgroupHeader) {
+        use bytes::Bytes;
+
+        use crate::coding::TrackNamespace;
+
+        let (track_writer, track_reader) =
+            serve::Track::new(TrackNamespace::from_utf8_path("test"), "video").produce();
+        let mut subgroups_writer = track_writer.subgroups().unwrap();
+        let mut subgroup_writer = subgroups_writer
+            .create(serve::Subgroup {
+                group_id: 1,
+                subgroup_id: 0,
+                priority: 0,
+            })
+            .unwrap();
+        subgroup_writer.write(Bytes::from_static(b"hello")).unwrap();
+        drop(subgroup_writer);
+        drop(subgroups_writer);
+
+        let mut subgroups = match track_reader.mode().await.unwrap() {
+            TrackReaderMode::Subgroups(subgroups) => subgroups,
+            _ => panic!("expected subgroups mode"),
+        };
+        let subgroup = subgroups.next().await.unwrap().expect("subgroup available");
+        let header = data::SubgroupHeader {
+            header_type: data::StreamHeaderType::SubgroupIdExt,
+            track_alias: 1,
+            group_id: subgroup.group_id,
+            subgroup_id: Some(subgroup.subgroup_id),
+            publisher_priority: subgroup.priority,
+        };
+
+        (subgroup, header)
+    }
+
+    #[cfg(test)]
+    fn all_objects() -> DeliveryFilter {
+        DeliveryFilter {
+            forward: true,
+            start_location: None,
+            end_group_id: None,
+        }
+    }
+
+    /// A fully delivered subgroup is the one case where draft-16 §10.4.3 permits
+    /// a FIN.
+    #[tokio::test]
+    async fn complete_subgroup_is_finished_with_fin() {
+        let (subgroup, header) = subgroup_with_one_object().await;
+        let state = State::<ObjectForwarderState>::default();
+
+        let (_buffer, res, termination) =
+            ObjectForwarder::serve_subgroup_to_parts(header, subgroup, state, all_objects()).await;
+
+        res.expect("serving a complete subgroup should succeed");
+        assert_eq!(termination, Some(SubgroupTermination::Fin));
+    }
+
+    /// Draft-16 §10.4.3 lists UNSUBSCRIBE as a case that MUST reset rather than
+    /// FIN, and the stream must not be cut inside an object.
+    ///
+    /// This is the regression test for the truncation bug: the forwarder used to
+    /// encode an object header (promising `payload_length` bytes) and only then
+    /// check whether the subscription was still alive. When an UNSUBSCRIBE landed
+    /// in that window it returned early, dropped the `Writer`, and quinn
+    /// implicitly FINed the stream mid-object.
+    #[tokio::test]
+    async fn unsubscribe_mid_subgroup_resets_at_an_object_boundary() {
+        use bytes::{Buf, Bytes};
+
+        use crate::coding::{Decode, TrackNamespace};
+
+        let (track_writer, track_reader) =
+            serve::Track::new(TrackNamespace::from_utf8_path("test"), "video").produce();
+        let mut subgroups_writer = track_writer.subgroups().unwrap();
+        let mut subgroup_writer = subgroups_writer
+            .create(serve::Subgroup {
+                group_id: 1,
+                subgroup_id: 0,
+                priority: 0,
+            })
+            .unwrap();
+
+        // First object is available immediately; the second arrives only after we
+        // simulate the UNSUBSCRIBE.
+        subgroup_writer.write(Bytes::from_static(b"hello")).unwrap();
+
+        let mut subgroups = match track_reader.mode().await.unwrap() {
+            TrackReaderMode::Subgroups(subgroups) => subgroups,
+            _ => panic!("expected subgroups mode"),
+        };
+        let subgroup = subgroups.next().await.unwrap().expect("subgroup available");
+        let header = data::SubgroupHeader {
+            header_type: data::StreamHeaderType::SubgroupIdExt,
+            track_alias: 1,
+            group_id: subgroup.group_id,
+            subgroup_id: Some(subgroup.subgroup_id),
+            publisher_priority: subgroup.priority,
+        };
+
+        // Dropping one half of the split state is what UNSUBSCRIBE does to the
+        // forwarder: `lock_mut` starts returning None.
+        let (unsubscribe_handle, state) = State::<ObjectForwarderState>::default().split();
+
+        let fut = ObjectForwarder::serve_subgroup_to_parts(
+            header.clone(),
+            subgroup,
+            state,
+            all_objects(),
+        );
+        tokio::pin!(fut);
+
+        // Let the forwarder deliver the first object and then park waiting for
+        // the next one.
+        tokio::select! {
+            _ = &mut fut => panic!("forwarder should still be awaiting the next object"),
+            _ = tokio::time::sleep(std::time::Duration::from_millis(50)) => {}
+        }
+
+        drop(unsubscribe_handle);
+        subgroup_writer.write(Bytes::from_static(b"world")).unwrap();
+
+        let (buffer, res, termination) = fut.await;
+
+        assert!(res.is_err(), "forwarding should fail once unsubscribed");
+        assert_eq!(
+            termination,
+            Some(SubgroupTermination::Reset(DataStreamResetCode::Cancelled)),
+            "an early-terminated subgroup must be reset, never FINed"
+        );
+
+        // The bytes on the wire must end on an object boundary: the subgroup
+        // header plus exactly the first complete object, with no header for the
+        // object we never delivered.
+        let mut buffer = buffer.freeze();
+        let header_type = data::StreamHeaderType::decode(&mut buffer).unwrap();
+        assert_eq!(
+            data::SubgroupHeader::decode(header_type, &mut buffer).unwrap(),
+            header
+        );
+
+        let object = data::SubgroupObjectExt::decode(&mut buffer).unwrap();
+        assert_eq!(object.payload_length, 5);
+        assert_eq!(&buffer.copy_to_bytes(object.payload_length)[..], b"hello");
+        assert!(
+            !buffer.has_remaining(),
+            "no partial object should follow the last complete one"
+        );
+    }
+
+    /// FIN must be refused while payload bytes are still owed, even if a caller
+    /// asks for one; otherwise the receiver sees a truncated object.
+    #[tokio::test]
+    async fn finish_mid_object_resets_instead_of_truncating() {
+        let mut output = SubgroupOutput::buffer();
+
+        output.begin_object(10);
+        output.write(b"abc").await.unwrap();
+        assert!(!output.at_object_boundary());
+
+        let err = output.finish().expect_err("FIN mid-object must be refused");
+        assert!(matches!(err, SessionError::Serve(ServeError::Size)));
+
+        let (_buffer, termination) = output.into_parts();
+        assert_eq!(
+            termination,
+            Some(SubgroupTermination::Reset(
+                DataStreamResetCode::InternalError
+            ))
+        );
+    }
+
+    #[tokio::test]
+    async fn owed_payload_tracking_follows_writes() {
+        let mut output = SubgroupOutput::buffer();
+        assert!(output.at_object_boundary(), "no object in flight");
+
+        output.begin_object(5);
+        assert!(!output.at_object_boundary());
+
+        output.write(b"hel").await.unwrap();
+        assert!(!output.at_object_boundary());
+
+        output.write(b"lo").await.unwrap();
+        assert!(output.at_object_boundary(), "object fully delivered");
+
+        output.finish().expect("FIN legal at object boundary");
+    }
+
+    #[test]
+    fn reset_codes_follow_the_failure_cause() {
+        // §10.4.3: subscription ended early.
+        assert_eq!(
+            ObjectForwarder::reset_code_for(&ServeError::Done.into()),
+            DataStreamResetCode::Cancelled
+        );
+        assert_eq!(
+            ObjectForwarder::reset_code_for(&ServeError::Cancel.into()),
+            DataStreamResetCode::Cancelled
+        );
+        // Upstream gave us fewer bytes than its object header promised.
+        assert_eq!(
+            ObjectForwarder::reset_code_for(&ServeError::Size.into()),
+            DataStreamResetCode::MalformedTrack
+        );
+        assert_eq!(
+            ObjectForwarder::reset_code_for(&ServeError::Closed(0x2).into()),
+            DataStreamResetCode::SessionClosed
+        );
+        assert_eq!(
+            ObjectForwarder::reset_code_for(&ServeError::internal_ctx("boom").into()),
+            DataStreamResetCode::InternalError
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What this changes

Two independent bugs found while working on #191, plus cleanup.

Fixes #191.

### 1. `fix: reset subgroup streams instead of FIN-ing mid-object`

`quinn::SendStream::drop` calls `finish()` — a clean FIN at the current offset. `subscribed.rs` built `SubgroupOutput::Stream(Writer::new(send_stream))` and never called `finish()` explicitly, so **every** early return from the forwarding loop sent a FIN wherever it happened to stop.

When that offset is inside an object, the receiver has already been promised `payload_length` bytes by the object header. It sees a subgroup that ended cleanly mid-object and treats the track as malformed.

Two triggers in a relay:

- **Downstream UNSUBSCRIBE** — `recv_unsubscribe` → `remove_subscribe` → `ObjectForwarderRecv` dropped → the `state.lock_mut().ok_or(ServeError::Done)?` in `serve_subgroup_objects` fails *after* the object header was already encoded → `Writer` dropped → FIN mid-object.
- **Upstream failing mid-object** — `SubgroupObjectWriter` dropped with `remain != 0` sets `ServeError::Size`, producing the same truncating FIN downstream.

draft-16 §10.4.3 permits a FIN only when every object in the subgroup was delivered, and explicitly lists early termination due to UNSUBSCRIBE as a case that MUST use RESET_STREAM.

The fix:

- A `SubgroupStream` wrapper that **resets on drop unless explicitly finished**, so the spec-safe outcome is the default and async cancellation is covered without a separate code path.
- Track owed payload bytes and refuse to FIN while mid-object.
- Move the liveness/location check **ahead of** the object header encode, so a cancellation in that window stops on an object boundary rather than after the promise.
- Add the §13.4.4 data stream reset codes (`DataStreamResetCode`) and map failures onto them: `CANCELLED` for a subscription ending early, `MALFORMED_TRACK` for an upstream object shorter than declared, `SESSION_CLOSED` / `INTERNAL_ERROR` otherwise.

The regression test was verified to actually catch the bug: reverting only the check reordering makes `unsubscribe_mid_subgroup_resets_at_an_object_boundary` fail with "no partial object should follow the last complete one".

### 2. `fix: release upstream subscriptions for idle cached tracks` (#191)

A relay caches tracks it does not publish itself so several downstream subscribers can share one upstream subscription. Nothing counted how many subscribers were actually using a cached reader, so the upstream subscription lived until the upstream session died — after the last subscriber left, the relay kept receiving a track nobody was watching.

New `TrackInterest` / `TrackInterestGuard`: a reference count backed by a `watch` channel that can also await "unwatched for a while". Subscribers hold a guard while being served, so the count is maintained by RAII and a cancelled subscriber cannot leak a reference. Once an entry has been unwatched for the grace period it is evicted and the upstream `Subscribe` is dropped, sending UNSUBSCRIBE.

Both cache layers are covered: the local PUBLISH_NAMESPACE pull-through cache in `Locals`, and the cross-relay track cache in `RemoteManager`.

Three details this depends on:

- **Guards hold a strong reference to the counter, not a cache key.** An outstanding guard from an evicted entry decrements the counter it came from rather than making a same-named replacement look busy.
- **Guards are created under the same lock the idle check is made under.** A subscriber racing eviction is therefore either counted (eviction abandoned) or misses the cache and requests a fresh entry.
- **The entry is cleared before the upstream subscription is dropped**, so a subscriber arriving in that window re-subscribes rather than attaching to a reader about to go silent.

Grace period defaults to 30s, configurable via `--cache-idle-timeout`; `0` restores the previous behaviour.

The timeout is plumbed through a new `Relay::new_with_cache_idle_timeout` constructor rather than a `RelayConfig` field, specifically so that exhaustive struct-literal construction of `RelayConfig` keeps compiling for embedders. See **Compatibility** below for the API surface this *does* break.

### 3. `perf: stream namespace paths into the formatter`

`Display for TrackNamespace` called `namespace_path()` internally and built a `String`, so it was no cheaper than `to_utf8_path()` — and the `%namespace.to_utf8_path()` pattern at tracing call sites allocated on every call, including at log levels that were not enabled. `Display` now streams into the formatter; `to_utf8_path()` delegates to it so there is one implementation of the path format. Tracing call sites become `%namespace`, which is both lazy and allocation-free.

### 4. `feat: add metrics for lock poisoning and broadcast lag`

Lease registry lock poisoning means a `PrefixInterest` can never be retired, so the upstream namespace pull it owns leaks for the process lifetime — the visible symptom is upstream subscriptions that never go away, which is hard to trace back to one log line. Broadcast `Lagged` is recovered from with a full resync (correct, but silent). Both are now counted. Also registers `moq_relay_cache_idle_evictions_total`, which this branch emits but which had no `describe_counter!` entry and so shipped with no Prometheus HELP text.

## Testing

`cargo fmt --check`, `cargo clippy --no-deps`, `cargo test` (386 passing), `cargo machete` — all clean.

New coverage: subgroup FIN-vs-RESET termination and reset-code mapping; interest counting, grace-period restart and generation identity; idle eviction, warm-cache reuse within the grace period, cancelled-requester safety, zero-timeout opt-out, and stale-guard isolation on both the local and remote paths.

## Compatibility

**This is a source-breaking change to `moq-relay-ietf`.** Three exported methods change return type so that a downstream-interest guard travels with the reader:

| Method | Before | After |
|---|---|---|
| `Locals::register_namespace` | `mpsc::Receiver<TrackWriter>` | `mpsc::Receiver<TrackRequest>` |
| `Locals::get_or_request_track` | `Option<TrackReader>` | `Option<(TrackReader, Option<TrackInterestGuard>)>` |
| `RemoteManager::subscribe` | `Result<Option<TrackReader>>` | `Result<Option<(TrackReader, TrackInterestGuard)>>` |

Intentional. release-plz picks up breaking API changes at release prep and bumps semver accordingly.

Preserved deliberately: `RelayConfig` is unchanged, so embedders constructing it as an exhaustive struct literal are unaffected. That is why the idle timeout went through a new constructor instead of a config field, and it was verified by compiling a downstream embedder against this branch.

Guard-less variants of the three methods above were **not** kept as an additive migration path. The design's correctness depends on the interest guard being created under the same lock as the idle check, so a method that returns a cached reader *without* a guard hands back an entry that registers no interest — it looks idle immediately and can be evicted while it is still being served. That is the bug class this PR fixes, so a compile error at each call site is preferable to an API that silently reintroduces it.

## Open questions (not addressed here)

Worth flagging for discussion rather than blocking this PR:

1. **Should a relay start writing an object downstream before it has the whole object from upstream?** Today it does — it commits to `payload_length` and then streams chunks. Good for latency, but it commits to a length it cannot yet guarantee.
2. **What should a relay do when the remainder of an already-committed object cannot be obtained?** Once the header is written there is no legal way to un-promise those bytes. Resetting the subgroup (what this does) discards objects that were fine. `MALFORMED_TRACK` is arguably the wrong code — the track isn't malformed, the upstream *delivery* failed — and `INTERNAL_ERROR` is no better. There may be a gap in the §13.4.4 registry for "relay could not obtain the rest of an object it had already committed to", which is a normal relay condition rather than a fault in either the track or the relay.

## Notes

- `draft-ietf-moq-transport-14`-based #180 overlaps with part 2 and independently converged on `TrackRequest { writer, lease }`. It targets an obsolete base with a failing build; differences to reconcile if it is revived are that it places interest tracking in `moq_transport::serve` rather than the relay crate, uses a 3s linger, and does not appear to cover `RemoteManager`.
