### PR TITLE
fix: wait for upstream subscription before sending SUBSCRIBE_OK

### DIFF
--- a/moq-relay-ietf/src/consumer.rs
+++ b/moq-relay-ietf/src/consumer.rs
@@ -256,7 +256,7 @@ impl Consumer {
                     tracing::info!(namespace = %ns, "PUBLISH_NAMESPACE closed");
                     return Ok(());
                 },
-                Some(TrackRequest { writer, lease }) = requests.recv() => {
+                Some(TrackRequest { writer, lease, upstream }) = requests.recv() => {
                     let mut subscriber = self.subscriber.clone();
 
                     tasks.push(async move {
@@ -272,8 +272,15 @@ impl Consumer {
                         // Hold the subscription explicitly rather than using
                         // `subscribe()`, so it can be dropped — sending
                         // UNSUBSCRIBE — once downstream interest goes away.
+                        //
+                        // `subscribe_open` resolves once the upstream publisher
+                        // answers, so its outcome is exactly what downstream
+                        // subscribers are waiting on to satisfy draft-16 §8.4.
                         let subscribe = match subscriber.subscribe_open(writer).await {
-                            Ok(subscribe) => subscribe,
+                            Ok(subscribe) => {
+                                upstream.established();
+                                subscribe
+                            }
                             Err(err) => {
                                 tracing::warn!(
                                     namespace = %namespace,
@@ -281,6 +288,10 @@ impl Consumer {
                                     error = %err,
                                     "failed forwarding subscribe: {:?}", info
                                 );
+                                // Release waiting downstream subscribers with the
+                                // upstream reason so they get a REQUEST_ERROR that
+                                // matches it, rather than a premature accept.
+                                upstream.failed(err);
                                 return Ok(());
                             }
                         };

--- a/moq-relay-ietf/src/local.rs
+++ b/moq-relay-ietf/src/local.rs
@@ -10,7 +10,7 @@ use moq_transport::{
     coding::{TrackNamespace, TrackNamespacePrefix},
     serve::{FullTrackName, ServeError, Track, TrackReader, TrackWriter},
 };
-use tokio::sync::{broadcast, mpsc};
+use tokio::sync::{broadcast, mpsc, watch};
 
 use crate::interest::{TrackInterest, TrackInterestGuard};
 use crate::metrics::GaugeGuard;
@@ -61,6 +61,94 @@ pub struct TrackRequest {
     /// The requester should hold the upstream subscription open until
     /// [`CacheLease::released`] resolves, then drop it to send UNSUBSCRIBE.
     pub lease: CacheLease,
+
+    /// Reports whether the upstream subscription was established.
+    ///
+    /// Downstream subscribers wait on this before SUBSCRIBE_OK is sent, so the
+    /// requester must resolve it exactly once — via
+    /// [`UpstreamReadyTx::established`] or [`UpstreamReadyTx::failed`] — as soon
+    /// as the upstream publisher answers.
+    pub upstream: UpstreamReadyTx,
+}
+
+/// State of the upstream subscription backing a pull-through cache entry.
+#[derive(Clone)]
+enum UpstreamState {
+    /// The upstream SUBSCRIBE has been queued but not answered yet.
+    Pending,
+
+    /// The upstream publisher acknowledged the SUBSCRIBE.
+    Established,
+
+    /// The upstream subscription could not be established.
+    Failed(ServeError),
+}
+
+/// Readiness gate for the upstream subscription behind a cached track.
+///
+/// Draft-16 §8.4 requires a relay to have an established upstream subscription
+/// before it sends SUBSCRIBE_OK for a downstream SUBSCRIBE. The pull-through
+/// cache reserves its entry synchronously but subscribes upstream asynchronously
+/// (the publishing session owns that side), so the entry exists before the
+/// upstream subscription does. Serving a downstream subscriber has to wait for
+/// this gate rather than for the entry alone.
+///
+/// Shared by every downstream subscriber of the same cache entry, so a second
+/// subscriber arriving mid-handshake waits on the same result instead of
+/// triggering a duplicate upstream SUBSCRIBE.
+#[derive(Clone)]
+pub struct UpstreamReady {
+    state: watch::Receiver<UpstreamState>,
+}
+
+impl UpstreamReady {
+    /// Wait until the upstream subscription is established.
+    ///
+    /// Returns the upstream failure if it could not be established, so the caller
+    /// can reject the downstream request with a matching REQUEST_ERROR instead of
+    /// accepting it and later reporting the failure as PUBLISH_DONE.
+    ///
+    /// Resolves as an error rather than hanging if the requester is dropped
+    /// without answering — an abandoned request is not an established one.
+    pub async fn established(&self) -> Result<(), ServeError> {
+        let mut state = self.state.clone();
+
+        loop {
+            match &*state.borrow_and_update() {
+                UpstreamState::Established => return Ok(()),
+                UpstreamState::Failed(err) => return Err(err.clone()),
+                UpstreamState::Pending => {}
+            }
+
+            if state.changed().await.is_err() {
+                return Err(ServeError::internal_ctx(
+                    "upstream subscription abandoned before it was established",
+                ));
+            }
+        }
+    }
+}
+
+/// Sender half of [`UpstreamReady`], held by the session that owns the upstream
+/// subscription.
+///
+/// Dropping this without resolving it releases any waiting downstream subscriber
+/// with an error, so a requester that gives up cannot strand them.
+pub struct UpstreamReadyTx {
+    state: watch::Sender<UpstreamState>,
+}
+
+impl UpstreamReadyTx {
+    /// Report that the upstream publisher acknowledged the SUBSCRIBE.
+    pub fn established(&self) {
+        // Fails only when every downstream subscriber has already gone away.
+        let _ = self.state.send(UpstreamState::Established);
+    }
+
+    /// Report that the upstream subscription could not be established.
+    pub fn failed(&self, err: ServeError) {
+        let _ = self.state.send(UpstreamState::Failed(err));
+    }
 }
 
 /// Ties an upstream subscription to downstream interest in its cache entry.
@@ -131,6 +219,31 @@ struct TrackEntry {
     /// Locally published tracks have no upstream subscription to release, so
     /// there is nothing to count.
     interest: Option<TrackInterest>,
+
+    /// Upstream readiness for [`TrackSource::Cache`] entries only.
+    ///
+    /// Locally published tracks are already established by the time they are
+    /// registered, so there is nothing to wait for.
+    upstream: Option<UpstreamReady>,
+}
+
+/// A track resolved from the relay-local registry, with the handles a caller must
+/// observe while serving it.
+pub struct LocalTrack {
+    /// The media reader to serve downstream.
+    pub reader: TrackReader,
+
+    /// Held for as long as the caller serves [`Self::reader`]. Dropping it is what
+    /// eventually lets an idle upstream subscription be released.
+    ///
+    /// `None` for locally published tracks, which have no upstream subscription.
+    pub interest: Option<TrackInterestGuard>,
+
+    /// Must resolve before the caller sends SUBSCRIBE_OK downstream (draft-16
+    /// §8.4).
+    ///
+    /// `None` for locally published tracks, which are already established.
+    pub upstream: Option<UpstreamReady>,
 }
 
 #[derive(Clone, Copy, Eq, PartialEq)]
@@ -444,8 +557,10 @@ impl Locals {
                 reader: track.clone(),
                 source: TrackSource::Published,
                 // A locally published track has no upstream subscription to
-                // release, so there is nothing to count interest against.
+                // release, so there is nothing to count interest against and
+                // nothing to wait for before accepting a downstream SUBSCRIBE.
                 interest: None,
+                upstream: None,
             }),
             hash_map::Entry::Occupied(_) => return Err(ServeError::Duplicate.into()),
         };
@@ -591,14 +706,15 @@ impl Locals {
     /// the actual track reader is stored in `tracks`, while PUBLISH_NAMESPACE is
     /// only a source to ask when a track is missing.
     /// Returns the reader plus, for pull-through cache entries, a guard the caller
-    /// must hold for as long as it is serving that reader. Dropping the guard is
-    /// what eventually lets the upstream subscription be released.
+    /// must hold for as long as it is serving that reader (dropping it is what
+    /// eventually lets the upstream subscription be released) and a readiness gate
+    /// the caller must await before accepting the downstream request.
     pub async fn get_or_request_track(
         &mut self,
         scope: Option<&str>,
         namespace: TrackNamespace,
         track_name: impl Into<moq_transport::coding::TrackName>,
-    ) -> Option<(TrackReader, Option<TrackInterestGuard>)> {
+    ) -> Option<LocalTrack> {
         let track_name = track_name.into();
         let full_name = FullTrackName {
             namespace: namespace.clone(),
@@ -617,14 +733,17 @@ impl Locals {
         // that finds no live entry claims the slot with a freshly produced track and
         // owns requesting it from the source; concurrent callers share the reserved
         // reader instead of racing to insert and failing with a spurious `None`.
-        let (writer, reader, interest, guard) = {
+        let (writer, reader, interest, guard, upstream_tx, upstream) = {
             let mut tracks = self.tracks.write().ok()?;
             let bucket = tracks.entry(scope_key.clone()).or_default();
 
             if let Some(entry) = bucket.get(&full_name) {
                 if !entry.reader.is_closed() {
-                    let guard = entry.interest.as_ref().map(TrackInterest::guard);
-                    return Some((entry.reader.clone(), guard));
+                    return Some(LocalTrack {
+                        reader: entry.reader.clone(),
+                        interest: entry.interest.as_ref().map(TrackInterest::guard),
+                        upstream: entry.upstream.clone(),
+                    });
                 }
             }
 
@@ -637,15 +756,29 @@ impl Locals {
             // setting up the upstream subscription.
             let guard = interest.guard();
 
+            // Published alongside the entry so that a subscriber arriving while
+            // the upstream handshake is still in flight shares this gate rather
+            // than being served a reader nothing has subscribed to yet.
+            let (upstream_tx, upstream_rx) = watch::channel(UpstreamState::Pending);
+            let upstream = UpstreamReady { state: upstream_rx };
+
             bucket.insert(
                 full_name.clone(),
                 TrackEntry {
                     reader: reader.clone(),
                     source: TrackSource::Cache,
                     interest: Some(interest.clone()),
+                    upstream: Some(upstream.clone()),
                 },
             );
-            (writer, reader, interest, guard)
+            (
+                writer,
+                reader,
+                interest,
+                guard,
+                UpstreamReadyTx { state: upstream_tx },
+                upstream,
+            )
         };
 
         let lease = CacheLease {
@@ -657,7 +790,11 @@ impl Locals {
 
         if source
             .requests
-            .send(TrackRequest { writer, lease })
+            .send(TrackRequest {
+                writer,
+                lease,
+                upstream: upstream_tx,
+            })
             .await
             .is_err()
         {
@@ -668,7 +805,11 @@ impl Locals {
             return None;
         }
 
-        Some((reader, Some(guard)))
+        Some(LocalTrack {
+            reader,
+            interest: Some(guard),
+            upstream: Some(upstream),
+        })
     }
 
     /// Remove a cache entry if it is still the given generation, regardless of
@@ -711,14 +852,17 @@ impl Locals {
         &self,
         scope_key: &str,
         full_name: &FullTrackName,
-    ) -> Option<(TrackReader, Option<TrackInterestGuard>)> {
+    ) -> Option<LocalTrack> {
         {
             let tracks = self.tracks.read().ok()?;
             let bucket = tracks.get(scope_key)?;
             match bucket.get(full_name) {
                 Some(entry) if !entry.reader.is_closed() => {
-                    let guard = entry.interest.as_ref().map(TrackInterest::guard);
-                    return Some((entry.reader.clone(), guard));
+                    return Some(LocalTrack {
+                        reader: entry.reader.clone(),
+                        interest: entry.interest.as_ref().map(TrackInterest::guard),
+                        upstream: entry.upstream.clone(),
+                    });
                 }
                 Some(_) => {} // closed: fall through to prune under the write lock
                 None => return None,
@@ -861,6 +1005,7 @@ impl Drop for LocalTrackRegistration {
 mod tests {
     use super::*;
     use moq_transport::coding::TrackName;
+    use moq_transport::message::RequestErrorCode;
 
     fn ns(path: &str) -> TrackNamespace {
         TrackNamespace::from_utf8_path(path)
@@ -1060,13 +1205,18 @@ mod tests {
             .await
             .expect("namespace source should register");
 
-        let (reader, guard) = locals
+        let local = locals
             .get_or_request_track(None, namespace.clone(), "video")
             .await
             .expect("missing track should be requested from namespace source");
+        let reader = local.reader;
         assert!(
-            guard.is_some(),
+            local.interest.is_some(),
             "a cached track should hand back an interest guard"
+        );
+        assert!(
+            local.upstream.is_some(),
+            "a cached track should hand back an upstream readiness gate"
         );
 
         let requested = requests
@@ -1083,12 +1233,12 @@ mod tests {
         assert_eq!(cached.namespace, reader.namespace);
         assert_eq!(cached.name, reader.name);
 
-        let (reader_again, _guard_again) = locals
+        let again = locals
             .get_or_request_track(None, namespace.clone(), "video")
             .await
             .expect("cached track should be returned");
-        assert_eq!(reader_again.namespace, namespace);
-        assert_eq!(reader_again.name, TrackName::from("video"));
+        assert_eq!(again.reader.namespace, namespace);
+        assert_eq!(again.reader.name, TrackName::from("video"));
 
         let no_second_request =
             tokio::time::timeout(std::time::Duration::from_millis(50), requests.recv()).await;
@@ -1114,9 +1264,12 @@ mod tests {
             second.get_or_request_track(None, namespace.clone(), "video"),
         );
 
-        let (first_reader, _first_guard) = first_reader.expect("first request should get a reader");
-        let (second_reader, _second_guard) =
-            second_reader.expect("second request should get cached reader");
+        let first_reader = first_reader
+            .expect("first request should get a reader")
+            .reader;
+        let second_reader = second_reader
+            .expect("second request should get cached reader")
+            .reader;
         assert_eq!(first_reader.namespace, namespace);
         assert_eq!(second_reader.namespace, namespace);
         assert_eq!(first_reader.name, TrackName::from("video"));
@@ -1191,11 +1344,11 @@ mod tests {
             .expect("long prefix should register");
 
         let requested_ns = ns("room/123/camera");
-        let (reader, _guard) = locals
+        let local = locals
             .get_or_request_track(None, requested_ns.clone(), "video")
             .await
             .expect("track should be requested from longest prefix");
-        assert_eq!(reader.namespace, requested_ns);
+        assert_eq!(local.reader.namespace, requested_ns);
 
         let long_request = long_requests
             .recv()
@@ -1446,6 +1599,177 @@ mod tests {
             TrackChange::Added { .. } => panic!("expected removed event"),
         }
     }
+    /// Draft-16 §8.4: the gate must not resolve until the requester reports that
+    /// the upstream subscription is established, because the caller sends
+    /// SUBSCRIBE_OK as soon as it does.
+    #[tokio::test]
+    async fn upstream_gate_waits_for_the_requester() {
+        let mut locals = Locals::new();
+        let namespace = ns("room/123");
+        let (_registration, mut requests) = locals
+            .register_namespace(None, namespace.clone())
+            .await
+            .expect("namespace source should register");
+
+        let upstream = locals
+            .get_or_request_track(None, namespace.clone(), "video")
+            .await
+            .expect("missing track should be requested")
+            .upstream
+            .expect("a cached track should hand back an upstream readiness gate");
+        let request = requests.recv().await.expect("source should get a request");
+
+        let pending = tokio::time::timeout(Duration::from_millis(50), upstream.established()).await;
+        assert!(
+            pending.is_err(),
+            "the gate must not resolve before the upstream subscription is established"
+        );
+
+        request.upstream.established();
+
+        upstream
+            .established()
+            .await
+            .expect("gate should resolve once the upstream subscription is established");
+    }
+
+    /// An upstream rejection has to surface as the same error, so the caller can
+    /// answer REQUEST_ERROR with a matching code instead of accepting the request
+    /// and reporting the failure later as PUBLISH_DONE.
+    #[tokio::test]
+    async fn upstream_gate_propagates_the_upstream_rejection() {
+        let mut locals = Locals::new();
+        let namespace = ns("room/123");
+        let (_registration, mut requests) = locals
+            .register_namespace(None, namespace.clone())
+            .await
+            .expect("namespace source should register");
+
+        let upstream = locals
+            .get_or_request_track(None, namespace.clone(), "video")
+            .await
+            .expect("missing track should be requested")
+            .upstream
+            .expect("cached track should hand back a gate");
+        let request = requests.recv().await.expect("source should get a request");
+
+        let rejection = ServeError::Closed(RequestErrorCode::DoesNotExist as u64);
+        request.upstream.failed(rejection.clone());
+
+        let err = upstream
+            .established()
+            .await
+            .expect_err("a rejected upstream subscription must not resolve as established");
+        assert_eq!(err, rejection);
+    }
+
+    /// A subscriber arriving mid-handshake is a cache hit on an entry that is not
+    /// established yet, so it must wait on the same gate rather than be served a
+    /// reader with no upstream subscription behind it.
+    #[tokio::test]
+    async fn upstream_gate_is_shared_by_concurrent_subscribers() {
+        let mut locals = Locals::new();
+        let namespace = ns("room/123");
+        let (_registration, mut requests) = locals
+            .register_namespace(None, namespace.clone())
+            .await
+            .expect("namespace source should register");
+
+        let first = locals
+            .get_or_request_track(None, namespace.clone(), "video")
+            .await
+            .expect("first request")
+            .upstream
+            .expect("first gate");
+        let request = requests.recv().await.expect("source should get a request");
+
+        let second = locals
+            .get_or_request_track(None, namespace.clone(), "video")
+            .await
+            .expect("second request")
+            .upstream
+            .expect("second gate");
+
+        let pending = tokio::time::timeout(Duration::from_millis(50), second.established()).await;
+        assert!(
+            pending.is_err(),
+            "a cache hit on an unestablished entry must still wait"
+        );
+
+        request.upstream.established();
+
+        first
+            .established()
+            .await
+            .expect("first subscriber should be released");
+        second
+            .established()
+            .await
+            .expect("second subscriber should be released");
+        assert!(
+            requests.try_recv().is_err(),
+            "sharing the gate must not trigger a second upstream SUBSCRIBE"
+        );
+    }
+
+    /// A requester that gives up without answering must release waiting
+    /// subscribers with an error rather than stranding them: an abandoned request
+    /// is not an established subscription.
+    #[tokio::test]
+    async fn abandoned_request_releases_waiting_subscribers() {
+        let mut locals = Locals::new();
+        let namespace = ns("room/123");
+        let (_registration, mut requests) = locals
+            .register_namespace(None, namespace.clone())
+            .await
+            .expect("namespace source should register");
+
+        let upstream = locals
+            .get_or_request_track(None, namespace.clone(), "video")
+            .await
+            .expect("missing track should be requested")
+            .upstream
+            .expect("cached track should hand back a gate");
+
+        drop(requests.recv().await.expect("source should get a request"));
+
+        let err = upstream
+            .established()
+            .await
+            .expect_err("an abandoned request must not leave subscribers waiting forever");
+        assert!(
+            matches!(err, ServeError::InternalWithId(_, _)),
+            "unexpected error: {err}"
+        );
+    }
+
+    /// Locally published tracks are already established when they are registered,
+    /// so serving one must not wait on anything.
+    #[tokio::test]
+    async fn published_track_has_no_upstream_gate() {
+        let mut locals = Locals::new();
+        let namespace = ns("room/123");
+        let (_writer, reader) = Track::new(namespace.clone(), "audio").produce();
+        let _registration = locals
+            .register_track(None, reader)
+            .await
+            .expect("track should register");
+
+        let local = locals
+            .get_or_request_track(None, namespace, "audio")
+            .await
+            .expect("published track should be served");
+
+        assert!(
+            local.upstream.is_none(),
+            "a published track needs no upstream readiness gate"
+        );
+        assert!(
+            local.interest.is_none(),
+            "a published track has no upstream subscription to lease"
+        );
+    }
+
     /// The core fix: once the last downstream subscriber leaves, the cache entry
     /// is evicted and the lease resolves so the upstream subscription can be
     /// dropped (sending UNSUBSCRIBE).
@@ -1459,11 +1783,12 @@ mod tests {
             .await
             .expect("namespace source should register");
 
-        let (_reader, guard) = locals
+        let guard = locals
             .get_or_request_track(None, namespace.clone(), "video")
             .await
-            .expect("missing track should be requested");
-        let guard = guard.expect("cached track should hand back a guard");
+            .expect("missing track should be requested")
+            .interest
+            .expect("cached track should hand back a guard");
 
         let request = requests.recv().await.expect("source should get a request");
         let key = full(&namespace, "video");
@@ -1507,7 +1832,7 @@ mod tests {
             .await
             .expect("namespace source should register");
 
-        let (_reader, guard) = locals
+        let local = locals
             .get_or_request_track(None, namespace.clone(), "video")
             .await
             .expect("missing track should be requested");
@@ -1516,7 +1841,11 @@ mod tests {
         let released = request.lease.released();
         tokio::pin!(released);
 
-        drop(guard.expect("cached track should hand back a guard"));
+        drop(
+            local
+                .interest
+                .expect("cached track should hand back a guard"),
+        );
 
         tokio::select! {
             _ = &mut released => panic!("evicted before the grace period elapsed"),
@@ -1524,11 +1853,12 @@ mod tests {
         }
 
         // New subscriber inside the grace period: served from cache, no new request.
-        let (_reader, guard) = locals
+        let guard = locals
             .get_or_request_track(None, namespace.clone(), "video")
             .await
-            .expect("warm entry should still be served");
-        let guard = guard.expect("cached track should hand back a guard");
+            .expect("warm entry should still be served")
+            .interest
+            .expect("cached track should hand back a guard");
 
         tokio::select! {
             _ = &mut released => panic!("evicted while a subscriber was present"),
@@ -1560,14 +1890,14 @@ mod tests {
             .await
             .expect("namespace source should register");
 
-        let (_reader, guard) = locals
+        let local = locals
             .get_or_request_track(None, namespace.clone(), "video")
             .await
             .expect("missing track should be requested");
 
         // The subscriber goes away before the source has even picked up the
         // request, which is what a cancelled SUBSCRIBE looks like.
-        drop(guard);
+        drop(local);
 
         let request = requests.recv().await.expect("source should get a request");
         request.lease.released().await;
@@ -1591,13 +1921,13 @@ mod tests {
             .await
             .expect("namespace source should register");
 
-        let (_reader, guard) = locals
+        let local = locals
             .get_or_request_track(None, namespace.clone(), "video")
             .await
             .expect("missing track should be requested");
         let request = requests.recv().await.expect("source should get a request");
 
-        drop(guard);
+        drop(local);
 
         tokio::select! {
             _ = request.lease.released() => panic!("eviction should be disabled"),
@@ -1620,7 +1950,7 @@ mod tests {
             .await
             .expect("namespace source should register");
 
-        let (_reader, first_guard) = locals
+        let first = locals
             .get_or_request_track(None, namespace.clone(), "video")
             .await
             .expect("first request");
@@ -1628,7 +1958,7 @@ mod tests {
 
         // Drop the first generation's entry while deliberately keeping its guard
         // alive, modelling a slow subscriber that outlives its cache entry.
-        let stale_guard = first_guard.expect("guard");
+        let stale_guard = first.interest.expect("guard");
         let key = full(&namespace, "video");
         locals
             .tracks
@@ -1640,12 +1970,12 @@ mod tests {
         drop(first_request);
 
         // A second subscriber creates a fresh generation.
-        let (_reader, second_guard) = locals
+        let second = locals
             .get_or_request_track(None, namespace.clone(), "video")
             .await
             .expect("second request");
         let second_request = requests.recv().await.expect("second request received");
-        drop(second_guard.expect("guard"));
+        drop(second.interest.expect("guard"));
 
         // The stale guard belongs to the old counter, so it must not make the new
         // entry look busy.

--- a/moq-relay-ietf/src/local.rs
+++ b/moq-relay-ietf/src/local.rs
@@ -65,9 +65,11 @@ pub struct TrackRequest {
     /// Reports whether the upstream subscription was established.
     ///
     /// Downstream subscribers wait on this before SUBSCRIBE_OK is sent, so the
-    /// requester must resolve it exactly once — via
-    /// [`UpstreamReadyTx::established`] or [`UpstreamReadyTx::failed`] — as soon
-    /// as the upstream publisher answers.
+    /// requester must report the outcome as soon as the upstream publisher
+    /// answers — via [`UpstreamReadyTx::established`] or
+    /// [`UpstreamReadyTx::failed`] — or drop the sender to abandon the request,
+    /// which releases any waiting subscribers with an error rather than
+    /// stranding them until the upstream response timeout.
     pub upstream: UpstreamReadyTx,
 }
 

--- a/moq-relay-ietf/src/metrics.rs
+++ b/moq-relay-ietf/src/metrics.rs
@@ -51,7 +51,7 @@
 //!
 //! | Name | Labels | Description |
 //! |------|--------|-------------|
-//! | `moq_relay_subscribe_latency_seconds` | `source` | Time to resolve subscription (source: local, remote, not_found, route_error, upstream_error) |
+//! | `moq_relay_subscribe_latency_seconds` | `source` | Time to resolve subscription (source: local, remote, not_found, route_error, upstream_error, downstream_left) |
 
 use metrics::{describe_counter, describe_gauge, describe_histogram, Unit};
 
@@ -168,7 +168,7 @@ pub fn describe_metrics() {
     describe_histogram!(
         "moq_relay_subscribe_latency_seconds",
         Unit::Seconds,
-        "Time to resolve subscription by source (local, remote, not_found, route_error, upstream_error)"
+        "Time to resolve subscription by source (local, remote, not_found, route_error, upstream_error, downstream_left)"
     );
 }
 

--- a/moq-relay-ietf/src/metrics.rs
+++ b/moq-relay-ietf/src/metrics.rs
@@ -29,6 +29,7 @@
 //! | `moq_relay_subscribers_total` | - | Total subscribers (SUBSCRIBE requests) received |
 //! | `moq_relay_subscribe_not_found_total` | - | Track not found after checking all sources |
 //! | `moq_relay_subscribe_route_errors_total` | - | Infrastructure failure when routing to remote |
+//! | `moq_relay_subscribe_upstream_errors_total` | - | Upstream subscription could not be established, so the downstream SUBSCRIBE was rejected |
 //! | `moq_relay_upstream_errors_total` | `stage` | Upstream connection failures (stage: connect, session) |
 //! | `moq_relay_namespace_transition_timeouts_total` | - | Namespace pull streams reset after graceful transition timeout |
 //! | `moq_relay_cache_idle_evictions_total` | `source` | Unwatched cache entries evicted, releasing an upstream subscription (source: local, remote) |
@@ -50,7 +51,7 @@
 //!
 //! | Name | Labels | Description |
 //! |------|--------|-------------|
-//! | `moq_relay_subscribe_latency_seconds` | `source` | Time to resolve subscription (source: local, remote, not_found, route_error) |
+//! | `moq_relay_subscribe_latency_seconds` | `source` | Time to resolve subscription (source: local, remote, not_found, route_error, upstream_error) |
 
 use metrics::{describe_counter, describe_gauge, describe_histogram, Unit};
 
@@ -109,6 +110,10 @@ pub fn describe_metrics() {
         "Infrastructure failure when routing to remote"
     );
     describe_counter!(
+        "moq_relay_subscribe_upstream_errors_total",
+        "Upstream subscription could not be established, so the downstream SUBSCRIBE was rejected"
+    );
+    describe_counter!(
         "moq_relay_upstream_errors_total",
         "Upstream connection failures by stage (connect, session)"
     );
@@ -163,7 +168,7 @@ pub fn describe_metrics() {
     describe_histogram!(
         "moq_relay_subscribe_latency_seconds",
         Unit::Seconds,
-        "Time to resolve subscription by source (local, remote, not_found, route_error)"
+        "Time to resolve subscription by source (local, remote, not_found, route_error, upstream_error)"
     );
 }
 

--- a/moq-relay-ietf/src/producer.rs
+++ b/moq-relay-ietf/src/producer.rs
@@ -17,6 +17,7 @@ use crate::{
     metrics::{GaugeGuard, TimingGuard},
     upstream_namespaces::UpstreamNamespaces,
     Coordinator, Locals, NamespaceChange, RemoteManager, SessionContext, TrackChange,
+    UpstreamReady,
 };
 
 /// Producer of tracks to a remote Subscriber
@@ -154,18 +155,40 @@ impl Producer {
         // 1. actual FullTrackName -> TrackReader media cache
         // 2. PUBLISH_NAMESPACE route source, which triggers upstream SUBSCRIBE
         let mut locals = self.locals.clone();
-        if let Some((track, interest_guard)) = locals
+        if let Some(local) = locals
             .get_or_request_track(self.context.scope(), namespace.clone(), &track_name)
             .await
         {
             let ns = namespace.to_utf8_path();
-            tracing::info!(namespace = %ns, track = %track_name, source = "local", "serving subscribe from local: {:?}", track.info);
+            tracing::info!(namespace = %ns, track = %track_name, source = "local", "serving subscribe from local: {:?}", local.reader.info);
             timing_guard.set_label("source", "local");
             let _track_guard = GaugeGuard::new("moq_relay_active_tracks");
             // Held until serving finishes. Once the last guard for a cached track
             // drops, its upstream subscription becomes eligible for release.
-            let _interest_guard = interest_guard;
-            return Ok(subscribed.serve(track).await?);
+            let _interest_guard = local.interest;
+
+            // Draft-16 §8.4: a relay MUST have an Established upstream
+            // subscription before it sends SUBSCRIBE_OK. A pull-through cache
+            // entry exists before its upstream subscription does, so wait for it.
+            if let Some(upstream) = local.upstream {
+                if let Err(err) = Self::await_upstream(&subscribed, &upstream).await {
+                    if Self::is_expected_serve_shutdown_err(&err) {
+                        tracing::debug!(namespace = %ns, track = %track_name, error = %err, "downstream subscriber left before the upstream subscription was established");
+                    } else {
+                        tracing::warn!(namespace = %ns, track = %track_name, error = %err, "upstream subscription could not be established");
+                        metrics::counter!("moq_relay_subscribe_upstream_errors_total").increment(1);
+                    }
+                    timing_guard.set_label("source", "upstream_error");
+
+                    // Rejects when the subscription is already closed (the
+                    // downstream-left case), which is fine: the error below is
+                    // still the reason we stopped.
+                    let _ = subscribed.close(err.clone());
+                    return Err(err.into());
+                }
+            }
+
+            return Ok(subscribed.serve(local.reader).await?);
         }
 
         // Check remote tracks after local exact tracks and namespace route sources.
@@ -217,6 +240,21 @@ impl Producer {
         ));
         subscribed.close(err.clone())?;
         Err(err.into())
+    }
+
+    /// Wait for the upstream subscription behind a cached track to be established.
+    ///
+    /// Also completes when the downstream subscriber goes away first, so a
+    /// cancelled SUBSCRIBE is not held here for the full upstream response
+    /// timeout.
+    async fn await_upstream(
+        subscribed: &Subscribed,
+        upstream: &UpstreamReady,
+    ) -> Result<(), ServeError> {
+        tokio::select! {
+            res = upstream.established() => res,
+            res = subscribed.closed() => Err(res.err().unwrap_or(ServeError::Done)),
+        }
     }
 
     /// Serve a SUBSCRIBE_NAMESPACE request using relay-local namespace state.
@@ -513,13 +551,18 @@ impl Producer {
     }
 
     fn is_expected_serve_shutdown(err: &anyhow::Error) -> bool {
-        matches!(
-            err.downcast_ref::<SessionError>(),
-            Some(SessionError::Serve(ServeError::Cancel | ServeError::Done))
-        ) || matches!(
-            err.downcast_ref::<ServeError>(),
-            Some(ServeError::Cancel | ServeError::Done)
-        )
+        let serve = match err.downcast_ref::<SessionError>() {
+            Some(SessionError::Serve(err)) => Some(err),
+            _ => err.downcast_ref::<ServeError>(),
+        };
+
+        serve.is_some_and(Self::is_expected_serve_shutdown_err)
+    }
+
+    /// True for the errors that mean nobody is waiting for the subscription any
+    /// more, rather than a failure worth warning about.
+    fn is_expected_serve_shutdown_err(err: &ServeError) -> bool {
+        matches!(err, ServeError::Cancel | ServeError::Done)
     }
 
     /// Serve a track_status request.

--- a/moq-relay-ietf/src/producer.rs
+++ b/moq-relay-ietf/src/producer.rs
@@ -172,13 +172,17 @@ impl Producer {
             // entry exists before its upstream subscription does, so wait for it.
             if let Some(upstream) = local.upstream {
                 if let Err(err) = Self::await_upstream(&subscribed, &upstream).await {
+                    // Distinguish a cancelled SUBSCRIBE from a genuine upstream
+                    // failure, so the latency histogram is not polluted with
+                    // subscribers that simply went away while waiting.
                     if Self::is_expected_serve_shutdown_err(&err) {
                         tracing::debug!(namespace = %ns, track = %track_name, error = %err, "downstream subscriber left before the upstream subscription was established");
+                        timing_guard.set_label("source", "downstream_left");
                     } else {
                         tracing::warn!(namespace = %ns, track = %track_name, error = %err, "upstream subscription could not be established");
                         metrics::counter!("moq_relay_subscribe_upstream_errors_total").increment(1);
+                        timing_guard.set_label("source", "upstream_error");
                     }
-                    timing_guard.set_label("source", "upstream_error");
 
                     // Rejects when the subscription is already closed (the
                     // downstream-left case), which is fine: the error below is

--- a/moq-relay-ietf/src/producer.rs
+++ b/moq-relay-ietf/src/producer.rs
@@ -31,6 +31,22 @@ pub struct Producer {
     context: SessionContext,
 }
 
+/// Why the wait for upstream readiness ended without the subscription being
+/// established.
+///
+/// The two cases carry the same [`ServeError`] variants — an upstream rejection
+/// can be `Cancel` or `Done` just as a departing subscriber can — so the
+/// direction has to come from which branch resolved rather than from the error.
+/// Getting it wrong misreports publisher failures as subscriber cancellations in
+/// the subscribe metrics.
+enum UpstreamWait {
+    /// The upstream subscription could not be established.
+    UpstreamFailed(ServeError),
+
+    /// The downstream subscriber went away before it was established.
+    DownstreamLeft(ServeError),
+}
+
 impl Producer {
     pub fn new(
         publisher: Publisher,
@@ -171,18 +187,26 @@ impl Producer {
             // subscription before it sends SUBSCRIBE_OK. A pull-through cache
             // entry exists before its upstream subscription does, so wait for it.
             if let Some(upstream) = local.upstream {
-                if let Err(err) = Self::await_upstream(&subscribed, &upstream).await {
-                    // Distinguish a cancelled SUBSCRIBE from a genuine upstream
-                    // failure, so the latency histogram is not polluted with
-                    // subscribers that simply went away while waiting.
-                    if Self::is_expected_serve_shutdown_err(&err) {
-                        tracing::debug!(namespace = %ns, track = %track_name, error = %err, "downstream subscriber left before the upstream subscription was established");
-                        timing_guard.set_label("source", "downstream_left");
-                    } else {
-                        tracing::warn!(namespace = %ns, track = %track_name, error = %err, "upstream subscription could not be established");
-                        metrics::counter!("moq_relay_subscribe_upstream_errors_total").increment(1);
-                        timing_guard.set_label("source", "upstream_error");
-                    }
+                if let Err(outcome) = Self::await_upstream(&subscribed, &upstream).await {
+                    // Which side ended the wait is decided by the branch that
+                    // resolved, not by the error variant: an upstream failure can
+                    // itself be Cancel or Done, so sniffing the variant would
+                    // report a publisher-side failure as a subscriber cancellation
+                    // and skip the upstream-error counter.
+                    let err = match outcome {
+                        UpstreamWait::DownstreamLeft(err) => {
+                            tracing::debug!(namespace = %ns, track = %track_name, error = %err, "downstream subscriber left before the upstream subscription was established");
+                            timing_guard.set_label("source", "downstream_left");
+                            err
+                        }
+                        UpstreamWait::UpstreamFailed(err) => {
+                            tracing::warn!(namespace = %ns, track = %track_name, error = %err, "upstream subscription could not be established");
+                            metrics::counter!("moq_relay_subscribe_upstream_errors_total")
+                                .increment(1);
+                            timing_guard.set_label("source", "upstream_error");
+                            err
+                        }
+                    };
 
                     // Rejects when the subscription is already closed (the
                     // downstream-left case), which is fine: the error below is
@@ -250,14 +274,17 @@ impl Producer {
     ///
     /// Also completes when the downstream subscriber goes away first, so a
     /// cancelled SUBSCRIBE is not held here for the full upstream response
-    /// timeout.
+    /// timeout. The two cases are reported separately because they cannot be
+    /// told apart from the error alone — see [`UpstreamWait`].
     async fn await_upstream(
         subscribed: &Subscribed,
         upstream: &UpstreamReady,
-    ) -> Result<(), ServeError> {
+    ) -> Result<(), UpstreamWait> {
         tokio::select! {
-            res = upstream.established() => res,
-            res = subscribed.closed() => Err(res.err().unwrap_or(ServeError::Done)),
+            res = upstream.established() => res.map_err(UpstreamWait::UpstreamFailed),
+            res = subscribed.closed() => Err(UpstreamWait::DownstreamLeft(
+                res.err().unwrap_or(ServeError::Done),
+            )),
         }
     }
 


### PR DESCRIPTION
## Problem

Draft-16 §8.4 requires a relay to have an *Established* upstream subscription before it sends `SUBSCRIBE_OK` in response to a downstream `SUBSCRIBE`. The relay sends `SUBSCRIBE_OK` optimistically, as soon as it has reserved a pull-through cache slot — before it knows whether the upstream subscription will succeed.

A subscriber can therefore receive `SUBSCRIBE_OK` for a subscription that cannot be established at all, and only learns the truth later. That matters to applications: code that treats `SUBSCRIBE_OK` as "this track is live" will commit to a track that never produces an object instead of failing fast and trying another publisher. `SUBSCRIBE_OK` also carries Largest Object (§9.10), which the relay cannot know without an upstream subscription.

## Root cause

`Locals::get_or_request_track` reserves the cache entry and returns a `TrackReader` immediately after queuing a `TrackRequest`. `Producer::serve_subscribe` then called `Subscribed::serve(track)` — which sends `SUBSCRIBE_OK` — while the `Consumer` task only awaited `subscriber.subscribe_open(writer)` afterwards. The two events were unsynchronized.

## Fix

Carry a `watch`-based readiness handle alongside the pull-through request:

- `TrackRequest` gains an `UpstreamReadyTx`, which the `Consumer` resolves: `established()` when `subscribe_open` succeeds, `failed(err)` when it does not. Dropping the sender abandons the request and releases any waiters.
- `TrackEntry` holds the corresponding `UpstreamReady` receiver. `get_or_request_track` returns it via a new `LocalTrack` struct, replacing the `(TrackReader, Option<TrackInterestGuard>)` tuple.
- `Producer::serve_subscribe` awaits the gate before calling `serve`, selected against `subscribed.closed()` so a subscriber that goes away while waiting doesn't leak the task.
- On upstream failure the error propagates downstream verbatim: `Subscribed::drop` with `ok == false` maps `ServeError::Closed(code)` back through `request_error_code`.

Locally published tracks are already established, so they get no gate. The direct cross-relay path (`RemoteManager::subscribe`) already awaited `subscribe_open` and is unchanged.

**No new timeout is introduced.** `moq-transport` already enforces a 30s `RESPONSE_TIMEOUT` on pending requests, which bounds the wait by causing `subscribe_open` to fail.

## Observability

Genuine upstream failures increment a new `moq_relay_subscribe_upstream_errors_total` counter and record `source=upstream_error` on the subscribe latency histogram. A subscriber that closes while waiting records `source=downstream_left`, so cancellations don't pollute the classification.

The two cases are distinguished by which `select!` branch resolved rather than by inspecting the `ServeError` variant. This is deliberate: an upstream rejection can itself be `Cancel` or `Done`, exactly like a departing subscriber, so sniffing the variant would report publisher-side failures as subscriber cancellations and skip the counter. `UpstreamWait` makes that misclassification unrepresentable.

## Verification

Full CI gate locally: `cargo fmt --check`, `cargo clippy --no-deps`, `cargo machete`, `cargo test --workspace`. The relay lib goes from 114 to 119 tests.

Five new unit tests cover the readiness primitive: waiting for the requester, propagating an upstream rejection, sharing across concurrent subscribers, abandoned requests releasing waiters, and published tracks having no gate.

### End-to-end before/after

The wiring was validated with a local scenario in which the publisher advertises a namespace but **never creates the requested track**, so an upstream subscription can never be established. A conforming relay must answer `REQUEST_ERROR`; `SUBSCRIBE_OK` is then unambiguously wrong rather than merely early. Same test client, two relay builds, three runs each:

| Relay build | Result |
|---|---|
| `8a963bcb` (this PR's parent) | 3/3 **fail** — relay sent `SUBSCRIBE_OK` |
| `8515af8d` (this PR) | 3/3 **pass** — relay sent `REQUEST_ERROR` (`DoesNotExist`) |

Control-message sequence at the relay:

```
before:  recv SUBSCRIBE -> sent SUBSCRIBE_OK -> sent SUBSCRIBE(upstream) -> recv REQUEST_ERROR
after:   recv SUBSCRIBE -> sent SUBSCRIBE(upstream) -> recv REQUEST_ERROR -> sent REQUEST_ERROR
```

Before the fix, `SUBSCRIBE_OK` was sent before the upstream `SUBSCRIBE` had even been sent. The fixed run also exercises the downstream `REQUEST_ERROR` propagation path end to end.

Separately, a `moq-clock` publisher/subscriber pair through the relay confirms the ordinary path still works and the added wait does not stall: 4/4 runs show downstream `SUBSCRIBE_OK` following the upstream `SUBSCRIBE_OK`, with objects flowing.

### Why the test has to be shaped that way

Timing-based assertions on loopback are unreliable here. Before the fix the ordering was an unsynchronized race, and when the upstream publisher *does* create the track the response arrives in a few milliseconds, so loopback usually wins the race by luck — a `moq-clock` pair showed correct ordering in 8/8 pre-fix runs. The violation only becomes observable when the upstream subscription fails or is slow, which is why it reproduced against a deployed relay at ~95ms RTT but not locally. Removing the upstream's ability to succeed at all is what makes the test deterministic.

## Note on test placement

The scenario above is not included in this PR. `moq-test-client` implements the WG-wide shared interop test specifications, whereas this is a regression test for one relay's internal wiring — a different concern.

It is also not currently expressible as an in-crate unit test: `Subscribed::new` is `pub(super)`, and `Subscriber::new`, `Queue`, and `PendingRequests` are not public, so a `Publisher`/`Subscribed` pair cannot be constructed from inside `moq-relay-ietf`. The readiness primitive is unit-tested; the wiring rests on the end-to-end check above.
