### PR TITLE
fix: release upstream subscriptions for idle cached tracks, and stop FIN-ing subgroup streams mid-object (draft-14)

### DIFF
--- a/moq-relay-ietf/Cargo.toml
+++ b/moq-relay-ietf/Cargo.toml
@@ -70,6 +70,11 @@ thiserror = "2.0.17"
 metrics = "0.24"
 metrics-exporter-prometheus = { version = "0.16", optional = true }
 
+[dev-dependencies]
+# test-util provides the paused-clock runtime used to test idle timeouts without
+# sleeping for real.
+tokio = { version = "1", features = ["full", "test-util"] }
+
 [features]
 default = []
 metrics-prometheus = ["dep:metrics-exporter-prometheus"]

--- a/moq-relay-ietf/src/bin/moq-relay-ietf/main.rs
+++ b/moq-relay-ietf/src/bin/moq-relay-ietf/main.rs
@@ -5,6 +5,7 @@ mod api_coordinator;
 mod file_coordinator;
 
 use std::sync::Arc;
+use std::time::Duration;
 use std::{net, path::PathBuf};
 
 use clap::Parser;
@@ -36,6 +37,12 @@ pub struct Cli {
     /// If not provided, the relay accepts every unique announce.
     #[arg(long)]
     pub announce: Option<Url>,
+
+    /// Seconds to keep a cached track with no subscribers before releasing its
+    /// upstream subscription. 0 disables eviction, holding upstream
+    /// subscriptions for the lifetime of the upstream session.
+    #[arg(long, default_value_t = 30)]
+    pub cache_idle_timeout: u64,
 
     /// The URL of the moq-api server in order to run a cluster.
     /// Must be used in conjunction with --node to advertise the origin
@@ -181,16 +188,19 @@ async fn main() -> anyhow::Result<()> {
     };
 
     // Create a QUIC server for media.
-    let relay = Relay::new(RelayConfig {
-        tls: tls.clone(),
-        bind: Some(cli.bind),
-        endpoints: vec![],
-        qlog_dir: qlog_dir_for_relay,
-        mlog_dir: mlog_dir_for_relay,
-        node: cli.node,
-        announce: cli.announce,
-        coordinator,
-    })?;
+    let relay = Relay::new_with_cache_idle_timeout(
+        RelayConfig {
+            tls: tls.clone(),
+            bind: Some(cli.bind),
+            endpoints: vec![],
+            qlog_dir: qlog_dir_for_relay,
+            mlog_dir: mlog_dir_for_relay,
+            node: cli.node,
+            announce: cli.announce,
+            coordinator,
+        },
+        Duration::from_secs(cli.cache_idle_timeout),
+    )?;
 
     if cli.dev {
         // Create a web server too.

--- a/moq-relay-ietf/src/bin/moq-relay-ietf/main.rs
+++ b/moq-relay-ietf/src/bin/moq-relay-ietf/main.rs
@@ -13,7 +13,7 @@ use url::Url;
 
 use api_coordinator::{ApiCoordinator, ApiCoordinatorConfig};
 use file_coordinator::FileCoordinator;
-use moq_relay_ietf::{Coordinator, Relay, RelayConfig, Web, WebConfig};
+use moq_relay_ietf::{Coordinator, Relay, RelayConfig, RelayTuning, Web, WebConfig};
 
 #[derive(Parser, Clone)]
 pub struct Cli {
@@ -43,6 +43,12 @@ pub struct Cli {
     /// subscriptions for the lifetime of the upstream session.
     #[arg(long, default_value_t = 30)]
     pub cache_idle_timeout: u64,
+
+    /// Seconds to wait for an upstream to acknowledge a SUBSCRIBE before giving
+    /// up. Must be at least 1: an unbounded wait on a peer is what this timeout
+    /// exists to prevent, so there is no "disabled" setting.
+    #[arg(long, default_value_t = 10, value_parser = clap::value_parser!(u64).range(1..))]
+    pub subscribe_timeout: u64,
 
     /// The URL of the moq-api server in order to run a cluster.
     /// Must be used in conjunction with --node to advertise the origin
@@ -188,7 +194,7 @@ async fn main() -> anyhow::Result<()> {
     };
 
     // Create a QUIC server for media.
-    let relay = Relay::new_with_cache_idle_timeout(
+    let relay = Relay::new_with_tuning(
         RelayConfig {
             tls: tls.clone(),
             bind: Some(cli.bind),
@@ -199,7 +205,9 @@ async fn main() -> anyhow::Result<()> {
             announce: cli.announce,
             coordinator,
         },
-        Duration::from_secs(cli.cache_idle_timeout),
+        RelayTuning::default()
+            .with_cache_idle_timeout(Duration::from_secs(cli.cache_idle_timeout))
+            .with_subscribe_timeout(Duration::from_secs(cli.subscribe_timeout)),
     )?;
 
     if cli.dev {

--- a/moq-relay-ietf/src/consumer.rs
+++ b/moq-relay-ietf/src/consumer.rs
@@ -182,10 +182,28 @@ impl Consumer {
                         // Hold the subscription explicitly rather than using
                         // `subscribe()`, so it can be dropped — sending
                         // UNSUBSCRIBE — once downstream interest goes away.
-                        let subscribe = match subscriber.subscribe_open(writer).await {
-                            Ok(subscribe) => subscribe,
-                            Err(err) => {
-                                tracing::warn!(namespace = %info.namespace, track = %track_name, error = %err, "failed forwarding subscribe: {:?}, error: {}", info, err);
+                        //
+                        // The handshake itself is raced against the lease, not just
+                        // the established subscription. `subscribe_open` waits for
+                        // SUBSCRIBE_OK, which an upstream is under no obligation to
+                        // ever send; without this arm a never-acked subscribe would
+                        // pin this task, and the `TrackWriter` it carries, until the
+                        // session died — the resource leak this path exists to avoid.
+                        // Dropping the in-flight future drops the `Subscribe`, whose
+                        // `Drop` sends UNSUBSCRIBE, so cancelling mid-handshake is
+                        // still clean. `remote.rs` races its handshake against
+                        // connection cancellation for the same reason.
+                        let subscribe = tokio::select! {
+                            result = subscriber.subscribe_open(writer) => match result {
+                                Ok(subscribe) => subscribe,
+                                Err(err) => {
+                                    tracing::warn!(namespace = %info.namespace, track = %track_name, error = %err, "failed forwarding subscribe: {:?}, error: {}", info, err);
+                                    return Ok(());
+                                }
+                            },
+                            _ = lease.released() => {
+                                tracing::info!(namespace = %info.namespace, track = %track_name, "abandoning upstream subscribe for idle cached track");
+                                metrics::counter!("moq_relay_cache_idle_evictions_total", "source" => "local").increment(1);
                                 return Ok(());
                             }
                         };

--- a/moq-relay-ietf/src/consumer.rs
+++ b/moq-relay-ietf/src/consumer.rs
@@ -72,12 +72,11 @@ impl Consumer {
 
                     tasks.push(async move {
                         let info = announce.clone();
-                        let namespace = info.namespace.to_utf8_path();
-                        tracing::info!(namespace = %namespace, "serving announce: {:?}", info);
+                        tracing::info!(namespace = %info.namespace, "serving announce: {:?}", info);
 
                         // Serve the announce request
                         if let Err(err) = this.serve(announce).await {
-                            tracing::warn!(namespace = %namespace, error = %err, "failed serving announce: {:?}, error: {}", info, err);
+                            tracing::warn!(namespace = %info.namespace, error = %err, "failed serving announce: {:?}, error: {}", info, err);
                             // Note: phase-specific error counters are incremented in serve()
                         }
                     });
@@ -102,10 +101,8 @@ impl Consumer {
         // should we allow the same namespace being served from multiple relays??
         // Manish: NO.
 
-        let ns = reader.namespace.to_utf8_path();
-
         // Register the local tracks, unregister on drop
-        tracing::debug!(namespace = %ns, "registering namespace in locals");
+        tracing::debug!(namespace = %reader.namespace, "registering namespace in locals");
         let _register = match self
             .locals
             .register(self.scope.as_deref(), reader.clone())
@@ -118,13 +115,13 @@ impl Consumer {
                 return Err(err);
             }
         };
-        tracing::debug!(namespace = %ns, "namespace registered in locals");
+        tracing::debug!(namespace = %reader.namespace, "namespace registered in locals");
 
         // NOTE(mpandit): once the track is pulled from origin, internally it will be relayed
         // from this metal only, because now coordinator will have entry for the namespace.
 
         // Register namespace with the coordinator
-        tracing::debug!(namespace = %ns, "registering namespace with coordinator");
+        tracing::debug!(namespace = %reader.namespace, "registering namespace with coordinator");
         let _namespace_registration = match self
             .coordinator
             .register_namespace(self.scope.as_deref(), &reader.namespace)
@@ -137,14 +134,14 @@ impl Consumer {
                 return Err(err.into());
             }
         };
-        tracing::debug!(namespace = %ns, "namespace registered with coordinator");
+        tracing::debug!(namespace = %reader.namespace, "namespace registered with coordinator");
 
         // Accept the announce with an OK response
         if let Err(err) = announce.ok() {
             metrics::counter!("moq_relay_announce_errors_total", "phase" => "send_ok").increment(1);
             return Err(err.into());
         }
-        tracing::debug!(namespace = %ns, "sent ANNOUNCE_OK");
+        tracing::debug!(namespace = %reader.namespace, "sent ANNOUNCE_OK");
 
         // Successfully sent ANNOUNCE_OK
         metrics::counter!("moq_relay_announce_ok_total").increment(1);
@@ -153,8 +150,7 @@ impl Consumer {
         if let Some(mut forward) = self.forward {
             tasks.push(
                 async move {
-                    let namespace = reader.namespace.to_utf8_path();
-                    tracing::info!(namespace = %namespace, "forwarding announce: {:?}", reader.info);
+                    tracing::info!(namespace = %reader.namespace, "forwarding announce: {:?}", reader.info);
                     forward
                         .announce(reader)
                         .await
@@ -169,8 +165,7 @@ impl Consumer {
             tokio::select! {
                 // If the announce is closed, return the error
                 Err(err) = announce.closed() => {
-                    let ns = announce.namespace.to_utf8_path();
-                    tracing::info!(namespace = %ns, error = %err, "announce closed");
+                    tracing::info!(namespace = %announce.namespace, error = %err, "announce closed");
                     return Err(err.into());
                 },
 
@@ -181,9 +176,8 @@ impl Consumer {
                     // Spawn a new task to handle the subscribe
                     tasks.push(async move {
                         let info = writer.info.clone();
-                        let namespace = info.namespace.to_utf8_path();
                         let track_name = info.name.clone();
-                        tracing::info!(namespace = %namespace, track = %track_name, "forwarding subscribe: {:?}", info);
+                        tracing::info!(namespace = %info.namespace, track = %track_name, "forwarding subscribe: {:?}", info);
 
                         // Hold the subscription explicitly rather than using
                         // `subscribe()`, so it can be dropped — sending
@@ -191,7 +185,7 @@ impl Consumer {
                         let subscribe = match subscriber.subscribe_open(writer).await {
                             Ok(subscribe) => subscribe,
                             Err(err) => {
-                                tracing::warn!(namespace = %namespace, track = %track_name, error = %err, "failed forwarding subscribe: {:?}, error: {}", info, err);
+                                tracing::warn!(namespace = %info.namespace, track = %track_name, error = %err, "failed forwarding subscribe: {:?}, error: {}", info, err);
                                 return Ok(());
                             }
                         };
@@ -199,14 +193,14 @@ impl Consumer {
                         tokio::select! {
                             res = subscribe.closed() => {
                                 if let Err(err) = res {
-                                    tracing::warn!(namespace = %namespace, track = %track_name, error = %err, "failed forwarding subscribe: {:?}, error: {}", info, err)
+                                    tracing::warn!(namespace = %info.namespace, track = %track_name, error = %err, "failed forwarding subscribe: {:?}, error: {}", info, err)
                                 }
                             }
                             // The cached track went unwatched long enough to be
                             // evicted, so stop pulling it. Dropping `subscribe`
                             // below sends UNSUBSCRIBE upstream.
                             _ = lease.released() => {
-                                tracing::info!(namespace = %namespace, track = %track_name, "releasing upstream subscription for idle cached track");
+                                tracing::info!(namespace = %info.namespace, track = %track_name, "releasing upstream subscription for idle cached track");
                                 metrics::counter!("moq_relay_cache_idle_evictions_total", "source" => "local").increment(1);
                             }
                         }

--- a/moq-relay-ietf/src/consumer.rs
+++ b/moq-relay-ietf/src/consumer.rs
@@ -2,11 +2,12 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::Context;
 use futures::{stream::FuturesUnordered, FutureExt, StreamExt};
 use moq_transport::{
-    serve::Tracks,
+    serve::{TrackRequest, Tracks, DEFAULT_CACHE_IDLE_TIMEOUT},
     session::{Announced, SessionError, Subscriber},
 };
 
@@ -23,6 +24,10 @@ pub struct Consumer {
     /// Produced by `Coordinator::resolve_scope()` from the connection path.
     /// Passed to coordinator register/lookup calls to isolate namespaces.
     scope: Option<String>,
+    /// How long a pull-through cache entry with no downstream subscribers is
+    /// retained before its upstream subscription is released. Zero disables
+    /// eviction.
+    cache_idle_timeout: Duration,
 }
 
 impl Consumer {
@@ -39,7 +44,18 @@ impl Consumer {
             coordinator,
             forward,
             scope,
+            cache_idle_timeout: DEFAULT_CACHE_IDLE_TIMEOUT,
         }
+    }
+
+    /// Set how long an unwatched cached track is retained before its upstream
+    /// subscription is released.
+    ///
+    /// A builder method rather than a `new()` parameter so that existing callers
+    /// of [`Consumer::new`] keep compiling.
+    pub fn with_cache_idle_timeout(mut self, cache_idle_timeout: Duration) -> Self {
+        self.cache_idle_timeout = cache_idle_timeout;
+        self
     }
 
     /// Run the consumer to serve announce requests.
@@ -80,7 +96,8 @@ impl Consumer {
         let mut tasks = FuturesUnordered::new();
 
         // Produce the tracks for this announce and return the reader
-        let (_, mut request, reader) = Tracks::new(announce.namespace.clone()).produce();
+        let (_, mut request, reader) = Tracks::new(announce.namespace.clone())
+            .produce_with_cache_idle_timeout(self.cache_idle_timeout);
 
         // should we allow the same namespace being served from multiple relays??
         // Manish: NO.
@@ -158,20 +175,43 @@ impl Consumer {
                 },
 
                 // Wait for the next subscriber and serve the track.
-                Some(track) = request.next() => {
+                Some(TrackRequest { writer, lease }) = request.next() => {
                     let mut subscriber = self.subscriber.clone();
 
                     // Spawn a new task to handle the subscribe
                     tasks.push(async move {
-                        let info = track.clone();
+                        let info = writer.info.clone();
                         let namespace = info.namespace.to_utf8_path();
                         let track_name = info.name.clone();
                         tracing::info!(namespace = %namespace, track = %track_name, "forwarding subscribe: {:?}", info);
 
-                        // Forward the subscribe request
-                        if let Err(err) = subscriber.subscribe(track).await {
-                            tracing::warn!(namespace = %namespace, track = %track_name, error = %err, "failed forwarding subscribe: {:?}, error: {}", info, err)
+                        // Hold the subscription explicitly rather than using
+                        // `subscribe()`, so it can be dropped — sending
+                        // UNSUBSCRIBE — once downstream interest goes away.
+                        let subscribe = match subscriber.subscribe_open(writer).await {
+                            Ok(subscribe) => subscribe,
+                            Err(err) => {
+                                tracing::warn!(namespace = %namespace, track = %track_name, error = %err, "failed forwarding subscribe: {:?}, error: {}", info, err);
+                                return Ok(());
+                            }
+                        };
+
+                        tokio::select! {
+                            res = subscribe.closed() => {
+                                if let Err(err) = res {
+                                    tracing::warn!(namespace = %namespace, track = %track_name, error = %err, "failed forwarding subscribe: {:?}, error: {}", info, err)
+                                }
+                            }
+                            // The cached track went unwatched long enough to be
+                            // evicted, so stop pulling it. Dropping `subscribe`
+                            // below sends UNSUBSCRIBE upstream.
+                            _ = lease.released() => {
+                                tracing::info!(namespace = %namespace, track = %track_name, "releasing upstream subscription for idle cached track");
+                                metrics::counter!("moq_relay_cache_idle_evictions_total", "source" => "local").increment(1);
+                            }
                         }
+
+                        drop(subscribe);
 
                         Ok(())
                     }.boxed());

--- a/moq-relay-ietf/src/consumer.rs
+++ b/moq-relay-ietf/src/consumer.rs
@@ -11,7 +11,7 @@ use moq_transport::{
     session::{Announced, SessionError, Subscriber},
 };
 
-use crate::{metrics::GaugeGuard, Coordinator, Locals, Producer};
+use crate::{metrics::GaugeGuard, Coordinator, Locals, Producer, DEFAULT_SUBSCRIBE_TIMEOUT};
 
 /// Consumer of tracks from a remote Publisher
 #[derive(Clone)]
@@ -28,6 +28,9 @@ pub struct Consumer {
     /// retained before its upstream subscription is released. Zero disables
     /// eviction.
     cache_idle_timeout: Duration,
+    /// How long to wait for the upstream to acknowledge a SUBSCRIBE before
+    /// giving up. Never zero.
+    subscribe_timeout: Duration,
 }
 
 impl Consumer {
@@ -45,6 +48,7 @@ impl Consumer {
             forward,
             scope,
             cache_idle_timeout: DEFAULT_CACHE_IDLE_TIMEOUT,
+            subscribe_timeout: DEFAULT_SUBSCRIBE_TIMEOUT,
         }
     }
 
@@ -55,6 +59,15 @@ impl Consumer {
     /// of [`Consumer::new`] keep compiling.
     pub fn with_cache_idle_timeout(mut self, cache_idle_timeout: Duration) -> Self {
         self.cache_idle_timeout = cache_idle_timeout;
+        self
+    }
+
+    /// Set how long to wait for the upstream to acknowledge a SUBSCRIBE.
+    ///
+    /// A builder method rather than a `new()` parameter so that existing callers
+    /// of [`Consumer::new`] keep compiling.
+    pub fn with_subscribe_timeout(mut self, subscribe_timeout: Duration) -> Self {
+        self.subscribe_timeout = subscribe_timeout;
         self
     }
 
@@ -172,6 +185,7 @@ impl Consumer {
                 // Wait for the next subscriber and serve the track.
                 Some(TrackRequest { writer, lease }) = request.next() => {
                     let mut subscriber = self.subscriber.clone();
+                    let subscribe_timeout = self.subscribe_timeout;
 
                     // Spawn a new task to handle the subscribe
                     tasks.push(async move {
@@ -183,21 +197,32 @@ impl Consumer {
                         // `subscribe()`, so it can be dropped — sending
                         // UNSUBSCRIBE — once downstream interest goes away.
                         //
-                        // The handshake itself is raced against the lease, not just
-                        // the established subscription. `subscribe_open` waits for
-                        // SUBSCRIBE_OK, which an upstream is under no obligation to
-                        // ever send; without this arm a never-acked subscribe would
-                        // pin this task, and the `TrackWriter` it carries, until the
-                        // session died — the resource leak this path exists to avoid.
-                        // Dropping the in-flight future drops the `Subscribe`, whose
-                        // `Drop` sends UNSUBSCRIBE, so cancelling mid-handshake is
-                        // still clean. `remote.rs` races its handshake against
-                        // connection cancellation for the same reason.
+                        // The handshake is bounded two ways, because `subscribe_open`
+                        // waits for SUBSCRIBE_OK and an upstream is under no
+                        // obligation to ever send it. Left unbounded it would pin this
+                        // task, and the `TrackWriter` it carries, until the session
+                        // died — the resource leak this path exists to avoid.
+                        //
+                        // - `lease.released()` covers "nobody downstream is waiting
+                        //   for this track any more", which is the condition that
+                        //   actually matters and needs no arbitrary constant.
+                        // - `subscribe_timeout` covers the rest: a subscriber that is
+                        //   still waiting cannot wait forever on a peer that never
+                        //   answers.
+                        //
+                        // Either way the in-flight future is dropped, which drops the
+                        // `Subscribe`, whose `Drop` sends UNSUBSCRIBE — so giving up
+                        // mid-handshake leaves nothing dangling upstream.
                         let subscribe = tokio::select! {
-                            result = subscriber.subscribe_open(writer) => match result {
-                                Ok(subscribe) => subscribe,
-                                Err(err) => {
+                            result = tokio::time::timeout(subscribe_timeout, subscriber.subscribe_open(writer)) => match result {
+                                Ok(Ok(subscribe)) => subscribe,
+                                Ok(Err(err)) => {
                                     tracing::warn!(namespace = %info.namespace, track = %track_name, error = %err, "failed forwarding subscribe: {:?}, error: {}", info, err);
+                                    return Ok(());
+                                }
+                                Err(_elapsed) => {
+                                    tracing::warn!(namespace = %info.namespace, track = %track_name, timeout = ?subscribe_timeout, "upstream did not acknowledge SUBSCRIBE in time: {:?}", info);
+                                    metrics::counter!("moq_relay_subscribe_timeouts_total", "source" => "local").increment(1);
                                     return Ok(());
                                 }
                             },

--- a/moq-relay-ietf/src/local.rs
+++ b/moq-relay-ietf/src/local.rs
@@ -134,13 +134,12 @@ pub struct Registration {
 /// Deregister local tracks on drop.
 impl Drop for Registration {
     fn drop(&mut self) {
-        let ns = self.namespace.to_utf8_path();
         let scope = if self.scope_key.is_empty() {
             "<unscoped>"
         } else {
             &self.scope_key
         };
-        tracing::debug!(namespace = %ns, scope = %scope, "deregistering namespace from locals");
+        tracing::debug!(namespace = %self.namespace, scope = %scope, "deregistering namespace from locals");
 
         let mut lookup = self.locals.lookup.lock().unwrap();
         if let Some(bucket) = lookup.get_mut(self.scope_key.as_str()) {

--- a/moq-relay-ietf/src/metrics.rs
+++ b/moq-relay-ietf/src/metrics.rs
@@ -104,6 +104,10 @@ pub fn describe_metrics() {
         "moq_relay_cache_idle_evictions_total",
         "Cached tracks evicted for having no downstream subscribers, releasing their upstream subscription, by source (local, remote)"
     );
+    describe_counter!(
+        "moq_relay_subscribe_timeouts_total",
+        "Upstream subscriptions abandoned because SUBSCRIBE was not acknowledged within the configured timeout, by source (local, remote)"
+    );
 
     // Gauges
     describe_gauge!(

--- a/moq-relay-ietf/src/metrics.rs
+++ b/moq-relay-ietf/src/metrics.rs
@@ -100,6 +100,10 @@ pub fn describe_metrics() {
         "moq_relay_upstream_errors_total",
         "Upstream connection failures by stage (connect, session)"
     );
+    describe_counter!(
+        "moq_relay_cache_idle_evictions_total",
+        "Cached tracks evicted for having no downstream subscribers, releasing their upstream subscription, by source (local, remote)"
+    );
 
     // Gauges
     describe_gauge!(

--- a/moq-relay-ietf/src/producer.rs
+++ b/moq-relay-ietf/src/producer.rs
@@ -110,13 +110,17 @@ impl Producer {
         // Check local tracks first, and serve from local if possible
         if let Some(mut local) = self.locals.retrieve(self.scope.as_deref(), &namespace) {
             // Pass the full requested namespace, not the announced prefix
-            if let Some(track) = local.subscribe(namespace.clone(), &track_name) {
+            if let Some((track, interest)) = local.subscribe(namespace.clone(), &track_name) {
                 let ns = namespace.to_utf8_path();
                 tracing::info!(namespace = %ns, track = %track_name, source = "local", "serving subscribe from local: {:?}", track.info);
                 // Update label to indicate local source, timing recorded on drop
                 timing_guard.set_label("source", "local");
                 // Track active tracks - decrements when serve completes
                 let _track_guard = GaugeGuard::new("moq_relay_active_tracks");
+                // Hold the downstream-interest guard for as long as we are
+                // serving, so the cache entry backing this reader is not evicted
+                // (and its upstream subscription released) underneath us.
+                let _interest = interest;
                 return Ok(subscribed.serve(track).await?);
             }
         }
@@ -128,13 +132,18 @@ impl Producer {
             .await
         {
             Ok(track) => {
-                if let Some(track) = track {
+                if let Some((track, interest)) = track {
                     let ns = namespace.to_utf8_path();
                     tracing::info!(namespace = %ns, track = %track_name, source = "remote", "serving subscribe from remote: {:?}", track.info);
                     // Update label to indicate remote source, timing recorded on drop
                     timing_guard.set_label("source", "remote");
                     // Track active tracks - decrements when serve completes
                     let _track_guard = GaugeGuard::new("moq_relay_active_tracks");
+                    // Hold the downstream-interest guard for as long as we are
+                    // serving, so the cross-relay cache entry backing this reader
+                    // is not evicted (and its peer subscription released) while
+                    // we are still forwarding from it.
+                    let _interest = interest;
                     return Ok(subscribed.serve(track).await?);
                 }
             }

--- a/moq-relay-ietf/src/producer.rs
+++ b/moq-relay-ietf/src/producer.rs
@@ -63,13 +63,12 @@ impl Producer {
                     // Spawn a new task to handle the subscribe
                     tasks.push(async move {
                         let info = subscribed.clone();
-                        let namespace = info.track_namespace.to_utf8_path();
                         let track_name = info.track_name.clone();
-                        tracing::info!(namespace = %namespace, track = %track_name, "serving subscribe: {:?}", info);
+                        tracing::info!(namespace = %info.track_namespace, track = %track_name, "serving subscribe: {:?}", info);
 
                         // Serve the subscribe request
                         if let Err(err) = this.serve_subscribe(subscribed).await {
-                            tracing::warn!(namespace = %namespace, track = %track_name, error = %err, "failed serving subscribe: {:?}, error: {}", info, err);
+                            tracing::warn!(namespace = %info.track_namespace, track = %track_name, error = %err, "failed serving subscribe: {:?}, error: {}", info, err);
                         }
                     }.boxed())
                 },
@@ -80,13 +79,12 @@ impl Producer {
                     // Spawn a new task to handle the track_status request
                     tasks.push(async move {
                         let info = track_status_requested.request_msg.clone();
-                        let namespace = info.track_namespace.to_utf8_path();
                         let track_name = info.track_name.clone();
-                        tracing::info!(namespace = %namespace, track = %track_name, "serving track_status: {:?}", info);
+                        tracing::info!(namespace = %info.track_namespace, track = %track_name, "serving track_status: {:?}", info);
 
                         // Serve the track_status request
                         if let Err(err) = this.serve_track_status(track_status_requested).await {
-                            tracing::warn!(namespace = %namespace, track = %track_name, error = %err, "failed serving track_status: {:?}, error: {}", info, err)
+                            tracing::warn!(namespace = %info.track_namespace, track = %track_name, error = %err, "failed serving track_status: {:?}, error: {}", info, err)
                         }
                     }.boxed())
                 },
@@ -111,8 +109,7 @@ impl Producer {
         if let Some(mut local) = self.locals.retrieve(self.scope.as_deref(), &namespace) {
             // Pass the full requested namespace, not the announced prefix
             if let Some((track, interest)) = local.subscribe(namespace.clone(), &track_name) {
-                let ns = namespace.to_utf8_path();
-                tracing::info!(namespace = %ns, track = %track_name, source = "local", "serving subscribe from local: {:?}", track.info);
+                tracing::info!(namespace = %namespace, track = %track_name, source = "local", "serving subscribe from local: {:?}", track.info);
                 // Update label to indicate local source, timing recorded on drop
                 timing_guard.set_label("source", "local");
                 // Track active tracks - decrements when serve completes
@@ -133,8 +130,7 @@ impl Producer {
         {
             Ok(track) => {
                 if let Some((track, interest)) = track {
-                    let ns = namespace.to_utf8_path();
-                    tracing::info!(namespace = %ns, track = %track_name, source = "remote", "serving subscribe from remote: {:?}", track.info);
+                    tracing::info!(namespace = %namespace, track = %track_name, source = "remote", "serving subscribe from remote: {:?}", track.info);
                     // Update label to indicate remote source, timing recorded on drop
                     timing_guard.set_label("source", "remote");
                     // Track active tracks - decrements when serve completes
@@ -150,8 +146,7 @@ impl Producer {
             Err(e) => {
                 // Route error = infrastructure failure (couldn't reach coordinator/upstream)
                 // This is different from "not found" - we don't know if the track exists
-                let ns = namespace.to_utf8_path();
-                tracing::error!(namespace = %ns, track = %track_name, error = %e, "failed to route to remote: {}", e);
+                tracing::error!(namespace = %namespace, track = %track_name, error = %e, "failed to route to remote: {}", e);
                 timing_guard.set_label("source", "route_error");
                 metrics::counter!("moq_relay_subscribe_route_errors_total").increment(1);
 
@@ -192,10 +187,7 @@ impl Producer {
                 &track_status_requested.request_msg.track_namespace,
                 &track_status_requested.request_msg.track_name,
             ) {
-                let namespace = track_status_requested
-                    .request_msg
-                    .track_namespace
-                    .to_utf8_path();
+                let namespace = &track_status_requested.request_msg.track_namespace;
                 let track_name = &track_status_requested.request_msg.track_name;
                 tracing::info!(namespace = %namespace, track = %track_name, source = "local", "serving track_status from local: {:?}", track.info);
                 return Ok(track_status_requested.respond_ok(&track)?);

--- a/moq-relay-ietf/src/relay.rs
+++ b/moq-relay-ietf/src/relay.rs
@@ -56,6 +56,58 @@ pub struct RelayConfig {
     pub coordinator: Arc<dyn Coordinator>,
 }
 
+/// How long to wait for an upstream to acknowledge a SUBSCRIBE before giving up.
+///
+/// MoQ does not bound SUBSCRIBE_OK, so this is a policy choice rather than a
+/// protocol constant. A downstream subscriber is blocked for the whole window,
+/// and upstream is normally a nearby relay or origin for which a control round
+/// trip is well under a second, so ten seconds is generous without leaving a
+/// subscriber waiting long past the point it has given up.
+pub const DEFAULT_SUBSCRIBE_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Tuning knobs for a [`Relay`].
+///
+/// Deliberately separate from [`RelayConfig`]: embedders construct `RelayConfig`
+/// as an exhaustive struct literal, so adding a field there is a breaking change.
+/// This struct is `#[non_exhaustive]` with a `Default` and builder methods, so
+/// future knobs can be added without breaking anyone.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub struct RelayTuning {
+    /// How long a cached track with no downstream subscribers is retained before
+    /// its upstream subscription is released. Zero disables eviction, holding
+    /// upstream subscriptions for the lifetime of the upstream session.
+    pub cache_idle_timeout: Duration,
+
+    /// How long to wait for an upstream to acknowledge a SUBSCRIBE before giving
+    /// up. Must be non-zero; [`Relay::new_with_tuning`] rejects zero.
+    pub subscribe_timeout: Duration,
+}
+
+impl Default for RelayTuning {
+    fn default() -> Self {
+        Self {
+            cache_idle_timeout: DEFAULT_CACHE_IDLE_TIMEOUT,
+            subscribe_timeout: DEFAULT_SUBSCRIBE_TIMEOUT,
+        }
+    }
+}
+
+impl RelayTuning {
+    /// Set how long an unwatched cached track is retained before its upstream
+    /// subscription is released. Zero disables eviction.
+    pub fn with_cache_idle_timeout(mut self, cache_idle_timeout: Duration) -> Self {
+        self.cache_idle_timeout = cache_idle_timeout;
+        self
+    }
+
+    /// Set how long to wait for an upstream to acknowledge a SUBSCRIBE.
+    pub fn with_subscribe_timeout(mut self, subscribe_timeout: Duration) -> Self {
+        self.subscribe_timeout = subscribe_timeout;
+        self
+    }
+}
+
 /// MoQ Relay server.
 pub struct Relay {
     quic_endpoints: Vec<Endpoint>,
@@ -64,25 +116,29 @@ pub struct Relay {
     locals: Locals,
     remotes: RemoteManager,
     coordinator: Arc<dyn Coordinator>,
-    cache_idle_timeout: Duration,
+    tuning: RelayTuning,
 }
 
 impl Relay {
     pub fn new(config: RelayConfig) -> anyhow::Result<Self> {
-        Self::new_with_cache_idle_timeout(config, DEFAULT_CACHE_IDLE_TIMEOUT)
+        Self::new_with_tuning(config, RelayTuning::default())
     }
 
-    /// Create a relay that releases upstream subscriptions for cached tracks that
-    /// have had no downstream subscribers for `cache_idle_timeout`.
+    /// Create a relay with non-default [`RelayTuning`].
     ///
-    /// The relay caches tracks it does not publish itself so multiple downstream
-    /// subscribers can share one upstream subscription. Without a timeout that
-    /// subscription outlives the last subscriber and the relay keeps receiving a
-    /// track nobody is watching. A zero timeout restores that behaviour.
-    pub fn new_with_cache_idle_timeout(
-        config: RelayConfig,
-        cache_idle_timeout: Duration,
-    ) -> anyhow::Result<Self> {
+    /// Tuning is passed here rather than as `RelayConfig` fields so that
+    /// embedders constructing `RelayConfig` as an exhaustive struct literal are
+    /// unaffected by knobs being added.
+    ///
+    /// Returns an error if `tuning.subscribe_timeout` is zero. Waiting forever
+    /// for an upstream to acknowledge a SUBSCRIBE is never the intent, and an
+    /// unbounded wait on a peer is what this timeout exists to prevent, so
+    /// there is deliberately no "disabled" setting.
+    pub fn new_with_tuning(config: RelayConfig, tuning: RelayTuning) -> anyhow::Result<Self> {
+        if tuning.subscribe_timeout.is_zero() {
+            anyhow::bail!("subscribe_timeout must be non-zero");
+        }
+
         if config.bind.is_some() && !config.endpoints.is_empty() {
             anyhow::bail!("cannot specify both bind and endpoints");
         }
@@ -123,7 +179,8 @@ impl Relay {
 
         // Create remote manager - uses coordinator for namespace lookups
         let remotes = RemoteManager::new(config.coordinator.clone(), remote_clients)
-            .with_cache_idle_timeout(cache_idle_timeout);
+            .with_cache_idle_timeout(tuning.cache_idle_timeout)
+            .with_subscribe_timeout(tuning.subscribe_timeout);
 
         Ok(Self {
             quic_endpoints: endpoints,
@@ -132,7 +189,7 @@ impl Relay {
             locals,
             remotes,
             coordinator: config.coordinator,
-            cache_idle_timeout,
+            tuning,
         })
     }
 
@@ -145,7 +202,7 @@ impl Relay {
             locals,
             remotes,
             coordinator,
-            cache_idle_timeout,
+            tuning,
         } = self;
 
         let run_result = async {
@@ -203,7 +260,8 @@ impl Relay {
                             None,
                             forward_scope,
                         )
-                        .with_cache_idle_timeout(cache_idle_timeout),
+                        .with_cache_idle_timeout(tuning.cache_idle_timeout)
+                        .with_subscribe_timeout(tuning.subscribe_timeout),
                     ),
                     // Forward connections are always full read-write relay peers,
                     // so no reject loops needed.
@@ -344,7 +402,7 @@ impl Relay {
                             };
 
                             let (consumer, reject_publishes) = if can_publish {
-                                (subscriber.map(|subscriber| Consumer::new(subscriber, locals, coordinator, forward, scope_id).with_cache_idle_timeout(cache_idle_timeout)), None)
+                                (subscriber.map(|subscriber| Consumer::new(subscriber, locals, coordinator, forward, scope_id).with_cache_idle_timeout(tuning.cache_idle_timeout).with_subscribe_timeout(tuning.subscribe_timeout)), None)
                             } else {
                                 (None, subscriber)
                             };
@@ -386,5 +444,137 @@ impl Relay {
 
         remotes.shutdown().await;
         run_result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use async_trait::async_trait;
+    use moq_transport::coding::TrackNamespace;
+
+    use crate::{CoordinatorError, CoordinatorResult, NamespaceOrigin, NamespaceRegistration};
+
+    /// Enough of a coordinator to construct a `RelayConfig`.
+    struct StubCoordinator;
+
+    #[async_trait]
+    impl Coordinator for StubCoordinator {
+        async fn register_namespace(
+            &self,
+            _scope: Option<&str>,
+            _namespace: &TrackNamespace,
+        ) -> CoordinatorResult<NamespaceRegistration> {
+            Ok(NamespaceRegistration::new(()))
+        }
+
+        async fn unregister_namespace(
+            &self,
+            _scope: Option<&str>,
+            _namespace: &TrackNamespace,
+        ) -> CoordinatorResult<()> {
+            Ok(())
+        }
+
+        async fn lookup(
+            &self,
+            _scope: Option<&str>,
+            _namespace: &TrackNamespace,
+        ) -> CoordinatorResult<(NamespaceOrigin, Option<quic::Client>)> {
+            Err(CoordinatorError::NamespaceNotFound)
+        }
+    }
+
+    /// No `bind` and no `endpoints`, so construction always fails — the point is
+    /// *which* error it fails with.
+    fn minimal_config() -> RelayConfig {
+        RelayConfig {
+            bind: None,
+            endpoints: vec![],
+            tls: moq_native_ietf::tls::Args::default()
+                .load()
+                .expect("default TLS config"),
+            qlog_dir: None,
+            mlog_dir: None,
+            announce: None,
+            node: None,
+            coordinator: Arc::new(StubCoordinator),
+        }
+    }
+
+    /// `Relay` is not `Debug`, so `expect_err` is unavailable.
+    fn construction_error(result: anyhow::Result<Relay>) -> String {
+        match result {
+            Ok(_) => panic!("expected relay construction to fail"),
+            Err(err) => err.to_string(),
+        }
+    }
+
+    #[test]
+    fn default_tuning_matches_the_documented_defaults() {
+        let tuning = RelayTuning::default();
+        assert_eq!(tuning.cache_idle_timeout, DEFAULT_CACHE_IDLE_TIMEOUT);
+        assert_eq!(tuning.subscribe_timeout, DEFAULT_SUBSCRIBE_TIMEOUT);
+        assert_eq!(tuning.subscribe_timeout, Duration::from_secs(10));
+    }
+
+    /// Both knobs are `Duration`, so a builder assigning to the wrong field would
+    /// compile and silently mis-tune the relay.
+    #[test]
+    fn each_builder_sets_only_its_own_knob() {
+        let base = RelayTuning::default();
+
+        let idle = base.with_cache_idle_timeout(Duration::from_secs(7));
+        assert_eq!(idle.cache_idle_timeout, Duration::from_secs(7));
+        assert_eq!(idle.subscribe_timeout, base.subscribe_timeout);
+
+        let subscribe = base.with_subscribe_timeout(Duration::from_secs(3));
+        assert_eq!(subscribe.subscribe_timeout, Duration::from_secs(3));
+        assert_eq!(subscribe.cache_idle_timeout, base.cache_idle_timeout);
+    }
+
+    /// There is deliberately no "disabled" setting: an unbounded wait on a peer is
+    /// exactly what the timeout exists to prevent.
+    #[test]
+    fn a_zero_subscribe_timeout_is_rejected() {
+        let tuning = RelayTuning::default().with_subscribe_timeout(Duration::ZERO);
+
+        let err = construction_error(Relay::new_with_tuning(minimal_config(), tuning));
+
+        assert!(
+            err.contains("subscribe_timeout"),
+            "expected a subscribe_timeout error, got: {err}"
+        );
+    }
+
+    /// The counterpart to the above: with a valid timeout, construction gets far
+    /// enough to fail on the missing endpoints instead. This pins the rejection to
+    /// the timeout rather than to any config being invalid.
+    #[test]
+    fn a_nonzero_subscribe_timeout_passes_validation() {
+        let err = construction_error(Relay::new_with_tuning(
+            minimal_config(),
+            RelayTuning::default(),
+        ));
+
+        assert!(
+            err.contains("no endpoints"),
+            "expected to fail past timeout validation, got: {err}"
+        );
+    }
+
+    /// A zero cache idle timeout stays legal: it means "never evict", which is the
+    /// pre-existing behaviour and a reasonable thing to ask for.
+    #[test]
+    fn a_zero_cache_idle_timeout_is_still_allowed() {
+        let tuning = RelayTuning::default().with_cache_idle_timeout(Duration::ZERO);
+
+        let err = construction_error(Relay::new_with_tuning(minimal_config(), tuning));
+
+        assert!(
+            err.contains("no endpoints"),
+            "a zero cache idle timeout must not be rejected, got: {err}"
+        );
     }
 }

--- a/moq-relay-ietf/src/relay.rs
+++ b/moq-relay-ietf/src/relay.rs
@@ -1,12 +1,13 @@
 // SPDX-FileCopyrightText: 2024-2026 Cloudflare Inc., Luke Curley, Mike English and contributors
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use std::{future::Future, net, path::PathBuf, pin::Pin, sync::Arc};
+use std::{future::Future, net, path::PathBuf, pin::Pin, sync::Arc, time::Duration};
 
 use anyhow::Context;
 
 use futures::{stream::FuturesUnordered, FutureExt, StreamExt};
 use moq_native_ietf::quic::{self, Endpoint};
+use moq_transport::serve::DEFAULT_CACHE_IDLE_TIMEOUT;
 use url::Url;
 
 use crate::{metrics::GaugeGuard, Consumer, Coordinator, Locals, Producer, RemoteManager, Session};
@@ -63,10 +64,25 @@ pub struct Relay {
     locals: Locals,
     remotes: RemoteManager,
     coordinator: Arc<dyn Coordinator>,
+    cache_idle_timeout: Duration,
 }
 
 impl Relay {
     pub fn new(config: RelayConfig) -> anyhow::Result<Self> {
+        Self::new_with_cache_idle_timeout(config, DEFAULT_CACHE_IDLE_TIMEOUT)
+    }
+
+    /// Create a relay that releases upstream subscriptions for cached tracks that
+    /// have had no downstream subscribers for `cache_idle_timeout`.
+    ///
+    /// The relay caches tracks it does not publish itself so multiple downstream
+    /// subscribers can share one upstream subscription. Without a timeout that
+    /// subscription outlives the last subscriber and the relay keeps receiving a
+    /// track nobody is watching. A zero timeout restores that behaviour.
+    pub fn new_with_cache_idle_timeout(
+        config: RelayConfig,
+        cache_idle_timeout: Duration,
+    ) -> anyhow::Result<Self> {
         if config.bind.is_some() && !config.endpoints.is_empty() {
             anyhow::bail!("cannot specify both bind and endpoints");
         }
@@ -106,7 +122,8 @@ impl Relay {
             .collect::<Vec<_>>();
 
         // Create remote manager - uses coordinator for namespace lookups
-        let remotes = RemoteManager::new(config.coordinator.clone(), remote_clients);
+        let remotes = RemoteManager::new(config.coordinator.clone(), remote_clients)
+            .with_cache_idle_timeout(cache_idle_timeout);
 
         Ok(Self {
             quic_endpoints: endpoints,
@@ -115,6 +132,7 @@ impl Relay {
             locals,
             remotes,
             coordinator: config.coordinator,
+            cache_idle_timeout,
         })
     }
 
@@ -127,6 +145,7 @@ impl Relay {
             locals,
             remotes,
             coordinator,
+            cache_idle_timeout,
         } = self;
 
         let run_result = async {
@@ -176,13 +195,16 @@ impl Relay {
                         remote_manager.clone(),
                         forward_scope.clone(),
                     )),
-                    consumer: Some(Consumer::new(
-                        subscriber,
-                        locals.clone(),
-                        forward_coordinator,
-                        None,
-                        forward_scope,
-                    )),
+                    consumer: Some(
+                        Consumer::new(
+                            subscriber,
+                            locals.clone(),
+                            forward_coordinator,
+                            None,
+                            forward_scope,
+                        )
+                        .with_cache_idle_timeout(cache_idle_timeout),
+                    ),
                     // Forward connections are always full read-write relay peers,
                     // so no reject loops needed.
                     reject_publishes: None,
@@ -322,7 +344,7 @@ impl Relay {
                             };
 
                             let (consumer, reject_publishes) = if can_publish {
-                                (subscriber.map(|subscriber| Consumer::new(subscriber, locals, coordinator, forward, scope_id)), None)
+                                (subscriber.map(|subscriber| Consumer::new(subscriber, locals, coordinator, forward, scope_id).with_cache_idle_timeout(cache_idle_timeout)), None)
                             } else {
                                 (None, subscriber)
                             };

--- a/moq-relay-ietf/src/remote.rs
+++ b/moq-relay-ietf/src/remote.rs
@@ -5,10 +5,13 @@ use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Weak};
+use std::time::Duration;
 
 use moq_native_ietf::quic;
 use moq_transport::coding::TrackNamespace;
-use moq_transport::serve::{Track, TrackReader};
+use moq_transport::serve::{
+    Track, TrackInterest, TrackInterestGuard, TrackReader, DEFAULT_CACHE_IDLE_TIMEOUT,
+};
 use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
 use url::Url;
@@ -22,7 +25,17 @@ use crate::{metrics::GaugeGuard, Coordinator, CoordinatorError};
 type RemoteCacheKey = (Url, Option<SocketAddr>);
 type RemoteSlot = Arc<Mutex<Option<Remote>>>;
 type TrackCacheKey = (TrackNamespace, String);
-type TrackSlot = Arc<Mutex<Option<TrackReader>>>;
+type TrackSlot = Arc<Mutex<Option<CachedTrack>>>;
+
+/// A cached cross-relay track reader plus the downstream interest in it.
+#[derive(Clone)]
+struct CachedTrack {
+    reader: TrackReader,
+
+    /// Interest in this cached reader. When it goes idle for the configured
+    /// grace period the upstream subscription to the peer relay is released.
+    interest: TrackInterest,
+}
 
 /// Manages connections to remote relays.
 ///
@@ -34,6 +47,10 @@ pub struct RemoteManager {
     coordinator: Arc<dyn Coordinator>,
     clients: Vec<quic::Client>,
     remotes: Arc<Mutex<HashMap<RemoteCacheKey, RemoteSlot>>>,
+
+    /// How long an unwatched cross-relay cache entry is retained before its
+    /// upstream subscription is released. Zero disables eviction.
+    cache_idle_timeout: Duration,
 }
 
 impl RemoteManager {
@@ -43,7 +60,18 @@ impl RemoteManager {
             coordinator,
             clients,
             remotes: Arc::new(Mutex::new(HashMap::new())),
+            cache_idle_timeout: DEFAULT_CACHE_IDLE_TIMEOUT,
         }
+    }
+
+    /// Override how long an unwatched cross-relay cache entry is retained before
+    /// its upstream subscription is released.
+    ///
+    /// A zero timeout disables idle eviction, holding subscriptions to peer
+    /// relays for as long as the peer session lives.
+    pub fn with_cache_idle_timeout(mut self, cache_idle_timeout: Duration) -> Self {
+        self.cache_idle_timeout = cache_idle_timeout;
+        self
     }
 
     /// Subscribe to a track from a remote relay.
@@ -57,7 +85,7 @@ impl RemoteManager {
         scope: Option<&str>,
         namespace: &TrackNamespace,
         track_name: &str,
-    ) -> anyhow::Result<Option<TrackReader>> {
+    ) -> anyhow::Result<Option<(TrackReader, TrackInterestGuard)>> {
         let (origin, client) = match self.coordinator.lookup(scope, namespace).await {
             Ok(result) => result,
             Err(CoordinatorError::NamespaceNotFound) => return Ok(None),
@@ -144,6 +172,7 @@ impl RemoteManager {
                 cache_key.0.clone(),
                 cache_key.1,
                 client,
+                self.cache_idle_timeout,
                 Arc::downgrade(&self.remotes),
                 cache_key.clone(),
                 Arc::downgrade(&slot),
@@ -218,6 +247,52 @@ async fn remove_empty_remote_slot(
     }
 }
 
+/// Clear a cached cross-relay track once it has been unwatched for `timeout`.
+///
+/// Resolving means the caller should drop its subscription to the peer relay. The
+/// slot is cleared *before* returning, while the lock is still held, so a
+/// subscriber arriving afterwards misses the cache and re-subscribes instead of
+/// attaching to a reader whose upstream subscription is being torn down.
+///
+/// The idle re-check happens under the slot lock, which is also where interest
+/// guards are created, so a subscriber racing eviction is either counted here
+/// (and we keep waiting) or misses the slot entirely.
+///
+/// Never resolves when `timeout` is zero, preserving the previous behaviour of
+/// holding the subscription for as long as the peer session lives.
+async fn evict_when_idle(slot: &TrackSlot, interest: &TrackInterest, timeout: Duration) {
+    if timeout.is_zero() {
+        // Idle eviction disabled.
+        std::future::pending::<()>().await;
+    }
+
+    loop {
+        interest.idle_for(timeout).await;
+
+        let mut cached = slot.lock().await;
+
+        // A different generation now owns the slot; it has its own idle timer, so
+        // this subscription is no longer serving anything and must not clear it.
+        let ours = matches!(
+            cached.as_ref(),
+            Some(current) if current.interest.same_generation(interest)
+        );
+
+        if !ours {
+            return;
+        }
+
+        if interest.is_idle() {
+            cached.take();
+            return;
+        }
+
+        // Interest returned between the timer firing and taking the lock, so keep
+        // serving and start waiting again.
+        drop(cached);
+    }
+}
+
 async fn remove_empty_track_slot(
     tracks: &Arc<Mutex<HashMap<TrackCacheKey, TrackSlot>>>,
     key: &TrackCacheKey,
@@ -245,6 +320,8 @@ struct Remote {
     connected: Arc<AtomicBool>,
     /// Cancellation token for the session task.
     cancel: CancellationToken,
+    /// Idle timeout applied to this peer's cached track readers.
+    cache_idle_timeout: Duration,
 }
 
 impl Remote {
@@ -253,6 +330,7 @@ impl Remote {
         url: Url,
         addr: Option<SocketAddr>,
         client: &quic::Client,
+        cache_idle_timeout: Duration,
         remotes: Weak<Mutex<HashMap<RemoteCacheKey, RemoteSlot>>>,
         cache_key: RemoteCacheKey,
         cache_slot: Weak<Mutex<Option<Remote>>>,
@@ -327,6 +405,7 @@ impl Remote {
             tracks: Arc::new(Mutex::new(HashMap::new())),
             connected,
             cancel,
+            cache_idle_timeout,
         })
     }
 
@@ -351,7 +430,7 @@ impl Remote {
         &self,
         namespace: TrackNamespace,
         track_name: String,
-    ) -> anyhow::Result<Option<TrackReader>> {
+    ) -> anyhow::Result<Option<(TrackReader, TrackInterestGuard)>> {
         let key = (namespace.clone(), track_name.clone());
 
         loop {
@@ -378,9 +457,11 @@ impl Remote {
                 continue;
             }
 
-            if let Some(reader) = cached.as_ref() {
-                if !reader.is_closed() {
-                    return Ok(Some(reader.clone()));
+            if let Some(entry) = cached.as_ref() {
+                if !entry.reader.is_closed() {
+                    // Register interest while still holding the slot lock, which
+                    // is the same lock idle eviction re-checks under.
+                    return Ok(Some((entry.reader.clone(), entry.interest.guard())));
                 }
 
                 tracing::debug!(remote_url = %self.url, namespace = %key.0, track = %key.1, "removing closed remote track from cache");
@@ -420,12 +501,22 @@ impl Remote {
                 anyhow::bail!("remote connection to {} is closed", self.url);
             }
 
-            *cached = Some(reader.clone());
+            let interest = TrackInterest::new();
+
+            // Take this caller's guard before the entry becomes visible, so the
+            // cleanup task cannot see a brand new entry as idle.
+            let guard = interest.guard();
+
+            *cached = Some(CachedTrack {
+                reader: reader.clone(),
+                interest: interest.clone(),
+            });
             drop(cached);
 
             let cleanup_key = key.clone();
             let cleanup_reader = reader.clone();
             let cleanup_slot = slot.clone();
+            let idle_timeout = self.cache_idle_timeout;
             tokio::spawn(async move {
                 tokio::select! {
                     result = subscribe.closed() => {
@@ -441,11 +532,23 @@ impl Remote {
                     _ = cancel.cancelled() => {
                         tracing::debug!(remote_url = %url, namespace = %cleanup_key.0, track = %cleanup_key.1, "remote track subscription cancelled");
                     }
+                    // Nobody downstream is watching this cross-relay track any
+                    // more, so stop pulling it from the peer relay. The slot is
+                    // already cleared by the time this resolves, so a later
+                    // subscriber re-subscribes rather than attaching to a reader
+                    // that is about to go silent.
+                    _ = evict_when_idle(&cleanup_slot, &interest, idle_timeout) => {
+                        tracing::info!(remote_url = %url, namespace = %cleanup_key.0, track = %cleanup_key.1, "releasing idle remote track subscription");
+                        metrics::counter!("moq_relay_cache_idle_evictions_total", "source" => "remote").increment(1);
+                    }
                 }
+
+                // Sends UNSUBSCRIBE to the peer relay if it is still open.
+                drop(subscribe);
 
                 if let Some(tracks) = tracks.upgrade() {
                     let mut cached = cleanup_slot.lock().await;
-                    if matches!(cached.as_ref(), Some(current) if Arc::ptr_eq(&current.info, &cleanup_reader.info))
+                    if matches!(cached.as_ref(), Some(current) if Arc::ptr_eq(&current.reader.info, &cleanup_reader.info))
                     {
                         cached.take();
                     }
@@ -455,7 +558,7 @@ impl Remote {
                 }
             });
 
-            return Ok(Some(reader));
+            return Ok(Some((reader, guard)));
         }
     }
 }
@@ -466,5 +569,99 @@ impl std::fmt::Debug for Remote {
             .field("url", &self.url.to_string())
             .field("connected", &self.is_connected())
             .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const GRACE: Duration = Duration::from_secs(30);
+
+    fn cached_track() -> (TrackSlot, TrackInterest) {
+        let (_writer, reader) = Track::new(
+            TrackNamespace::from_utf8_path("example.com"),
+            "video".to_string(),
+        )
+        .produce();
+        let interest = TrackInterest::new();
+        let slot: TrackSlot = Arc::new(Mutex::new(Some(CachedTrack {
+            reader,
+            interest: interest.clone(),
+        })));
+        (slot, interest)
+    }
+
+    /// The slot must be cleared before the caller drops its peer subscription, so
+    /// a later subscriber re-subscribes instead of attaching to a dying reader.
+    #[tokio::test(start_paused = true)]
+    async fn evict_when_idle_clears_the_slot_once_unwatched() {
+        let (slot, interest) = cached_track();
+
+        evict_when_idle(&slot, &interest, GRACE).await;
+
+        assert!(
+            slot.lock().await.is_none(),
+            "slot must be cleared before the subscription is released"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn evict_when_idle_waits_for_the_last_subscriber() {
+        let (slot, interest) = cached_track();
+        let guard = interest.guard();
+
+        let evict = evict_when_idle(&slot, &interest, GRACE);
+        tokio::pin!(evict);
+
+        tokio::select! {
+            _ = &mut evict => panic!("evicted a track that still has a subscriber"),
+            _ = tokio::time::sleep(GRACE * 4) => {}
+        }
+        assert!(slot.lock().await.is_some());
+
+        drop(guard);
+        evict.await;
+        assert!(slot.lock().await.is_none());
+    }
+
+    /// A replacement generation owns the slot now, so this subscription is stale:
+    /// it should be released without disturbing the new entry.
+    #[tokio::test(start_paused = true)]
+    async fn evict_when_idle_leaves_a_replacement_generation_alone() {
+        let (slot, interest) = cached_track();
+        let (_replacement_slot, replacement_interest) = cached_track();
+
+        {
+            let mut cached = slot.lock().await;
+            let reader = cached.as_ref().unwrap().reader.clone();
+            *cached = Some(CachedTrack {
+                reader,
+                interest: replacement_interest.clone(),
+            });
+        }
+
+        // Resolves (so the stale subscription is dropped) but must not clear the
+        // slot the replacement is using.
+        evict_when_idle(&slot, &interest, GRACE).await;
+
+        assert!(
+            slot.lock().await.is_some(),
+            "a stale lease must not evict the replacement entry"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn evict_when_idle_is_disabled_by_a_zero_timeout() {
+        let (slot, interest) = cached_track();
+
+        tokio::select! {
+            _ = evict_when_idle(&slot, &interest, Duration::ZERO) => {
+                panic!("a zero timeout must disable eviction")
+            }
+            _ = tokio::time::sleep(Duration::from_secs(3600)) => {}
+        }
+
+        assert!(slot.lock().await.is_some());
     }
 }

--- a/moq-relay-ietf/src/remote.rs
+++ b/moq-relay-ietf/src/remote.rs
@@ -9,14 +9,12 @@ use std::time::Duration;
 
 use moq_native_ietf::quic;
 use moq_transport::coding::TrackNamespace;
-use moq_transport::serve::{
-    Track, TrackInterest, TrackInterestGuard, TrackReader, DEFAULT_CACHE_IDLE_TIMEOUT,
-};
+use moq_transport::serve::{Track, TrackInterest, TrackInterestGuard, TrackReader};
 use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
 use url::Url;
 
-use crate::{metrics::GaugeGuard, Coordinator, CoordinatorError};
+use crate::{metrics::GaugeGuard, Coordinator, CoordinatorError, RelayTuning};
 
 /// Cache key for upstream relay-to-relay connections.
 ///
@@ -48,9 +46,8 @@ pub struct RemoteManager {
     clients: Vec<quic::Client>,
     remotes: Arc<Mutex<HashMap<RemoteCacheKey, RemoteSlot>>>,
 
-    /// How long an unwatched cross-relay cache entry is retained before its
-    /// upstream subscription is released. Zero disables eviction.
-    cache_idle_timeout: Duration,
+    /// Timeouts applied to this relay's upstream track subscriptions.
+    tuning: RelayTuning,
 }
 
 impl RemoteManager {
@@ -60,7 +57,7 @@ impl RemoteManager {
             coordinator,
             clients,
             remotes: Arc::new(Mutex::new(HashMap::new())),
-            cache_idle_timeout: DEFAULT_CACHE_IDLE_TIMEOUT,
+            tuning: RelayTuning::default(),
         }
     }
 
@@ -70,7 +67,13 @@ impl RemoteManager {
     /// A zero timeout disables idle eviction, holding subscriptions to peer
     /// relays for as long as the peer session lives.
     pub fn with_cache_idle_timeout(mut self, cache_idle_timeout: Duration) -> Self {
-        self.cache_idle_timeout = cache_idle_timeout;
+        self.tuning.cache_idle_timeout = cache_idle_timeout;
+        self
+    }
+
+    /// Override how long to wait for a peer relay to acknowledge a SUBSCRIBE.
+    pub fn with_subscribe_timeout(mut self, subscribe_timeout: Duration) -> Self {
+        self.tuning.subscribe_timeout = subscribe_timeout;
         self
     }
 
@@ -172,7 +175,7 @@ impl RemoteManager {
                 cache_key.0.clone(),
                 cache_key.1,
                 client,
-                self.cache_idle_timeout,
+                self.tuning,
                 Arc::downgrade(&self.remotes),
                 cache_key.clone(),
                 Arc::downgrade(&slot),
@@ -320,8 +323,8 @@ struct Remote {
     connected: Arc<AtomicBool>,
     /// Cancellation token for the session task.
     cancel: CancellationToken,
-    /// Idle timeout applied to this peer's cached track readers.
-    cache_idle_timeout: Duration,
+    /// Timeouts applied to this peer's track subscriptions.
+    tuning: RelayTuning,
 }
 
 impl Remote {
@@ -330,7 +333,7 @@ impl Remote {
         url: Url,
         addr: Option<SocketAddr>,
         client: &quic::Client,
-        cache_idle_timeout: Duration,
+        tuning: RelayTuning,
         remotes: Weak<Mutex<HashMap<RemoteCacheKey, RemoteSlot>>>,
         cache_key: RemoteCacheKey,
         cache_slot: Weak<Mutex<Option<Remote>>>,
@@ -405,7 +408,7 @@ impl Remote {
             tracks: Arc::new(Mutex::new(HashMap::new())),
             connected,
             cancel,
-            cache_idle_timeout,
+            tuning,
         })
     }
 
@@ -477,8 +480,15 @@ impl Remote {
             tracing::info!(remote_url = %url, namespace = %key.0, track = %key.1, "subscribing to remote track");
 
             let (writer, reader) = Track::new(namespace.clone(), track_name.clone()).produce();
+
+            // `subscribe_open` waits for SUBSCRIBE_OK, which a peer relay is under
+            // no obligation to ever send, so the handshake is bounded three ways:
+            // the peer connection closing, a wall-clock timeout, and — once the
+            // entry exists — idle eviction. Dropping the in-flight future drops the
+            // `Subscribe`, whose `Drop` sends UNSUBSCRIBE, so giving up here leaves
+            // nothing dangling on the peer.
             let subscribe_result = tokio::select! {
-                result = subscriber.subscribe_open(writer) => result,
+                result = tokio::time::timeout(self.tuning.subscribe_timeout, subscriber.subscribe_open(writer)) => result,
                 _ = cancel.cancelled() => {
                     drop(cached);
                     remove_empty_track_slot(&self.tracks, &key, &slot).await;
@@ -487,11 +497,23 @@ impl Remote {
             };
 
             let subscribe = match subscribe_result {
-                Ok(subscribe) => subscribe,
-                Err(err) => {
+                Ok(Ok(subscribe)) => subscribe,
+                Ok(Err(err)) => {
                     drop(cached);
                     remove_empty_track_slot(&self.tracks, &key, &slot).await;
                     return Err(err.into());
+                }
+                Err(_elapsed) => {
+                    tracing::warn!(remote_url = %url, namespace = %key.0, track = %key.1, timeout = ?self.tuning.subscribe_timeout, "remote relay did not acknowledge SUBSCRIBE in time");
+                    metrics::counter!("moq_relay_subscribe_timeouts_total", "source" => "remote")
+                        .increment(1);
+                    drop(cached);
+                    remove_empty_track_slot(&self.tracks, &key, &slot).await;
+                    anyhow::bail!(
+                        "remote relay {} did not acknowledge SUBSCRIBE within {:?}",
+                        self.url,
+                        self.tuning.subscribe_timeout
+                    );
                 }
             };
 
@@ -516,7 +538,7 @@ impl Remote {
             let cleanup_key = key.clone();
             let cleanup_reader = reader.clone();
             let cleanup_slot = slot.clone();
-            let idle_timeout = self.cache_idle_timeout;
+            let idle_timeout = self.tuning.cache_idle_timeout;
             tokio::spawn(async move {
                 tokio::select! {
                     result = subscribe.closed() => {

--- a/moq-sub/src/media.rs
+++ b/moq-sub/src/media.rs
@@ -111,11 +111,14 @@ impl<O: AsyncWrite + Send + Unpin + 'static> Media<O> {
                     });
                 });
 
-                tracks.push(
-                    self.broadcast
-                        .subscribe(self.broadcast.namespace.clone(), &name)
-                        .context("no track")?,
-                );
+                // The track was just created locally by `tracks_writer.create`,
+                // so this is a plain cache hit with no pull-through interest to
+                // register (hence no guard to hold).
+                let (track_reader, _interest) = self
+                    .broadcast
+                    .subscribe(self.broadcast.namespace.clone(), &name)
+                    .context("no track")?;
+                tracks.push(track_reader);
             }
         }
 
@@ -151,7 +154,7 @@ impl<O: AsyncWrite + Send + Unpin + 'static> Media<O> {
             });
         });
 
-        let track = self
+        let (track, _interest) = self
             .broadcast
             .subscribe(self.broadcast.namespace.clone(), track_name)
             .context(format!("no {alias} track"))?;

--- a/moq-transport/Cargo.toml
+++ b/moq-transport/Cargo.toml
@@ -21,7 +21,8 @@ categories = ["multimedia", "network-programming", "web-programming"]
 [dependencies]
 bytes = "1"
 thiserror = "1"
-tokio = { version = "1", features = ["macros", "io-util", "sync"] }
+# `time` backs the idle-interest grace period in `serve::TrackInterest`.
+tokio = { version = "1", features = ["macros", "io-util", "sync", "time"] }
 tracing = { workspace = true }
 uuid = { version = "1", features = ["v4"] }
 
@@ -32,3 +33,8 @@ futures = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_with = "3"
+
+[dev-dependencies]
+# test-util provides the paused-clock runtime used to test idle timeouts without
+# sleeping for real; rt is needed for #[tokio::test].
+tokio = { version = "1", features = ["macros", "io-util", "sync", "time", "rt", "test-util"] }

--- a/moq-transport/src/coding/track_namespace.rs
+++ b/moq-transport/src/coding/track_namespace.rs
@@ -17,6 +17,21 @@ pub enum TrackNamespaceError {
     FieldTooLarge(usize, usize),
 }
 
+/// Stream a `/`-separated namespace path straight into a formatter.
+///
+/// Writing through the formatter keeps `Display` allocation-free, which matters
+/// because namespaces are used as `tracing` fields on hot relay paths: with `%ns`
+/// the path is only rendered when the subscriber actually records the event, and
+/// even then nothing is allocated. `String::from_utf8_lossy` borrows for valid
+/// UTF-8, so only genuinely invalid fields allocate a replacement string.
+fn write_namespace_path(fields: &[TupleField], f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    for field in fields {
+        f.write_str("/")?;
+        f.write_str(&String::from_utf8_lossy(&field.value))?;
+    }
+    Ok(())
+}
+
 /// TrackNamespace
 #[derive(Clone, Default, Eq, PartialEq)]
 pub struct TrackNamespace {
@@ -46,13 +61,12 @@ impl TrackNamespace {
         tuple
     }
 
+    /// Render as a `/`-separated UTF-8 path.
+    ///
+    /// Allocates. Prefer the [`fmt::Display`] impl (e.g. `%namespace` in a
+    /// `tracing` field) when a `String` is not actually needed.
     pub fn to_utf8_path(&self) -> String {
-        let mut path = String::new();
-        for field in &self.fields {
-            path.push('/');
-            path.push_str(&String::from_utf8_lossy(&field.value));
-        }
-        path
+        self.to_string()
     }
 }
 
@@ -103,7 +117,7 @@ impl fmt::Debug for TrackNamespace {
 
 impl fmt::Display for TrackNamespace {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{0}", self.to_utf8_path())
+        write_namespace_path(&self.fields, f)
     }
 }
 
@@ -306,5 +320,42 @@ mod tests {
             result.unwrap_err(),
             TrackNamespaceError::FieldTooLarge(4097, 4096)
         ));
+    }
+
+    // ── Display / to_utf8_path equivalence ────────────────────────────────────
+
+    /// `to_utf8_path` delegates to `Display`, which streams into the formatter
+    /// rather than building a `String`. Both must keep producing the same path,
+    /// including for fields that are not valid UTF-8 (rendered lossily).
+    #[test]
+    fn display_matches_to_utf8_path() {
+        let namespace = TrackNamespace::from_utf8_path("example.com/meeting=123");
+        assert_eq!(namespace.to_string(), namespace.to_utf8_path());
+        assert_eq!(namespace.to_utf8_path(), "/example.com/meeting=123");
+
+        let empty = TrackNamespace::new();
+        assert_eq!(empty.to_string(), empty.to_utf8_path());
+        assert_eq!(empty.to_utf8_path(), "");
+    }
+
+    #[test]
+    fn display_renders_non_utf8_fields_lossily() {
+        let namespace = TrackNamespace {
+            fields: vec![
+                TupleField { value: vec![0xff] },
+                TupleField::from_utf8("ok"),
+            ],
+        };
+
+        assert_eq!(namespace.to_string(), namespace.to_utf8_path());
+        assert_eq!(namespace.to_utf8_path(), "/\u{fffd}/ok");
+    }
+
+    /// `Debug` is written in terms of `Display`, so it must not regress into
+    /// printing the raw field vector.
+    #[test]
+    fn debug_matches_display() {
+        let namespace = TrackNamespace::from_utf8_path("a/b");
+        assert_eq!(format!("{namespace:?}"), format!("{namespace}"));
     }
 }

--- a/moq-transport/src/data/mod.rs
+++ b/moq-transport/src/data/mod.rs
@@ -7,6 +7,7 @@ mod extension_headers;
 mod fetch;
 mod header;
 mod object_status;
+mod reset_code;
 mod subgroup;
 
 pub use datagram::*;
@@ -14,4 +15,5 @@ pub use extension_headers::*;
 pub use fetch::*;
 pub use header::*;
 pub use object_status::*;
+pub use reset_code::*;
 pub use subgroup::*;

--- a/moq-transport/src/data/reset_code.rs
+++ b/moq-transport/src/data/reset_code.rs
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2024-2026 Cloudflare Inc., Luke Curley, Mike English and contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+/// Draft-14 §13.1.8 Data Stream Reset Error Codes.
+///
+/// Sent as the QUIC/WebTransport `RESET_STREAM` application error code when a
+/// data stream is terminated before all of its objects have been delivered.
+///
+/// Draft-14 §10.4.3 requires a FIN only when every object in the subgroup has
+/// been delivered to the QUIC stream; any earlier termination MUST be a
+/// `RESET_STREAM` (or `RESET_STREAM_AT`). Truncating an object and then sending
+/// FIN instead tells the receiver the subgroup ended cleanly at a byte offset
+/// that lands in the middle of an object whose length it was already promised,
+/// which is a protocol violation.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum DataStreamResetCode {
+    /// An implementation specific error occurred.
+    InternalError = 0x0,
+    /// The stream was cancelled: the subscription ended early (for example an
+    /// UNSUBSCRIBE, or a publisher deciding to stop serving it).
+    Cancelled = 0x1,
+    /// An object in the subgroup exceeded its delivery timeout.
+    DeliveryTimeout = 0x2,
+    /// The session is going away.
+    SessionClosed = 0x3,
+}
+
+impl From<DataStreamResetCode> for u32 {
+    fn from(value: DataStreamResetCode) -> Self {
+        value as u32
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn codes_match_the_registry() {
+        // Draft-14 §13.1.8. These go on the wire as RESET_STREAM error codes, so
+        // the values are normative rather than internal labels.
+        assert_eq!(u32::from(DataStreamResetCode::InternalError), 0x0);
+        assert_eq!(u32::from(DataStreamResetCode::Cancelled), 0x1);
+        assert_eq!(u32::from(DataStreamResetCode::DeliveryTimeout), 0x2);
+        assert_eq!(u32::from(DataStreamResetCode::SessionClosed), 0x3);
+    }
+}

--- a/moq-transport/src/serve/interest.rs
+++ b/moq-transport/src/serve/interest.rs
@@ -1,0 +1,263 @@
+// SPDX-FileCopyrightText: 2024-2026 Cloudflare Inc., Luke Curley, Mike English and contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Downstream interest tracking for pull-through cache entries.
+//!
+//! When a relay serves a track it does not publish itself, it subscribes
+//! upstream and caches the resulting reader so later subscribers can share it.
+//! Nothing previously counted how many downstream subscribers were actually
+//! using that cached reader, so the upstream subscription lived until the
+//! upstream session died — the relay kept pulling bytes for a track nobody was
+//! watching.
+//!
+//! [`TrackInterest`] is a reference count with the ability to await "nobody has
+//! held a guard for a while". Each downstream subscriber holds a
+//! [`TrackInterestGuard`] for as long as it is being served, so the count is
+//! maintained by RAII and a cancelled subscriber cannot leak a reference.
+//!
+//! Guards hold a strong reference to the counter itself rather than a cache key.
+//! If a cache entry is evicted and a replacement is created for the same track
+//! name, an outstanding guard from the old entry decrements the old counter
+//! instead of making the new entry look busy.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::watch;
+
+/// How long a pull-through cache entry with no downstream subscribers is kept
+/// before the upstream subscription is released.
+///
+/// The grace period keeps the common case cheap: a subscriber reconnecting, or a
+/// player switching between renditions, reuses the warm cache entry instead of
+/// paying a fresh upstream SUBSCRIBE round trip. Past that we stop paying to
+/// receive a track nobody is watching.
+pub const DEFAULT_CACHE_IDLE_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Shared interest counter for one cache entry.
+#[derive(Clone, Debug)]
+pub struct TrackInterest {
+    inner: Arc<InterestInner>,
+}
+
+#[derive(Debug)]
+struct InterestInner {
+    /// Number of live guards. The count lives in the watch value so that
+    /// mutations and change notifications cannot get out of step.
+    count: watch::Sender<usize>,
+}
+
+impl Default for TrackInterest {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TrackInterest {
+    pub fn new() -> Self {
+        let (count, _) = watch::channel(0);
+        Self {
+            inner: Arc::new(InterestInner { count }),
+        }
+    }
+
+    /// Register a downstream subscriber, releasing the interest on drop.
+    ///
+    /// Callers must create the guard while holding the same cache lock that
+    /// [`TrackInterest::is_idle`] is checked under, so a subscriber arriving
+    /// concurrently with eviction is either counted or gets a fresh entry.
+    pub fn guard(&self) -> TrackInterestGuard {
+        self.inner.count.send_modify(|count| *count += 1);
+        TrackInterestGuard {
+            inner: self.inner.clone(),
+        }
+    }
+
+    /// Current number of downstream subscribers.
+    pub fn count(&self) -> usize {
+        *self.inner.count.borrow()
+    }
+
+    /// True when no downstream subscriber is being served from this entry.
+    pub fn is_idle(&self) -> bool {
+        self.count() == 0
+    }
+
+    /// True when both handles refer to the same counter, i.e. the same cache
+    /// entry generation.
+    pub fn same_generation(&self, other: &TrackInterest) -> bool {
+        Arc::ptr_eq(&self.inner, &other.inner)
+    }
+
+    /// Resolve once the count has been continuously zero for `grace`.
+    ///
+    /// The timer restarts whenever a subscriber appears, so a track that keeps
+    /// picking up new subscribers is never considered idle. A zero `grace`
+    /// resolves as soon as the count reaches zero.
+    pub async fn idle_for(&self, grace: Duration) {
+        let mut rx = self.inner.count.subscribe();
+
+        loop {
+            // Scoped so the borrow is released before the awaits below.
+            let busy = { *rx.borrow_and_update() > 0 };
+
+            if busy {
+                // Wait for the count to change at all before re-checking.
+                if rx.changed().await.is_err() {
+                    // Sender gone, so the entry is unreachable; treat as idle.
+                    return;
+                }
+                continue;
+            }
+
+            if grace.is_zero() {
+                return;
+            }
+
+            tokio::select! {
+                _ = tokio::time::sleep(grace) => return,
+                // A subscriber arrived (or another change landed) inside the
+                // grace period; go around again and restart the timer.
+                res = rx.changed() => {
+                    if res.is_err() {
+                        return;
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Held for as long as a downstream subscriber is served from a cache entry.
+#[derive(Debug)]
+pub struct TrackInterestGuard {
+    inner: Arc<InterestInner>,
+}
+
+impl Drop for TrackInterestGuard {
+    fn drop(&mut self) {
+        self.inner.count.send_modify(|count| {
+            // Saturating because an underflow here would make a busy track look
+            // permanently busy, pinning the upstream subscription forever.
+            *count = count.saturating_sub(1);
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use tokio::time::Instant;
+
+    const GRACE: Duration = Duration::from_millis(50);
+
+    #[test]
+    fn guards_count_subscribers() {
+        let interest = TrackInterest::new();
+        assert_eq!(interest.count(), 0);
+        assert!(interest.is_idle());
+
+        let first = interest.guard();
+        assert_eq!(interest.count(), 1);
+        assert!(!interest.is_idle());
+
+        let second = interest.guard();
+        assert_eq!(interest.count(), 2);
+
+        drop(first);
+        assert_eq!(interest.count(), 1);
+
+        drop(second);
+        assert_eq!(interest.count(), 0);
+        assert!(interest.is_idle());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn idle_for_resolves_when_nobody_subscribes() {
+        let interest = TrackInterest::new();
+        let start = Instant::now();
+
+        interest.idle_for(GRACE).await;
+
+        assert!(start.elapsed() >= GRACE);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn idle_for_waits_for_the_last_subscriber_to_leave() {
+        let interest = TrackInterest::new();
+        let guard = interest.guard();
+
+        let idle = interest.idle_for(GRACE);
+        tokio::pin!(idle);
+
+        // Busy: must not resolve no matter how long we wait.
+        tokio::select! {
+            _ = &mut idle => panic!("a busy track must never look idle"),
+            _ = tokio::time::sleep(GRACE * 10) => {}
+        }
+
+        drop(guard);
+        idle.await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn a_new_subscriber_restarts_the_grace_period() {
+        let interest = TrackInterest::new();
+
+        let idle = interest.idle_for(GRACE);
+        tokio::pin!(idle);
+
+        // Part-way through the grace period a subscriber arrives, so the entry
+        // must stop looking idle rather than being evicted out from under it.
+        tokio::select! {
+            _ = &mut idle => panic!("resolved before the grace period elapsed"),
+            _ = tokio::time::sleep(GRACE / 2) => {}
+        }
+
+        let guard = interest.guard();
+
+        tokio::select! {
+            _ = &mut idle => panic!("resolved while a subscriber was present"),
+            _ = tokio::time::sleep(GRACE * 10) => {}
+        }
+
+        // Once it leaves, a full grace period must pass again.
+        drop(guard);
+        let after_drop = Instant::now();
+        idle.await;
+        assert!(after_drop.elapsed() >= GRACE);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn zero_grace_resolves_immediately_when_idle() {
+        let interest = TrackInterest::new();
+        interest.idle_for(Duration::ZERO).await;
+    }
+
+    #[test]
+    fn generations_are_distinguished_by_identity() {
+        let interest = TrackInterest::new();
+        let clone = interest.clone();
+        let replacement = TrackInterest::new();
+
+        assert!(interest.same_generation(&clone));
+        assert!(!interest.same_generation(&replacement));
+    }
+
+    #[test]
+    fn a_stale_guard_does_not_make_a_replacement_look_busy() {
+        // A subscriber served by an evicted entry can outlive that entry. Its
+        // guard must decrement the old counter, not the new one.
+        let old = TrackInterest::new();
+        let stale_guard = old.guard();
+
+        let new = TrackInterest::new();
+        assert!(new.is_idle());
+
+        drop(stale_guard);
+
+        assert_eq!(old.count(), 0);
+        assert!(new.is_idle(), "replacement entry should still be idle");
+    }
+}

--- a/moq-transport/src/serve/mod.rs
+++ b/moq-transport/src/serve/mod.rs
@@ -4,6 +4,7 @@
 
 mod datagram;
 mod error;
+mod interest;
 mod object;
 mod stream;
 mod subgroup;
@@ -12,6 +13,7 @@ mod tracks;
 
 pub use datagram::*;
 pub use error::*;
+pub use interest::*;
 pub use object::*;
 pub use stream::*;
 pub use subgroup::*;

--- a/moq-transport/src/serve/track.rs
+++ b/moq-transport/src/serve/track.rs
@@ -91,7 +91,7 @@ impl TrackWriter {
         // Lock state to modify it
         let mut state = self.state.lock_mut().ok_or_else(|| {
             tracing::debug!(
-                namespace = %self.info.namespace.to_utf8_path(),
+                namespace = %self.info.namespace,
                 track = %self.info.name,
                 "track state dropped (Cancel) in stream()"
             );
@@ -114,7 +114,7 @@ impl TrackWriter {
         // Lock state to modify it
         let mut state = self.state.lock_mut().ok_or_else(|| {
             tracing::debug!(
-                namespace = %self.info.namespace.to_utf8_path(),
+                namespace = %self.info.namespace,
                 track = %self.info.name,
                 "track state dropped (Cancel) in subgroups()"
             );
@@ -135,7 +135,7 @@ impl TrackWriter {
         // Lock state to modify it
         let mut state = self.state.lock_mut().ok_or_else(|| {
             tracing::debug!(
-                namespace = %self.info.namespace.to_utf8_path(),
+                namespace = %self.info.namespace,
                 track = %self.info.name,
                 "track state dropped (Cancel) in datagrams()"
             );
@@ -150,7 +150,7 @@ impl TrackWriter {
     /// Close the track with an error.
     pub fn close(self, err: ServeError) -> Result<(), ServeError> {
         tracing::debug!(
-            namespace = %self.info.namespace.to_utf8_path(),
+            namespace = %self.info.namespace,
             track = %self.info.name,
             error = %err,
             "track closing"
@@ -160,7 +160,7 @@ impl TrackWriter {
 
         let mut state = state.into_mut().ok_or_else(|| {
             tracing::debug!(
-                namespace = %self.info.namespace.to_utf8_path(),
+                namespace = %self.info.namespace,
                 track = %self.info.name,
                 "track state already dropped during close"
             );

--- a/moq-transport/src/serve/tracks.rs
+++ b/moq-transport/src/serve/tracks.rs
@@ -335,7 +335,7 @@ impl Drop for TracksRequest {
         if !pending_tracks.is_empty() {
             tracing::debug!(
                 target: "moq_transport::tracks",
-                namespace = %self.info.namespace.to_utf8_path(),
+                namespace = %self.info.namespace,
                 count = pending_tracks.len(),
                 "TracksRequest dropped with pending track requests"
             );
@@ -419,7 +419,7 @@ impl TracksReader {
                 // Track is still active, return the cached reader
                 tracing::debug!(
                     target: "moq_transport::tracks",
-                    namespace = %namespace.to_utf8_path(),
+                    namespace = %namespace,
                     track = %track_name,
                     "track cache hit (active)"
                 );
@@ -429,7 +429,7 @@ impl TracksReader {
             // Track is closed/stale, fall through to create a new one
             tracing::debug!(
                 target: "moq_transport::tracks",
-                namespace = %namespace.to_utf8_path(),
+                namespace = %namespace,
                 track = %track_name,
                 "track cache hit but stale, will evict and re-request"
             );
@@ -463,7 +463,7 @@ impl TracksReader {
         if self.queue.push(TrackRequest { writer, lease }).is_err() {
             tracing::debug!(
                 target: "moq_transport::tracks",
-                namespace = %namespace.to_utf8_path(),
+                namespace = %namespace,
                 track = %track_name,
                 "track request queue closed"
             );
@@ -481,7 +481,7 @@ impl TracksReader {
 
         tracing::debug!(
             target: "moq_transport::tracks",
-            namespace = %namespace.to_utf8_path(),
+            namespace = %namespace,
             track = %track_name,
             "track cache miss, requested from upstream"
         );

--- a/moq-transport/src/serve/tracks.rs
+++ b/moq-transport/src/serve/tracks.rs
@@ -14,11 +14,14 @@
 //! A [Reader] can be cloned to create multiple subscriptions.
 //!
 //! The broadcast is automatically closed with [ServeError::Done] when [Writer] is dropped, or all [Reader]s are dropped.
-use std::{collections::HashMap, ops::Deref, sync::Arc};
+use std::{collections::HashMap, ops::Deref, sync::Arc, time::Duration};
 
-use super::{ServeError, Track, TrackReader, TrackWriter};
+use super::{
+    ServeError, Track, TrackInterest, TrackInterestGuard, TrackReader, TrackWriter,
+    DEFAULT_CACHE_IDLE_TIMEOUT,
+};
 use crate::coding::TrackNamespace;
-use crate::watch::{Queue, State};
+use crate::watch::{Queue, State, StateWeak};
 
 /// Full track identifier: namespace + track name
 #[derive(Hash, Eq, PartialEq, Clone, Debug)]
@@ -39,8 +42,23 @@ impl Tracks {
     }
 
     pub fn produce(self) -> (TracksWriter, TracksRequest, TracksReader) {
+        self.produce_with_cache_idle_timeout(DEFAULT_CACHE_IDLE_TIMEOUT)
+    }
+
+    /// Produce a broadcast whose pull-through cache entries are evicted after
+    /// `cache_idle_timeout` with no downstream subscribers.
+    ///
+    /// A zero timeout disables eviction, restoring the previous behaviour of
+    /// holding upstream subscriptions for as long as the session lives.
+    ///
+    /// This is a separate constructor rather than a field on [`Tracks`] so that
+    /// existing `Tracks { namespace }` construction keeps compiling.
+    pub fn produce_with_cache_idle_timeout(
+        self,
+        cache_idle_timeout: Duration,
+    ) -> (TracksWriter, TracksRequest, TracksReader) {
         let info = Arc::new(self);
-        let state = State::default().split();
+        let state = State::new(TracksState::new(cache_idle_timeout)).split();
         let queue = Queue::default().split();
 
         let writer = TracksWriter::new(state.0.clone(), info.clone());
@@ -51,9 +69,165 @@ impl Tracks {
     }
 }
 
-#[derive(Default)]
+/// A cached track reader plus the downstream interest in it.
+struct TrackCacheEntry {
+    reader: TrackReader,
+
+    /// Downstream subscribers currently being served from this reader, for
+    /// pull-through cache entries only.
+    ///
+    /// Locally created tracks ([`TracksWriter::create`]) have no upstream
+    /// subscription to release, so there is nothing to count.
+    ///
+    /// Held here rather than beside the upstream subscription so that
+    /// [`TracksReader::subscribe`] can register interest under the same lock it
+    /// reads the cache under, which is what makes eviction race-free.
+    interest: Option<TrackInterest>,
+}
+
 pub struct TracksState {
-    tracks: HashMap<FullTrackName, TrackReader>,
+    tracks: HashMap<FullTrackName, TrackCacheEntry>,
+
+    /// How long an unwatched cache entry is retained before its upstream
+    /// subscription is released. Zero disables eviction.
+    cache_idle_timeout: Duration,
+}
+
+impl TracksState {
+    fn new(cache_idle_timeout: Duration) -> Self {
+        Self {
+            tracks: HashMap::new(),
+            cache_idle_timeout,
+        }
+    }
+}
+
+impl Default for TracksState {
+    fn default() -> Self {
+        Self::new(DEFAULT_CACHE_IDLE_TIMEOUT)
+    }
+}
+
+/// A request for a track that is not cached yet, sent to the session that
+/// announced the namespace so it can SUBSCRIBE upstream.
+pub struct TrackRequest {
+    /// Writer the upstream subscription should fill.
+    pub writer: TrackWriter,
+
+    /// Lease on the pull-through cache entry backing this request.
+    ///
+    /// The requester should hold the upstream subscription open until
+    /// [`CacheLease::released`] resolves, then drop it to send UNSUBSCRIBE.
+    pub lease: CacheLease,
+}
+
+impl Deref for TrackRequest {
+    type Target = TrackWriter;
+
+    fn deref(&self) -> &Self::Target {
+        &self.writer
+    }
+}
+
+/// Ties an upstream subscription to downstream interest in its cache entry.
+///
+/// Handed to whichever session owns the upstream subscription so it can tell when
+/// the cached track has gone unwatched and stop paying for it.
+pub struct CacheLease {
+    state: StateWeak<TracksState>,
+    full_name: FullTrackName,
+    interest: TrackInterest,
+    cache_idle_timeout: Duration,
+}
+
+impl CacheLease {
+    /// Resolve once the cache entry has been evicted for lack of interest.
+    ///
+    /// The caller should drop its upstream subscription when this returns, which
+    /// sends UNSUBSCRIBE. Eviction happens first so that a subscriber arriving
+    /// afterwards misses the cache and triggers a fresh upstream SUBSCRIBE,
+    /// rather than attaching to a reader that is about to stop being fed.
+    ///
+    /// Never resolves when the idle timeout is disabled, preserving the previous
+    /// behaviour of holding the upstream subscription for the session's lifetime.
+    pub async fn released(&self) {
+        if self.cache_idle_timeout.is_zero() {
+            std::future::pending::<()>().await;
+        }
+
+        loop {
+            self.interest.idle_for(self.cache_idle_timeout).await;
+
+            if self.evict_if_idle() {
+                return;
+            }
+
+            // A subscriber arrived between the timer firing and the eviction
+            // taking the lock, so the entry is busy again. Go back to waiting.
+            tracing::trace!(
+                target: "moq_transport::tracks",
+                namespace = %self.full_name.namespace,
+                track = %self.full_name.name,
+                "cache eviction abandoned; downstream interest returned"
+            );
+        }
+    }
+
+    /// Remove the entry if it is still ours and still unwatched.
+    ///
+    /// Returns false, leaving the entry in place, only when interest returned
+    /// before the lock was acquired. Everything else — the broadcast being gone,
+    /// or the entry having been replaced by a newer generation — means this
+    /// upstream subscription is no longer serving anything, so it should be
+    /// released rather than pinned forever.
+    ///
+    /// The idle check happens under the same lock guards are created under, so a
+    /// subscriber racing eviction either gets counted here (and eviction is
+    /// abandoned) or misses the cache entirely and requests a fresh entry.
+    fn evict_if_idle(&self) -> bool {
+        // All `TracksReader`s are gone, so nothing can be served from this cache.
+        let Some(state) = self.state.upgrade() else {
+            return true;
+        };
+
+        let Some(mut state) = state.lock_mut() else {
+            return true;
+        };
+
+        match state.tracks.get(&self.full_name) {
+            Some(entry) => {
+                // Only evict the generation this lease belongs to. A replacement
+                // entry has its own lease and its own idle timer, and a locally
+                // created track has no upstream subscription at all.
+                let ours = entry
+                    .interest
+                    .as_ref()
+                    .is_some_and(|current| current.same_generation(&self.interest));
+
+                if !ours {
+                    return true;
+                }
+
+                if !self.interest.is_idle() {
+                    return false;
+                }
+
+                state.tracks.remove(&self.full_name);
+            }
+            // Already gone (e.g. evicted as stale), so the upstream subscription
+            // is no longer serving anything.
+            None => return true,
+        }
+
+        tracing::debug!(
+            target: "moq_transport::tracks",
+            namespace = %self.full_name.namespace,
+            track = %self.full_name.name,
+            "evicting idle cached track and releasing upstream subscription"
+        );
+
+        true
+    }
 }
 
 /// Publish new tracks for a broadcast by name.
@@ -82,7 +256,15 @@ impl TracksWriter {
             namespace: self.namespace.clone(),
             name: track.to_owned(),
         };
-        self.state.lock_mut()?.tracks.insert(full_name, reader);
+        self.state.lock_mut()?.tracks.insert(
+            full_name,
+            TrackCacheEntry {
+                reader,
+                // Created locally, so there is no upstream subscription to
+                // release and nothing to count interest against.
+                interest: None,
+            },
+        );
 
         Some(writer)
     }
@@ -93,7 +275,11 @@ impl TracksWriter {
             namespace: namespace.clone(),
             name: track_name.to_owned(),
         };
-        self.state.lock_mut()?.tracks.remove(&full_name)
+        self.state
+            .lock_mut()?
+            .tracks
+            .remove(&full_name)
+            .map(|entry| entry.reader)
     }
 }
 
@@ -108,12 +294,12 @@ impl Deref for TracksWriter {
 pub struct TracksRequest {
     #[allow(dead_code)] // Avoid dropping the write side
     state: State<TracksState>,
-    incoming: Option<Queue<TrackWriter>>,
+    incoming: Option<Queue<TrackRequest>>,
     pub info: Arc<Tracks>,
 }
 
 impl TracksRequest {
-    fn new(state: State<TracksState>, incoming: Queue<TrackWriter>, info: Arc<Tracks>) -> Self {
+    fn new(state: State<TracksState>, incoming: Queue<TrackRequest>, info: Arc<Tracks>) -> Self {
         Self {
             state,
             incoming: Some(incoming),
@@ -122,8 +308,14 @@ impl TracksRequest {
     }
 
     /// Wait for a request to create a new track.
+    ///
+    /// The returned [`TrackRequest`] carries both the writer to fill and a
+    /// [`CacheLease`]; the handler should hold its upstream subscription until
+    /// [`CacheLease::released`] resolves and then drop it, which sends
+    /// UNSUBSCRIBE.
+    ///
     /// None is returned if all [TracksReader]s have been dropped.
-    pub async fn next(&mut self) -> Option<TrackWriter> {
+    pub async fn next(&mut self) -> Option<TrackRequest> {
         self.incoming.as_mut()?.pop().await
     }
 }
@@ -149,7 +341,7 @@ impl Drop for TracksRequest {
             );
         }
         for track in pending_tracks {
-            let _ = track.close(ServeError::not_found_ctx(
+            let _ = track.writer.close(ServeError::not_found_ctx(
                 "tracks request dropped before track handled",
             ));
         }
@@ -162,17 +354,22 @@ impl Drop for TracksRequest {
 #[derive(Clone)]
 pub struct TracksReader {
     state: State<TracksState>,
-    queue: Queue<TrackWriter>,
+    queue: Queue<TrackRequest>,
     pub info: Arc<Tracks>,
 }
 
 impl TracksReader {
-    fn new(state: State<TracksState>, queue: Queue<TrackWriter>, info: Arc<Tracks>) -> Self {
+    fn new(state: State<TracksState>, queue: Queue<TrackRequest>, info: Arc<Tracks>) -> Self {
         Self { state, queue, info }
     }
 
     /// Get a track from the broadcast by full name, if it exists and is still alive.
     /// Returns None if the track doesn't exist or has been closed.
+    ///
+    /// This deliberately registers no interest: it is a point-in-time lookup (for
+    /// TRACK_STATUS) rather than the start of a subscription, so it must not keep
+    /// an otherwise-idle upstream subscription alive. Use [`Self::subscribe`] when
+    /// the reader will actually be served.
     pub fn get_track_reader(
         &mut self,
         namespace: &TrackNamespace,
@@ -184,9 +381,9 @@ impl TracksReader {
             name: track_name.to_owned(),
         };
 
-        if let Some(track_reader) = state.tracks.get(&full_name) {
-            if !track_reader.is_closed() {
-                return Some(track_reader.clone());
+        if let Some(entry) = state.tracks.get(&full_name) {
+            if !entry.reader.is_closed() {
+                return Some(entry.reader.clone());
             }
             // Track exists but is closed/stale - don't return it
         }
@@ -196,11 +393,20 @@ impl TracksReader {
     /// Get or request a track from the broadcast by full name.
     /// The namespace parameter should be the full requested namespace, not just the announced prefix.
     /// None is returned if [TracksWriter] or [TracksRequest] cannot fufill the request.
+    ///
+    /// Returns the reader plus, for pull-through cache entries, a guard the caller
+    /// must hold for as long as it is serving that reader. Dropping the guard is
+    /// what eventually lets the upstream subscription be released; a locally
+    /// created track has no upstream subscription and so yields no guard.
+    ///
+    /// The guard is taken while the cache lock is held. Taking it afterwards would
+    /// leave a window in which eviction sees an idle entry and removes the reader
+    /// this caller is about to serve.
     pub fn subscribe(
         &mut self,
         namespace: TrackNamespace,
         track_name: &str,
-    ) -> Option<TrackReader> {
+    ) -> Option<(TrackReader, Option<TrackInterestGuard>)> {
         let state = self.state.lock();
         let full_name = FullTrackName {
             namespace: namespace.clone(),
@@ -208,8 +414,8 @@ impl TracksReader {
         };
 
         // Check if we have a cached track that is still alive
-        if let Some(track_reader) = state.tracks.get(&full_name) {
-            if !track_reader.is_closed() {
+        if let Some(entry) = state.tracks.get(&full_name) {
+            if !entry.reader.is_closed() {
                 // Track is still active, return the cached reader
                 tracing::debug!(
                     target: "moq_transport::tracks",
@@ -217,7 +423,8 @@ impl TracksReader {
                     track = %track_name,
                     "track cache hit (active)"
                 );
-                return Some(track_reader.clone());
+                let guard = entry.interest.as_ref().map(TrackInterest::guard);
+                return Some((entry.reader.clone(), guard));
             }
             // Track is closed/stale, fall through to create a new one
             tracing::debug!(
@@ -233,13 +440,27 @@ impl TracksReader {
         // Remove the stale track if it exists (it was closed)
         state.tracks.remove(&full_name);
         // Use the full requested namespace, not self.namespace
-        let track_writer_reader = Track {
+        let (writer, reader) = Track {
             namespace: namespace.clone(),
             name: track_name.to_owned(),
         }
         .produce();
 
-        if self.queue.push(track_writer_reader.0).is_err() {
+        let interest = TrackInterest::new();
+
+        // Take this caller's guard before the entry is visible to anyone else, so
+        // the entry can never be seen as idle while we are still setting up the
+        // upstream subscription.
+        let guard = interest.guard();
+
+        let lease = CacheLease {
+            state: self.state.downgrade(),
+            full_name: full_name.clone(),
+            interest: interest.clone(),
+            cache_idle_timeout: state.cache_idle_timeout,
+        };
+
+        if self.queue.push(TrackRequest { writer, lease }).is_err() {
             tracing::debug!(
                 target: "moq_transport::tracks",
                 namespace = %namespace.to_utf8_path(),
@@ -250,9 +471,13 @@ impl TracksReader {
         }
 
         // We requested the track successfully so we can deduplicate it by full name.
-        state
-            .tracks
-            .insert(full_name, track_writer_reader.1.clone());
+        state.tracks.insert(
+            full_name,
+            TrackCacheEntry {
+                reader: reader.clone(),
+                interest: Some(interest),
+            },
+        );
 
         tracing::debug!(
             target: "moq_transport::tracks",
@@ -261,7 +486,7 @@ impl TracksReader {
             "track cache miss, requested from upstream"
         );
 
-        Some(track_writer_reader.1)
+        Some((reader, Some(guard)))
     }
 }
 
@@ -297,20 +522,21 @@ mod tests {
         let (_writer, mut request, mut reader) = Tracks::new(namespace.clone()).produce();
 
         // First subscription: subscriber requests the track
-        let track_reader_1 = reader
+        let (track_reader_1, _interest_1) = reader
             .subscribe(namespace.clone(), track_name)
             .expect("first subscribe should succeed");
 
         // Publisher receives the request and gets a TrackWriter
-        let track_writer_1 = request
+        let track_request_1 = request
             .next()
             .await
             .expect("publisher should receive first track request");
 
-        assert_eq!(track_writer_1.name, track_name);
+        assert_eq!(track_request_1.name, track_name);
 
         // Publisher closes the track with an error (simulates connection failure)
-        track_writer_1
+        track_request_1
+            .writer
             .close(ServeError::Cancel)
             .expect("close should succeed");
 
@@ -327,7 +553,7 @@ mod tests {
         );
 
         // Second subscription: subscriber requests the SAME track again
-        let track_reader_2 = reader
+        let (track_reader_2, _interest_2) = reader
             .subscribe(namespace.clone(), track_name)
             .expect("second subscribe should succeed");
 
@@ -342,11 +568,11 @@ mod tests {
             "Publisher should receive a new track request after the first one was closed"
         );
 
-        let track_writer_2 = maybe_track_writer_2
+        let track_request_2 = maybe_track_writer_2
             .unwrap()
             .expect("publisher should receive second track request");
 
-        assert_eq!(track_writer_2.name, track_name);
+        assert_eq!(track_request_2.name, track_name);
 
         // Verify that track_reader_2 is NOT already closed
         // (It should be a fresh, working track)
@@ -373,18 +599,18 @@ mod tests {
         let (_writer, mut request, mut reader) = Tracks::new(namespace.clone()).produce();
 
         // First subscription
-        let track_reader_1 = reader
+        let (track_reader_1, _interest_1) = reader
             .subscribe(namespace.clone(), track_name)
             .expect("first subscribe should succeed");
 
         // Publisher receives request
-        let _track_writer = request
+        let _track_request = request
             .next()
             .await
             .expect("publisher should receive track request");
 
         // Second subscription to the SAME track (while it's still alive)
-        let track_reader_2 = reader
+        let (track_reader_2, _interest_2) = reader
             .subscribe(namespace.clone(), track_name)
             .expect("second subscribe should succeed");
 
@@ -413,20 +639,21 @@ mod tests {
 
         let (_writer, mut request, mut reader) = Tracks::new(namespace.clone()).produce();
 
-        let _track_reader_1 = reader
+        let _sub_1 = reader
             .subscribe(namespace.clone(), track_name)
             .expect("first subscribe should succeed");
 
-        let track_writer = request
+        let track_request = request
             .next()
             .await
             .expect("publisher should receive track request");
 
-        let _subgroups_writer = track_writer
+        let _subgroups_writer = track_request
+            .writer
             .subgroups()
             .expect("subgroups transition should succeed");
 
-        let _track_reader_2 = reader
+        let _sub_2 = reader
             .subscribe(namespace.clone(), track_name)
             .expect("second subscribe should succeed");
 
@@ -448,21 +675,22 @@ mod tests {
 
         let (_writer, mut request, mut reader) = Tracks::new(namespace.clone()).produce();
 
-        let _track_reader_1 = reader
+        let _sub_1 = reader
             .subscribe(namespace.clone(), track_name)
             .expect("first subscribe should succeed");
 
-        let track_writer = request
+        let track_request = request
             .next()
             .await
             .expect("publisher should receive track request");
 
-        let subgroups_writer = track_writer
+        let subgroups_writer = track_request
+            .writer
             .subgroups()
             .expect("subgroups transition should succeed");
         drop(subgroups_writer);
 
-        let _track_reader_2 = reader
+        let _sub_2 = reader
             .subscribe(namespace.clone(), track_name)
             .expect("second subscribe should succeed");
 
@@ -477,5 +705,180 @@ mod tests {
         let _second_request = maybe_second_request
             .unwrap()
             .expect("publisher should receive second track request");
+    }
+
+    const GRACE: Duration = Duration::from_secs(30);
+
+    /// The bug this fixes: once the last downstream subscriber leaves, the
+    /// upstream subscription must be released rather than held for the session's
+    /// lifetime.
+    #[tokio::test(start_paused = true)]
+    async fn idle_cache_entry_is_evicted_and_the_lease_released() {
+        let namespace = TrackNamespace::from_utf8_path("test/namespace");
+        let track_name = "test-track";
+
+        let (_writer, mut request, mut reader) =
+            Tracks::new(namespace.clone()).produce_with_cache_idle_timeout(GRACE);
+
+        let (_track_reader, interest) = reader
+            .subscribe(namespace.clone(), track_name)
+            .expect("subscribe should succeed");
+        let request_1 = request.next().await.expect("upstream request");
+
+        let released = request_1.lease.released();
+        tokio::pin!(released);
+
+        // While a subscriber is being served the lease must never release.
+        tokio::select! {
+            _ = &mut released => panic!("a watched track must not be released"),
+            _ = tokio::time::sleep(GRACE * 10) => {}
+        }
+
+        // Last subscriber leaves.
+        drop(interest);
+        released.await;
+
+        // The entry was evicted, so the next subscriber gets a fresh upstream
+        // request rather than a reader nobody is feeding.
+        let _ = reader
+            .subscribe(namespace.clone(), track_name)
+            .expect("resubscribe should succeed");
+        let request_2 = tokio::time::timeout(Duration::from_millis(100), request.next())
+            .await
+            .expect("a fresh upstream request should be issued")
+            .expect("upstream request");
+        assert_eq!(request_2.name, track_name);
+    }
+
+    /// The grace period is what keeps a reconnecting subscriber, or a player
+    /// switching renditions, off a fresh upstream SUBSCRIBE round trip.
+    #[tokio::test(start_paused = true)]
+    async fn warm_cache_is_reused_within_the_grace_period() {
+        let namespace = TrackNamespace::from_utf8_path("test/namespace");
+        let track_name = "test-track";
+
+        let (_writer, mut request, mut reader) =
+            Tracks::new(namespace.clone()).produce_with_cache_idle_timeout(GRACE);
+
+        let (reader_1, interest) = reader
+            .subscribe(namespace.clone(), track_name)
+            .expect("subscribe should succeed");
+        let request_1 = request.next().await.expect("upstream request");
+
+        let released = request_1.lease.released();
+        tokio::pin!(released);
+
+        drop(interest);
+
+        // Part-way through the grace period a new subscriber arrives.
+        tokio::select! {
+            _ = &mut released => panic!("released before the grace period elapsed"),
+            _ = tokio::time::sleep(GRACE / 2) => {}
+        }
+
+        let (reader_2, interest_2) = reader
+            .subscribe(namespace.clone(), track_name)
+            .expect("resubscribe should succeed");
+
+        // Same warm entry, and no second upstream subscription.
+        assert!(Arc::ptr_eq(&reader_1.info, &reader_2.info));
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), request.next())
+                .await
+                .is_err(),
+            "a warm cache hit must not issue a new upstream request"
+        );
+
+        tokio::select! {
+            _ = &mut released => panic!("released while a subscriber was present"),
+            _ = tokio::time::sleep(GRACE * 10) => {}
+        }
+
+        drop(interest_2);
+        released.await;
+    }
+
+    /// A zero timeout is the opt-out: upstream subscriptions live as long as the
+    /// session, which is the behaviour before this change.
+    #[tokio::test(start_paused = true)]
+    async fn zero_timeout_never_releases_the_lease() {
+        let namespace = TrackNamespace::from_utf8_path("test/namespace");
+        let track_name = "test-track";
+
+        let (_writer, mut request, mut reader) =
+            Tracks::new(namespace.clone()).produce_with_cache_idle_timeout(Duration::ZERO);
+
+        let (_track_reader, interest) = reader
+            .subscribe(namespace.clone(), track_name)
+            .expect("subscribe should succeed");
+        let request_1 = request.next().await.expect("upstream request");
+
+        drop(interest);
+
+        tokio::select! {
+            _ = request_1.lease.released() => panic!("a zero timeout must disable eviction"),
+            _ = tokio::time::sleep(GRACE * 100) => {}
+        }
+    }
+
+    /// If every `TracksReader` is gone the broadcast can no longer serve anyone,
+    /// so the upstream subscription should be released rather than pinned by a
+    /// lease that can never be evicted.
+    #[tokio::test(start_paused = true)]
+    async fn lease_is_released_once_every_reader_is_dropped() {
+        let namespace = TrackNamespace::from_utf8_path("test/namespace");
+        let track_name = "test-track";
+
+        let (_writer, mut request, mut reader) =
+            Tracks::new(namespace.clone()).produce_with_cache_idle_timeout(GRACE);
+
+        let (_track_reader, interest) = reader
+            .subscribe(namespace.clone(), track_name)
+            .expect("subscribe should succeed");
+        let request_1 = request.next().await.expect("upstream request");
+
+        drop(interest);
+        drop(reader);
+
+        request_1.lease.released().await;
+    }
+
+    /// A guard outstanding from an evicted entry must not keep a same-named
+    /// replacement looking busy, and must not evict it either.
+    #[tokio::test(start_paused = true)]
+    async fn a_stale_lease_does_not_evict_a_replacement_entry() {
+        let namespace = TrackNamespace::from_utf8_path("test/namespace");
+        let track_name = "test-track";
+
+        let (_writer, mut request, mut reader) =
+            Tracks::new(namespace.clone()).produce_with_cache_idle_timeout(GRACE);
+
+        let (_reader_1, interest_1) = reader
+            .subscribe(namespace.clone(), track_name)
+            .expect("subscribe should succeed");
+        let request_1 = request.next().await.expect("first upstream request");
+
+        drop(interest_1);
+        request_1.lease.released().await;
+
+        // A replacement generation for the same track name.
+        let (_reader_2, interest_2) = reader
+            .subscribe(namespace.clone(), track_name)
+            .expect("resubscribe should succeed");
+        let request_2 = request.next().await.expect("second upstream request");
+
+        // Re-driving the old lease must be a no-op: it reports released (its own
+        // generation is gone) without touching the live replacement.
+        request_1.lease.released().await;
+
+        let released_2 = request_2.lease.released();
+        tokio::pin!(released_2);
+        tokio::select! {
+            _ = &mut released_2 => panic!("the replacement entry is still watched"),
+            _ = tokio::time::sleep(GRACE * 10) => {}
+        }
+
+        drop(interest_2);
+        released_2.await;
     }
 }

--- a/moq-transport/src/session/publisher.rs
+++ b/moq-transport/src/session/publisher.rs
@@ -173,10 +173,14 @@ impl Publisher {
         subscribed: Subscribed,
         mut tracks: TracksReader,
     ) -> Result<(), SessionError> {
-        if let Some(track) = tracks.subscribe(
+        if let Some((track, interest)) = tracks.subscribe(
             subscribed.info.track_namespace.clone(),
             &subscribed.info.track_name,
         ) {
+            // Hold the interest guard for the whole of `serve`, so the cache entry
+            // backing this reader is not evicted (and its upstream subscription
+            // released) while we are still forwarding from it.
+            let _interest = interest;
             subscribed.serve(track).await?;
         } else {
             let namespace = subscribed.info.track_namespace.clone();
@@ -194,7 +198,10 @@ impl Publisher {
         track_status_request: TrackStatusRequested,
         mut tracks: TracksReader,
     ) -> Result<(), SessionError> {
-        let track = tracks
+        // The guard is held only for the duration of the response; a status
+        // request is not a subscription, so it should not keep an idle upstream
+        // subscription alive beyond the grace period.
+        let (track, _interest) = tracks
             .subscribe(
                 track_status_request.request_msg.track_namespace.clone(),
                 &track_status_request.request_msg.track_name,

--- a/moq-transport/src/session/subscribed.rs
+++ b/moq-transport/src/session/subscribed.rs
@@ -9,6 +9,7 @@ use futures::stream::FuturesUnordered;
 use futures::StreamExt;
 
 use crate::coding::{Encode, Location, ReasonPhrase};
+use crate::data::DataStreamResetCode;
 use crate::mlog;
 use crate::serve::{ServeError, TrackReaderMode};
 use crate::watch::State;
@@ -17,6 +18,190 @@ use crate::{data, message, serve};
 use super::{Publisher, SessionError, SubscribeInfo, Writer};
 
 // This file defines Publisher handling of inbound Subscriptions
+
+/// A subgroup data stream that is reset unless it is explicitly finished.
+///
+/// Draft-14 §10.4.3: a FIN means "every object in this subgroup was delivered".
+/// Any earlier termination MUST be a `RESET_STREAM`, and the listed causes
+/// include early termination due to UNSUBSCRIBE and a publisher ending the
+/// subscription early — exactly the paths a relay hits when downstream interest
+/// disappears or an upstream track dies mid-object.
+///
+/// `quinn::SendStream::drop` implicitly calls `finish()`, so simply dropping the
+/// writer on a cancelled or failed forwarding task FINs the stream wherever it
+/// happened to stop. If that is mid-object the receiver has already been
+/// promised a payload length it will never get, and treats the truncated
+/// subgroup as a malformed track. This wrapper inverts that default: the stream
+/// is reset on drop unless [`SubgroupStream::finish`] ran, so the safe outcome
+/// is the automatic one.
+struct SubgroupStream {
+    writer: Writer,
+    /// Set once the stream has been explicitly finished or reset, after which
+    /// `Drop` must not touch it again.
+    terminated: bool,
+}
+
+impl SubgroupStream {
+    fn new(writer: Writer) -> Self {
+        Self {
+            writer,
+            terminated: false,
+        }
+    }
+
+    fn finish(&mut self) -> Result<(), SessionError> {
+        if self.terminated {
+            return Ok(());
+        }
+        self.terminated = true;
+        self.writer.finish()
+    }
+
+    fn reset(&mut self, code: DataStreamResetCode) {
+        if self.terminated {
+            return;
+        }
+        self.terminated = true;
+        self.writer.reset(code.into());
+    }
+}
+
+impl Drop for SubgroupStream {
+    fn drop(&mut self) {
+        // Covers async cancellation, where no error path gets a chance to run:
+        // dropping the forwarding future must not leave quinn to implicitly FIN
+        // a partially written subgroup. `Cancelled` is the right default because
+        // a dropped forwarding task means the subscription ended early.
+        self.reset(DataStreamResetCode::Cancelled);
+    }
+}
+
+/// How a subgroup stream was terminated. Recorded by the test sink so tests can
+/// assert FIN-vs-RESET behaviour without a real QUIC connection.
+#[cfg(test)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SubgroupTermination {
+    Fin,
+    Reset(DataStreamResetCode),
+}
+
+enum SubgroupSink {
+    Stream(SubgroupStream),
+    #[cfg(test)]
+    Buffer {
+        buffer: bytes::BytesMut,
+        termination: Option<SubgroupTermination>,
+    },
+}
+
+/// Writes a subgroup to a sink while tracking whether we are mid-object.
+///
+/// The accounting lives here rather than in the sink so there is exactly one
+/// place that knows whether a FIN is currently legal.
+struct SubgroupOutput {
+    sink: SubgroupSink,
+    /// Payload bytes still owed for the object whose header we already wrote.
+    /// Non-zero means we are mid-object and MUST NOT FIN.
+    owed: usize,
+}
+
+impl SubgroupOutput {
+    fn stream(writer: Writer) -> Self {
+        Self {
+            sink: SubgroupSink::Stream(SubgroupStream::new(writer)),
+            owed: 0,
+        }
+    }
+
+    #[cfg(test)]
+    fn buffer() -> Self {
+        Self {
+            sink: SubgroupSink::Buffer {
+                buffer: bytes::BytesMut::new(),
+                termination: None,
+            },
+            owed: 0,
+        }
+    }
+
+    async fn encode<T: Encode>(&mut self, msg: &T) -> Result<(), SessionError> {
+        match &mut self.sink {
+            SubgroupSink::Stream(stream) => stream.writer.encode(msg).await,
+            #[cfg(test)]
+            SubgroupSink::Buffer { buffer, .. } => {
+                msg.encode(buffer)?;
+                Ok(())
+            }
+        }
+    }
+
+    async fn write(&mut self, buf: &[u8]) -> Result<(), SessionError> {
+        match &mut self.sink {
+            SubgroupSink::Stream(stream) => stream.writer.write(buf).await?,
+            #[cfg(test)]
+            SubgroupSink::Buffer { buffer, .. } => buffer.extend_from_slice(buf),
+        }
+
+        self.owed = self.owed.saturating_sub(buf.len());
+        Ok(())
+    }
+
+    /// Record that an object header promising `len` payload bytes was written.
+    fn begin_object(&mut self, len: usize) {
+        self.owed = len;
+    }
+
+    /// True when every promised payload byte has been written.
+    fn at_object_boundary(&self) -> bool {
+        self.owed == 0
+    }
+
+    /// FIN the stream, asserting the whole subgroup was delivered.
+    ///
+    /// Only legal at an object boundary; finishing while payload bytes are still
+    /// owed is the truncation this type exists to prevent, so it resets instead.
+    fn finish(&mut self) -> Result<(), SessionError> {
+        if !self.at_object_boundary() {
+            tracing::warn!(
+                owed = self.owed,
+                "refusing to FIN a subgroup stream mid-object; resetting instead"
+            );
+            self.reset(DataStreamResetCode::InternalError);
+            return Err(ServeError::Size.into());
+        }
+
+        match &mut self.sink {
+            SubgroupSink::Stream(stream) => stream.finish(),
+            #[cfg(test)]
+            SubgroupSink::Buffer { termination, .. } => {
+                termination.get_or_insert(SubgroupTermination::Fin);
+                Ok(())
+            }
+        }
+    }
+
+    /// RESET the stream, signalling an incomplete subgroup.
+    fn reset(&mut self, code: DataStreamResetCode) {
+        match &mut self.sink {
+            SubgroupSink::Stream(stream) => stream.reset(code),
+            #[cfg(test)]
+            SubgroupSink::Buffer { termination, .. } => {
+                termination.get_or_insert(SubgroupTermination::Reset(code));
+            }
+        }
+    }
+
+    #[cfg(test)]
+    fn into_parts(self) -> (bytes::BytesMut, Option<SubgroupTermination>) {
+        match self.sink {
+            SubgroupSink::Buffer {
+                buffer,
+                termination,
+            } => (buffer, termination),
+            SubgroupSink::Stream(_) => unreachable!("test output should use a buffer"),
+        }
+    }
+}
 
 #[derive(Debug)]
 struct SubscribedState {
@@ -234,7 +419,7 @@ impl Subscribed {
 
     async fn serve_subgroup(
         header: data::SubgroupHeader,
-        mut subgroup_reader: serve::SubgroupReader,
+        subgroup_reader: serve::SubgroupReader,
         mut publisher: Publisher,
         state: State<SubscribedState>,
         mlog: Option<Arc<Mutex<mlog::MlogWriter>>>,
@@ -252,8 +437,47 @@ impl Subscribed {
         // TODO figure out u32 vs u64 priority
         send_stream.set_priority(subgroup_reader.priority as i32);
 
-        let mut writer = Writer::new(send_stream);
+        let mut output = SubgroupOutput::stream(Writer::new(send_stream));
+        let res =
+            Self::serve_subgroup_objects(header, subgroup_reader, &mut output, state, mlog).await;
 
+        // Draft-14 §10.4.3: FIN only if the whole subgroup was delivered,
+        // otherwise RESET_STREAM. Without this the `Writer` would be dropped and
+        // quinn would implicitly FIN wherever we stopped, which silently
+        // truncates the in-flight object.
+        match res {
+            Ok(()) => output.finish(),
+            Err(err) => {
+                output.reset(Self::reset_code_for(&err));
+                Err(err)
+            }
+        }
+    }
+
+    /// Map a forwarding failure onto a draft-14 §13.1.8 reset code.
+    fn reset_code_for(err: &SessionError) -> DataStreamResetCode {
+        match err {
+            // The subscriber went away (UNSUBSCRIBE) or the track was cancelled;
+            // §10.4.3 calls out UNSUBSCRIBE as a reset case explicitly.
+            SessionError::Serve(ServeError::Done | ServeError::Cancel) => {
+                DataStreamResetCode::Cancelled
+            }
+            SessionError::Serve(ServeError::Closed(_)) => DataStreamResetCode::SessionClosed,
+            // Everything else, including an upstream object that ran short of
+            // its declared payload length (`ServeError::Size`). Draft-16 added
+            // MALFORMED_TRACK (0x12) for that case, but draft-14 §13.1.8 has no
+            // equivalent, so it collapses into INTERNAL_ERROR here.
+            _ => DataStreamResetCode::InternalError,
+        }
+    }
+
+    async fn serve_subgroup_objects(
+        header: data::SubgroupHeader,
+        mut subgroup_reader: serve::SubgroupReader,
+        output: &mut SubgroupOutput,
+        state: State<SubscribedState>,
+        mlog: Option<Arc<Mutex<mlog::MlogWriter>>>,
+    ) -> Result<(), SessionError> {
         tracing::debug!(
             "[PUBLISHER] serve_subgroup: sending header - track_alias={}, group_id={}, subgroup_id={:?}, priority={}, header_type={:?}",
             header.track_alias,
@@ -263,7 +487,7 @@ impl Subscribed {
             header.header_type
         );
 
-        writer.encode(&header).await?;
+        output.encode(&header).await?;
 
         // Log subgroup header created/sent
         if let Some(ref mlog) = mlog {
@@ -299,7 +523,24 @@ impl Subscribed {
                 subgroup_object.extension_headers
             );
 
-            writer.encode(&subgroup_object).await?;
+            // Check the subscription is still live and the location is valid
+            // *before* writing the object header. The header promises
+            // `payload_length` bytes, so bailing out after writing it leaves the
+            // receiver waiting on payload we will never send. Previously this
+            // check ran after the encode, so a downstream UNSUBSCRIBE landing
+            // here truncated the object.
+            state
+                .lock_mut()
+                .ok_or(ServeError::Done)?
+                .update_largest_location(
+                    subgroup_reader.group_id,
+                    subgroup_object_reader.object_id,
+                )?;
+
+            output.encode(&subgroup_object).await?;
+            // From here until the payload is fully written we are mid-object and
+            // must not FIN.
+            output.begin_object(subgroup_object.payload_length);
 
             // Log subgroup object created/sent
             if let Some(ref mlog) = mlog {
@@ -318,14 +559,6 @@ impl Subscribed {
                 }
             }
 
-            state
-                .lock_mut()
-                .ok_or(ServeError::Done)?
-                .update_largest_location(
-                    subgroup_reader.group_id,
-                    subgroup_object_reader.object_id,
-                )?;
-
             let mut chunks_sent = 0;
             let mut bytes_sent = 0;
             while let Some(chunk) = subgroup_object_reader.read().await? {
@@ -336,7 +569,7 @@ impl Subscribed {
                     chunk.len()
                 );
                 bytes_sent += chunk.len();
-                writer.write(&chunk).await?;
+                output.write(&chunk).await?;
                 chunks_sent += 1;
             }
 
@@ -346,6 +579,21 @@ impl Subscribed {
                 chunks_sent,
                 bytes_sent
             );
+
+            // The reader ran out of chunks before satisfying the length we already
+            // promised. Surface it as an error so the stream is reset rather than
+            // FINed at a byte offset the receiver will read as a partial object.
+            if !output.at_object_boundary() {
+                tracing::warn!(
+                    group_id = subgroup_reader.group_id,
+                    object_id = subgroup_object_reader.object_id,
+                    promised = subgroup_object.payload_length,
+                    sent = bytes_sent,
+                    "upstream object ended short of its declared payload length"
+                );
+                return Err(ServeError::Size.into());
+            }
+
             object_count += 1;
         }
 
@@ -357,6 +605,35 @@ impl Subscribed {
         );
 
         Ok(())
+    }
+
+    /// Test helper mirroring [`Self::serve_subgroup`]'s termination logic so tests
+    /// can assert whether the stream would have been FINed or reset, without
+    /// needing a real QUIC connection to open a stream on.
+    #[cfg(test)]
+    async fn serve_subgroup_to_parts(
+        header: data::SubgroupHeader,
+        subgroup_reader: serve::SubgroupReader,
+        state: State<SubscribedState>,
+    ) -> (
+        bytes::BytesMut,
+        Result<(), SessionError>,
+        Option<SubgroupTermination>,
+    ) {
+        let mut output = SubgroupOutput::buffer();
+        let res =
+            Self::serve_subgroup_objects(header, subgroup_reader, &mut output, state, None).await;
+
+        let res = match res {
+            Ok(()) => output.finish(),
+            Err(err) => {
+                output.reset(Self::reset_code_for(&err));
+                Err(err)
+            }
+        };
+
+        let (buffer, termination) = output.into_parts();
+        (buffer, res, termination)
     }
 
     async fn serve_datagrams(
@@ -459,5 +736,211 @@ impl SubscribedRecv {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use bytes::{Buf, Bytes};
+
+    use crate::coding::{Decode, TrackNamespace};
+
+    /// Build a single-subgroup track reader carrying one complete object.
+    async fn subgroup_with_one_object() -> (serve::SubgroupReader, data::SubgroupHeader) {
+        let (track_writer, track_reader) =
+            serve::Track::new(TrackNamespace::from_utf8_path("test"), "video".to_string())
+                .produce();
+        let mut subgroups_writer = track_writer.subgroups().unwrap();
+        let mut subgroup_writer = subgroups_writer
+            .create(serve::Subgroup {
+                group_id: 1,
+                subgroup_id: 0,
+                priority: 0,
+            })
+            .unwrap();
+        subgroup_writer.write(Bytes::from_static(b"hello")).unwrap();
+        drop(subgroup_writer);
+        drop(subgroups_writer);
+
+        let mut subgroups = match track_reader.mode().await.unwrap() {
+            TrackReaderMode::Subgroups(subgroups) => subgroups,
+            _ => panic!("expected subgroups mode"),
+        };
+        let subgroup = subgroups.next().await.unwrap().expect("subgroup available");
+        let header = data::SubgroupHeader {
+            header_type: data::StreamHeaderType::SubgroupIdExt,
+            track_alias: 1,
+            group_id: subgroup.group_id,
+            subgroup_id: Some(subgroup.subgroup_id),
+            publisher_priority: subgroup.priority,
+        };
+
+        (subgroup, header)
+    }
+
+    /// A fully delivered subgroup is the one case where draft-14 §10.4.3 permits
+    /// a FIN.
+    #[tokio::test]
+    async fn complete_subgroup_is_finished_with_fin() {
+        let (subgroup, header) = subgroup_with_one_object().await;
+        let state = State::<SubscribedState>::default();
+
+        let (_buffer, res, termination) =
+            Subscribed::serve_subgroup_to_parts(header, subgroup, state).await;
+
+        res.expect("serving a complete subgroup should succeed");
+        assert_eq!(termination, Some(SubgroupTermination::Fin));
+    }
+
+    /// Draft-14 §10.4.3 lists UNSUBSCRIBE as a case that MUST reset rather than
+    /// FIN, and the stream must not be cut inside an object.
+    ///
+    /// This is the regression test for the truncation bug: the forwarder used to
+    /// encode an object header (promising `payload_length` bytes) and only then
+    /// check whether the subscription was still alive. When an UNSUBSCRIBE landed
+    /// in that window it returned early, dropped the `Writer`, and quinn
+    /// implicitly FINed the stream mid-object.
+    #[tokio::test]
+    async fn unsubscribe_mid_subgroup_resets_at_an_object_boundary() {
+        let (track_writer, track_reader) =
+            serve::Track::new(TrackNamespace::from_utf8_path("test"), "video".to_string())
+                .produce();
+        let mut subgroups_writer = track_writer.subgroups().unwrap();
+        let mut subgroup_writer = subgroups_writer
+            .create(serve::Subgroup {
+                group_id: 1,
+                subgroup_id: 0,
+                priority: 0,
+            })
+            .unwrap();
+
+        // First object is available immediately; the second arrives only after we
+        // simulate the UNSUBSCRIBE.
+        subgroup_writer.write(Bytes::from_static(b"hello")).unwrap();
+
+        let mut subgroups = match track_reader.mode().await.unwrap() {
+            TrackReaderMode::Subgroups(subgroups) => subgroups,
+            _ => panic!("expected subgroups mode"),
+        };
+        let subgroup = subgroups.next().await.unwrap().expect("subgroup available");
+        let header = data::SubgroupHeader {
+            header_type: data::StreamHeaderType::SubgroupIdExt,
+            track_alias: 1,
+            group_id: subgroup.group_id,
+            subgroup_id: Some(subgroup.subgroup_id),
+            publisher_priority: subgroup.priority,
+        };
+
+        // Dropping one half of the split state is what UNSUBSCRIBE does to the
+        // forwarder: `lock_mut` starts returning None.
+        let (unsubscribe_handle, state) = State::<SubscribedState>::default().split();
+
+        let fut = Subscribed::serve_subgroup_to_parts(header.clone(), subgroup, state);
+        tokio::pin!(fut);
+
+        // Let the forwarder deliver the first object and then park waiting for
+        // the next one.
+        tokio::select! {
+            _ = &mut fut => panic!("forwarder should still be awaiting the next object"),
+            _ = tokio::time::sleep(std::time::Duration::from_millis(50)) => {}
+        }
+
+        drop(unsubscribe_handle);
+        subgroup_writer.write(Bytes::from_static(b"world")).unwrap();
+
+        let (buffer, res, termination) = fut.await;
+
+        assert!(res.is_err(), "forwarding should fail once unsubscribed");
+        assert_eq!(
+            termination,
+            Some(SubgroupTermination::Reset(DataStreamResetCode::Cancelled)),
+            "an early-terminated subgroup must be reset, never FINed"
+        );
+
+        // The bytes on the wire must end on an object boundary: the subgroup
+        // header plus exactly the first complete object, with no header for the
+        // object we never delivered.
+        let mut buffer = buffer.freeze();
+        let header_type = data::StreamHeaderType::decode(&mut buffer).unwrap();
+        assert_eq!(
+            data::SubgroupHeader::decode(header_type, &mut buffer).unwrap(),
+            header
+        );
+
+        let object = data::SubgroupObjectExt::decode(&mut buffer).unwrap();
+        assert_eq!(object.payload_length, 5);
+        assert_eq!(&buffer.copy_to_bytes(object.payload_length)[..], b"hello");
+        assert!(
+            !buffer.has_remaining(),
+            "no partial object should follow the last complete one"
+        );
+    }
+
+    /// FIN must be refused while payload bytes are still owed, even if a caller
+    /// asks for one; otherwise the receiver sees a truncated object.
+    #[tokio::test]
+    async fn finish_mid_object_resets_instead_of_truncating() {
+        let mut output = SubgroupOutput::buffer();
+
+        output.begin_object(10);
+        output.write(b"abc").await.unwrap();
+        assert!(!output.at_object_boundary());
+
+        let err = output.finish().expect_err("FIN mid-object must be refused");
+        assert!(matches!(err, SessionError::Serve(ServeError::Size)));
+
+        let (_buffer, termination) = output.into_parts();
+        assert_eq!(
+            termination,
+            Some(SubgroupTermination::Reset(
+                DataStreamResetCode::InternalError
+            ))
+        );
+    }
+
+    #[tokio::test]
+    async fn owed_payload_tracking_follows_writes() {
+        let mut output = SubgroupOutput::buffer();
+        assert!(output.at_object_boundary(), "no object in flight");
+
+        output.begin_object(5);
+        assert!(!output.at_object_boundary());
+
+        output.write(b"hel").await.unwrap();
+        assert!(!output.at_object_boundary());
+
+        output.write(b"lo").await.unwrap();
+        assert!(output.at_object_boundary(), "object fully delivered");
+
+        output.finish().expect("FIN legal at object boundary");
+    }
+
+    #[test]
+    fn reset_codes_follow_the_failure_cause() {
+        // §10.4.3: subscription ended early.
+        assert_eq!(
+            Subscribed::reset_code_for(&ServeError::Done.into()),
+            DataStreamResetCode::Cancelled
+        );
+        assert_eq!(
+            Subscribed::reset_code_for(&ServeError::Cancel.into()),
+            DataStreamResetCode::Cancelled
+        );
+        assert_eq!(
+            Subscribed::reset_code_for(&ServeError::Closed(0x2).into()),
+            DataStreamResetCode::SessionClosed
+        );
+        // Draft-14 §13.1.8 has no MALFORMED_TRACK, so an upstream object that ran
+        // short of its declared length falls back to INTERNAL_ERROR.
+        assert_eq!(
+            Subscribed::reset_code_for(&ServeError::Size.into()),
+            DataStreamResetCode::InternalError
+        );
+        assert_eq!(
+            Subscribed::reset_code_for(&ServeError::internal_ctx("boom").into()),
+            DataStreamResetCode::InternalError
+        );
     }
 }

--- a/moq-transport/src/session/writer.rs
+++ b/moq-transport/src/session/writer.rs
@@ -89,4 +89,20 @@ impl Writer {
 
         Ok(())
     }
+
+    /// Cleanly close the stream with a FIN at the current offset.
+    ///
+    /// For data streams this asserts that everything the receiver was promised
+    /// has been written, so callers must only use it at a message boundary. See
+    /// [`crate::data::DataStreamResetCode`] for why a mid-object FIN is a
+    /// protocol violation rather than a cosmetic issue.
+    pub(super) fn finish(&mut self) -> Result<(), SessionError> {
+        self.stream.finish()?;
+        Ok(())
+    }
+
+    /// Abort the stream with a `RESET_STREAM` carrying `code`.
+    pub(super) fn reset(&mut self, code: u32) {
+        self.stream.reset(code);
+    }
 }


### PR DESCRIPTION
## What this changes

Backport of #196 to `draft-ietf-moq-transport-14`.

#191 was reported against the draft-14 deployment, so the fix needs to land on that branch as well as `main`. `main` is 112 commits ahead of this base and the relay was substantially reworked in between — ANNOUNCE became PUBLISH_NAMESPACE, `Locals` grew a pull-through cache, `subscribed.rs` went from 463 to 1337 lines — so nothing cherry-picked cleanly. This is a re-implementation of the same fixes against draft-14's structure. Where the shape had to change, it is called out below.

### 1. Reset subgroup streams instead of FIN-ing mid-object

`quinn::SendStream::drop` calls `finish()` — a clean FIN at the current offset. `subscribed.rs` built `SubgroupOutput::Stream(Writer::new(send_stream))` and never called `finish()` explicitly, so **every** early return from the forwarding loop sent a FIN wherever it happened to stop.

When that offset is inside an object, the receiver has already been promised `payload_length` bytes by the object header. It sees a subgroup that ended cleanly mid-object and treats the track as malformed.

Two triggers in a relay:

- **Downstream UNSUBSCRIBE** — `recv_unsubscribe` → `remove_subscribe` → `ObjectForwarderRecv` dropped → the `state.lock_mut().ok_or(ServeError::Done)?` in `serve_subgroup_objects` fails *after* the object header was already encoded → `Writer` dropped → FIN mid-object.
- **Upstream failing mid-object** — `SubgroupObjectWriter` dropped with `remain != 0` sets `ServeError::Size`, producing the same truncating FIN downstream.

draft-14 §10.4.3 ("Closing Subgroup Streams") permits a FIN only when every object in the subgroup has been delivered to the QUIC stream, and names UNSUBSCRIBE as a case that MUST use `RESET_STREAM`. The requirement is unchanged from draft-16, so the fix is the same:

- A `SubgroupStream` wrapper that **resets on drop unless explicitly finished**, so the spec-safe outcome is the default and async cancellation is covered without a separate code path.
- Track owed payload bytes and refuse to FIN while mid-object.
- Move the liveness/location check **ahead of** the object header encode, so a cancellation in that window stops on an object boundary rather than after the promise.
- Add the reset code registry as `DataStreamResetCode` and map failures onto it.

The regression test was verified to actually catch the bug: reverting only the check reordering makes `unsubscribe_mid_subgroup_resets_at_an_object_boundary` fail with "no partial object should follow the last complete one" — the same failure it produces on `main`.

**Draft-14 difference — the reset code registry is smaller.** draft-14 §13.1.8 defines only four codes: `INTERNAL_ERROR` (0x0), `CANCELLED` (0x1), `DELIVERY_TIMEOUT` (0x2), `SESSION_CLOSED` (0x3). `MALFORMED_TRACK` (0x12) does not exist yet, so the case #196 mapped to it — an upstream object that ran short of its declared `payload_length` — collapses into `INTERNAL_ERROR` here, with a comment at the mapping recording why. `CANCELLED` and `SESSION_CLOSED` map identically to `main`. This is the least-wrong option available on the wire for draft-14.

### 2. Release upstream subscriptions for idle cached tracks (#191)

A relay caches tracks it does not publish itself so several downstream subscribers can share one upstream subscription. Nothing counted how many subscribers were actually using a cached reader, so the upstream subscription lived until the upstream session died — after the last subscriber left, the relay kept receiving a track nobody was watching.

New `TrackInterest` / `TrackInterestGuard`: a reference count backed by a `watch` channel that can also await "unwatched for a while". Subscribers hold a guard while being served, so the count is maintained by RAII and a cancelled subscriber cannot leak a reference. Once an entry has been unwatched for the grace period it is evicted and the upstream `Subscribe` is dropped, sending UNSUBSCRIBE.

Both cache layers are covered: the pull-through cache reached through `TracksReader::subscribe`, and the cross-relay track cache in `RemoteManager`.

Three details this depends on, unchanged from #196:

- **Guards hold a strong reference to the counter, not a cache key.** An outstanding guard from an evicted entry decrements the counter it came from rather than making a same-named replacement look busy.
- **Guards are created under the same lock the idle check is made under.** A subscriber racing eviction is therefore either counted (eviction abandoned) or misses the cache and requests a fresh entry.
- **The entry is cleared before the upstream subscription is dropped**, so a subscriber arriving in that window re-subscribes rather than attaching to a reader about to go silent.

**Draft-14 difference — `TrackInterest` lives in `moq_transport::serve`, not the relay crate.** On `main` the pull-through cache is in `Locals` inside `moq-relay-ietf`, so interest tracking naturally went there. On draft-14 the cache is `TracksState` inside `moq-transport`, and the second invariant above requires the guard be taken under the same lock as the idle check — which is that crate's lock. Putting the guard in the relay crate would mean taking it after releasing the cache lock, reopening exactly the eviction race the design exists to close. So it goes in `moq-transport` alongside the state it guards. #180 independently reached the same placement on the same base.

This is what makes the API break land on `moq-transport` rather than `moq-relay-ietf` — see **Compatibility**.

### 3. Bound the upstream subscribe handshake

Related to the above, and part of the same problem: `subscribe_open` waits for SUBSCRIBE_OK, which an upstream is under no obligation to ever send. `Subscribe::ok()` loops on a state notify until the ack arrives or the session closes, so the wait was effectively unbounded. This predates the PR — the previous code called `Subscriber::subscribe`, which is `subscribe_open().await?` followed by `closed().await`, so the same wait was there one frame deeper — but it undercuts the point of the change above, since a never-acked subscribe pins the task and the `TrackWriter` it carries until the session dies.

Bounded two ways, because they cover different failures:

- **`lease.released()`** — nobody downstream is waiting for this track any more. This is the condition that actually matters and needs no arbitrary constant. `remote.rs` already raced its handshake against connection cancellation; the local path was the odd one out.
- **`--subscribe-timeout`** (default 10s) — a subscriber *is* still waiting, but the upstream never answers. Applied symmetrically to both the local pull-through path and the cross-relay path.

Ten seconds is a policy choice rather than a protocol constant, since MoQ does not bound SUBSCRIBE_OK. A downstream subscriber is blocked for the whole window, and upstream is normally a nearby relay or origin where a control round trip is well under a second.

Either mechanism drops the in-flight future, which drops the `Subscribe`, whose `Drop` sends UNSUBSCRIBE — so giving up mid-handshake leaves nothing dangling upstream.

### 4. Stream namespace paths into the formatter

`Display for TrackNamespace` called `to_utf8_path()` internally and built a `String`, so it was no cheaper than calling `to_utf8_path()` directly — and the `%namespace.to_utf8_path()` pattern at tracing call sites allocated on every call, including at log levels that were not enabled. `Display` now streams into the formatter and `to_utf8_path()` delegates to it, so there is one implementation of the path format. Tracing call sites become `%namespace`, which is both lazy and allocation-free. Callers that genuinely want an owned `String` (the moq-pub catalog field, the file coordinator, coordinator tests) keep using `to_utf8_path()`.

### Not backported

The lock-poisoning and broadcast-lag metrics from #196 do not apply: the lease registry and broadcast resync paths they instrument were added after draft-14 and have no equivalent here. The one piece that does apply — the missing `describe_counter!` for `moq_relay_cache_idle_evictions_total`, which this branch emits — is folded into part 2 so the counter ships with Prometheus HELP text.

## Configuration

| Flag | Default | Meaning |
|---|---|---|
| `--cache-idle-timeout` | `30` (seconds) | How long a cached track with no downstream subscribers is retained before its upstream subscription is released. `0` disables eviction, restoring the previous behaviour. |
| `--subscribe-timeout` | `10` (seconds) | How long to wait for an upstream to acknowledge a SUBSCRIBE. Must be at least 1 — an unbounded wait on a peer is what the timeout exists to prevent, so there is deliberately no "disabled" setting. Rejected by clap, and again by `Relay::new_with_tuning` for embedders that bypass the CLI. |

New metrics: `moq_relay_cache_idle_evictions_total` and `moq_relay_subscribe_timeouts_total`, both labelled by `source` (`local`, `remote`) so the two cache layers can be told apart.

## Testing

`cargo fmt --check`, `cargo clippy --no-deps --all-targets`, `cargo test` (180 passing), `cargo machete` — all clean.

New coverage: subgroup FIN-vs-RESET termination and reset-code mapping; the draft-14 §13.1.8 code values as a registry test; interest counting, grace-period restart and generation identity; idle eviction, warm-cache reuse within the grace period, cancelled-requester safety, zero-timeout opt-out, and stale-guard isolation on both the local and remote paths; `Display`/`to_utf8_path`/`Debug` equivalence including the non-UTF-8 lossy case; the documented tuning defaults, that each timeout builder sets only its own knob (both are `Duration`, so crossing them would compile silently), that a zero subscribe timeout is rejected, and that a zero cache idle timeout still is not.

Not covered by a new test: timeout expiry itself is `tokio::time::timeout` over an existing call, and the drop-sends-UNSUBSCRIBE behaviour it relies on is `Subscribe`'s existing tested `Drop`. A call-site test would need a full session mock for no additional assurance.

## Compatibility

**This is a source-breaking change to `moq-transport`** — note that this differs from #196, which broke `moq-relay-ietf` instead, for the reason given in part 2 above.

| Method | Before | After |
|---|---|---|
| `TracksReader::subscribe` | `Option<TrackReader>` | `Option<(TrackReader, Option<TrackInterestGuard>)>` |
| `TracksRequest::next` | `Option<TrackWriter>` | `Option<TrackRequest>` |

`TrackRequest` implements `Deref<Target = TrackWriter>`, so `.name`, `.namespace` and `.info` still work unchanged on the yielded value; only code that needs to *move* the writer has to reach for `.writer`.

Guard-less variants of the two methods above were **not** kept as an additive migration path. The design's correctness depends on the interest guard being created under the same lock as the idle check, so a method that returns a cached reader *without* a guard hands back an entry that registers no interest — it looks idle immediately and can be evicted while it is still being served. That is the bug class this PR fixes, so a compile error at each call site is preferable to an API that silently reintroduces it.

Preserved deliberately: `Tracks` struct literals, `Tracks::new`, `Tracks::produce`, `TracksWriter::create` / `remove`, `get_track_reader`, and `TracksState: Default` are all unchanged, and the idle timeout is opt-in through `Tracks::produce_with_cache_idle_timeout`.

**`moq-relay-ietf` is additive.** `RelayConfig` is untouched, so embedders constructing it as an exhaustive struct literal are unaffected — that is why tuning is passed separately rather than as config fields. `Relay::new(config)` keeps working on defaults. New public surface: `RelayTuning` (`#[non_exhaustive]`, with `Default` and builders), `Relay::new_with_tuning`, `DEFAULT_SUBSCRIBE_TIMEOUT`, and `RemoteManager::with_cache_idle_timeout` / `with_subscribe_timeout`.

## Relationship to #180

#180 is an independent fix for #191 on this same branch, and it converged on the same `TrackRequest { writer, lease }` shape and the same `moq_transport::serve` placement — useful corroboration that the placement is forced by draft-14's structure rather than a matter of taste. Thanks @thexeos.

This PR additionally covers the cross-relay `RemoteManager` cache, the subgroup FIN/RESET issue, and the handshake bounding described above, and keeps the backport aligned with what landed on `main` in #196.
