### PR TITLE
docs: update README and MLOG_SETUP to reflect current deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ This codebase was originally created by [Luke Curley (@kixelated)](https://githu
 
 The `main` branch targets **draft-16** of the MoQT specification and is the basis for Cloudflare's production deployment. Cloudflare currently runs draft-14 and draft-16 relays globally. See the [Cloudflare MoQ developer docs](https://developers.cloudflare.com/moq/) for endpoint URLs, provisioning, and a full feature matrix.
 
+Other branches:
+- [`draft-ietf-moq-transport-14`](https://github.com/cloudflare/moq-rs/tree/draft-ietf-moq-transport-14) — draft-14 maintenance branch
+- [`draft-18-dev`](https://github.com/cloudflare/moq-rs/tree/draft-18-dev) — early draft-18 development
+
 ### What's Included
 
 This repository provides:
@@ -34,19 +38,7 @@ This repository provides:
 
 ## Interoperability
 
-A public relay for interop testing is available at:
-
-```
-# WebTransport
-https://draft-18-interop.cloudflare.mediaoverquic.com:443
-
-# Raw QUIC
-moqt://draft-18-interop.cloudflare.mediaoverquic.com:443
-```
-
-For current endpoint URLs across all implementations and draft versions, see the [moq-interop-runner implementation registry](https://github.com/englishm/moq-interop-runner/blob/main/implementations.json).
-
-As an implementation targeting the IETF specification, this codebase should be compatible with other implementations targeting the same draft version. See the [moq-wg/moq-transport wiki](https://github.com/moq-wg/moq-transport/wiki/Interop) for a list of other implementations.
+This codebase is compatible with other MoQT implementations targeting the same draft version. See the [moq-wg/moq-transport wiki](https://github.com/moq-wg/moq-transport/wiki/Interop) for a list of implementations, and the [moq-interop-runner](https://github.com/englishm/moq-interop-runner) for interop test tooling and a registry of public relay endpoints across draft versions.
 
 For streaming format compatibility:
 - **[video-dev/moq-js](https://github.com/video-dev/moq-js)**: A TypeScript player implementation compatible with moq-pub's fMP4 output. Check draft version compatibility when selecting branches.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This codebase was originally created by [Luke Curley (@kixelated)](https://githu
 
 ## Protocol Support
 
-The `main` branch targets **draft-16** of the MoQT specification. For draft-07 compatibility (used in [Cloudflare's current production deployment](https://developers.cloudflare.com/moq/)), see the [`draft-ietf-moq-transport-07`](https://github.com/cloudflare/moq-rs/tree/draft-ietf-moq-transport-07) branch.
+The `main` branch targets **draft-16** of the MoQT specification and is the basis for Cloudflare's production deployment. Cloudflare currently runs draft-14 and draft-16 relays globally. See the [Cloudflare MoQ developer docs](https://developers.cloudflare.com/moq/) for endpoint URLs, provisioning, and a full feature matrix.
 
 ### What's Included
 
@@ -29,14 +29,21 @@ This repository provides:
 - Both stream ("subgroup") and datagram delivery modes
 
 **Not Supported:**
-- FETCH (Not Soon)
+- FETCH
+- GOAWAY
 
 ## Interoperability
 
-A public relay instance running the latest `main` branch is available for interop testing at:
-```
-https://interop-relay.cloudflare.mediaoverquic.com:443
-```
+Public relay endpoints for protocol testing:
+
+| Draft | Endpoint |
+|-------|----------|
+| draft-14 | `https://draft-14.cloudflare.mediaoverquic.com/` |
+| draft-16 | `https://draft-16.cloudflare.mediaoverquic.com/<token>` |
+
+The draft-16 endpoint requires an authentication token. Create a relay and issue tokens via the [Cloudflare MoQ provisioning API](https://developers.cloudflare.com/api/resources/moq) or the Cloudflare dashboard. Relays are free during the beta.
+
+For draft-18 interop testing ahead of a global deployment, see [moq-interop-runner](https://github.com/englishm/moq-interop-runner).
 
 As an implementation targeting the IETF specification, this codebase should be compatible with other implementations targeting the same draft version. See the [moq-wg/moq-transport wiki](https://github.com/moq-wg/moq-transport/wiki/Interop) for a list of other implementations.
 

--- a/README.md
+++ b/README.md
@@ -34,22 +34,17 @@ This repository provides:
 
 ## Interoperability
 
-Cloudflare operates public relay endpoints for protocol testing. For example:
+A public relay for interop testing is available at:
 
 ```
-# draft-14 (unauthenticated, WebTransport)
-https://draft-14.cloudflare.mediaoverquic.com:443/moq
-
-# draft-16 (requires auth token, WebTransport)
-https://draft-16.cloudflare.mediaoverquic.com:443/<token>
-
-# draft-18 (interop testing only, WebTransport)
+# WebTransport
 https://draft-18-interop.cloudflare.mediaoverquic.com:443/moq
+
+# Raw QUIC
+moqt://draft-18-interop.cloudflare.mediaoverquic.com:443
 ```
 
-The draft-16 endpoint requires an authentication token. Create a relay and issue tokens via the [Cloudflare MoQ provisioning API](https://developers.cloudflare.com/api/resources/moq) or the Cloudflare dashboard. Relays are free during the beta.
-
-For current endpoint URLs across all draft versions (including raw QUIC endpoints), see the [moq-interop-runner implementation registry](https://github.com/englishm/moq-interop-runner/blob/main/implementations.json).
+For current endpoint URLs across all implementations and draft versions, see the [moq-interop-runner implementation registry](https://github.com/englishm/moq-interop-runner/blob/main/implementations.json).
 
 As an implementation targeting the IETF specification, this codebase should be compatible with other implementations targeting the same draft version. See the [moq-wg/moq-transport wiki](https://github.com/moq-wg/moq-transport/wiki/Interop) for a list of other implementations.
 

--- a/README.md
+++ b/README.md
@@ -34,16 +34,22 @@ This repository provides:
 
 ## Interoperability
 
-Public relay endpoints for protocol testing:
+Cloudflare operates public relay endpoints for protocol testing. For example:
 
-| Draft | Endpoint |
-|-------|----------|
-| draft-14 | `https://draft-14.cloudflare.mediaoverquic.com/` |
-| draft-16 | `https://draft-16.cloudflare.mediaoverquic.com/<token>` |
+```
+# draft-14 (unauthenticated, WebTransport)
+https://draft-14.cloudflare.mediaoverquic.com:443/moq
+
+# draft-16 (requires auth token, WebTransport)
+https://draft-16.cloudflare.mediaoverquic.com:443/<token>
+
+# draft-18 (interop testing only, WebTransport)
+https://draft-18-interop.cloudflare.mediaoverquic.com:443/moq
+```
 
 The draft-16 endpoint requires an authentication token. Create a relay and issue tokens via the [Cloudflare MoQ provisioning API](https://developers.cloudflare.com/api/resources/moq) or the Cloudflare dashboard. Relays are free during the beta.
 
-For draft-18 interop testing ahead of a global deployment, see [moq-interop-runner](https://github.com/englishm/moq-interop-runner).
+For current endpoint URLs across all draft versions (including raw QUIC endpoints), see the [moq-interop-runner implementation registry](https://github.com/englishm/moq-interop-runner/blob/main/implementations.json).
 
 As an implementation targeting the IETF specification, this codebase should be compatible with other implementations targeting the same draft version. See the [moq-wg/moq-transport wiki](https://github.com/moq-wg/moq-transport/wiki/Interop) for a list of other implementations.
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ A public relay for interop testing is available at:
 
 ```
 # WebTransport
-https://draft-18-interop.cloudflare.mediaoverquic.com:443/moq
+https://draft-18-interop.cloudflare.mediaoverquic.com:443
 
 # Raw QUIC
 moqt://draft-18-interop.cloudflare.mediaoverquic.com:443

--- a/deploy/MLOG_SETUP.md
+++ b/deploy/MLOG_SETUP.md
@@ -6,13 +6,13 @@ Where QUIC qlog (see [QLOG_SETUP.md](QLOG_SETUP.md)) captures transport-layer ev
 
 ## Quick Start: Verify Your Messages Reached the Relay
 
-This walkthrough uses `moq-test-client` against the public interop relay to demonstrate the basics. You can adapt the same technique for your own client.
+This walkthrough uses `moq-test-client` against a public interop relay to demonstrate the basics. The URL below is an example — check the [moq-interop-runner registry](https://github.com/englishm/moq-interop-runner/blob/main/implementations.json) for current endpoints. You can adapt the same technique for your own relay.
 
 ### Step 1: Run a test
 
 ```bash
 cargo run --bin moq-test-client -- \
-  --relay https://interop-relay.cloudflare.mediaoverquic.com:443 \
+  --relay https://draft-18-interop.cloudflare.mediaoverquic.com:443 \
   --tls-disable-verify \
   --test setup-only
 ```
@@ -32,7 +32,7 @@ ok 1 - setup-only
 ### Step 3: Fetch your mlog
 
 ```bash
-curl https://interop-relay.cloudflare.mediaoverquic.com:443/mlog/22c73802597dcd91ef662a3cd67a03e0
+curl https://draft-18-interop.cloudflare.mediaoverquic.com:443/mlog/22c73802597dcd91ef662a3cd67a03e0
 ```
 
 ### Step 4: Read the results
@@ -58,7 +58,7 @@ The simplest test: connect, exchange CLIENT_SETUP/SERVER_SETUP, disconnect.
 
 ```bash
 cargo run --bin moq-test-client -- \
-  --relay https://interop-relay.cloudflare.mediaoverquic.com:443 \
+  --relay https://draft-18-interop.cloudflare.mediaoverquic.com:443 \
   --tls-disable-verify \
   --test setup-only
 ```
@@ -106,7 +106,7 @@ After SETUP, announce a namespace and verify the relay accepts it.
 
 ```bash
 cargo run --bin moq-test-client -- \
-  --relay https://interop-relay.cloudflare.mediaoverquic.com:443 \
+  --relay https://draft-18-interop.cloudflare.mediaoverquic.com:443 \
   --tls-disable-verify \
   --test publish-namespace-only
 ```
@@ -156,7 +156,7 @@ This test uses two connections: a publisher and a subscriber. The test client re
 
 ```bash
 cargo run --bin moq-test-client -- \
-  --relay https://interop-relay.cloudflare.mediaoverquic.com:443 \
+  --relay https://draft-18-interop.cloudflare.mediaoverquic.com:443 \
   --tls-disable-verify \
   --test publish-namespace-subscribe
 ```
@@ -176,10 +176,10 @@ Fetch both mlogs to see each side of the exchange:
 
 ```bash
 # Publisher's view
-curl https://interop-relay.cloudflare.mediaoverquic.com:443/mlog/71d4b5eb1a807779af03331c330d5fa9
+curl https://draft-18-interop.cloudflare.mediaoverquic.com:443/mlog/71d4b5eb1a807779af03331c330d5fa9
 
 # Subscriber's view
-curl https://interop-relay.cloudflare.mediaoverquic.com:443/mlog/08d0b03ede133f0839435bff64ed2fc5
+curl https://draft-18-interop.cloudflare.mediaoverquic.com:443/mlog/08d0b03ede133f0839435bff64ed2fc5
 ```
 
 **Publisher mlog** (after SETUP):


### PR DESCRIPTION
Updates the README and `deploy/MLOG_SETUP.md` to align with the current state of Cloudflare's MoQ deployment.

## Changes

**README - Protocol Support section:**
- Removes the incorrect statement that draft-07 is the current production deployment
- Updates to state that Cloudflare runs draft-14 and draft-16 relays globally, with a pointer to the developer docs for the full feature matrix and endpoint details
- Adds links to the draft-14 maintenance branch and draft-18-dev branch

**README - Protocol Feature Support:**
- Removes informal "(Not Soon)" qualifier from FETCH
- Adds GOAWAY to the unsupported list (consistent with the feature matrix in cloudflare-docs)

**README - Interoperability section:**
- Replaces specific endpoint URLs with prose pointing to the moq-wg/moq-transport wiki and moq-interop-runner for current relay endpoints across draft versions

**deploy/MLOG_SETUP.md:**
- Replaces stale `interop-relay.cloudflare.mediaoverquic.com` URL (7 occurrences) with the current `draft-18-interop.cloudflare.mediaoverquic.com` endpoint
- Adds a note in the Quick Start that the URL is an example and points to the interop-runner registry for current endpoints