### PR TITLE
fix: bound the upstream subscribe handshake with a wall-clock timeout

### DIFF
--- a/moq-relay-ietf/src/bin/moq-relay-ietf/main.rs
+++ b/moq-relay-ietf/src/bin/moq-relay-ietf/main.rs
@@ -12,7 +12,7 @@ use url::Url;
 
 use api_coordinator::{ApiCoordinator, ApiCoordinatorConfig};
 use file_coordinator::FileCoordinator;
-use moq_relay_ietf::{Coordinator, Relay, RelayConfig, SessionConfig, Web, WebConfig};
+use moq_relay_ietf::{Coordinator, Relay, RelayConfig, RelayTuning, SessionConfig, Web, WebConfig};
 use std::time::Duration;
 
 #[derive(Parser, Clone)]
@@ -42,6 +42,12 @@ pub struct Cli {
     /// subscriptions for the lifetime of the upstream session.
     #[arg(long, default_value_t = 30)]
     pub cache_idle_timeout: u64,
+
+    /// Seconds to wait for an upstream to acknowledge a SUBSCRIBE before giving
+    /// up. Must be at least 1: an unbounded wait on a peer is what this timeout
+    /// exists to prevent, so there is no "disabled" setting.
+    #[arg(long, default_value_t = 10, value_parser = clap::value_parser!(u64).range(1..))]
+    pub subscribe_timeout: u64,
 
     /// Forward all PUBLISH_NAMESPACE messages to the provided server for auth/routing.
     /// If not provided, the relay accepts every unique namespace publish.
@@ -195,7 +201,7 @@ async fn main() -> anyhow::Result<()> {
     };
 
     // Create a QUIC server for media.
-    let relay = Relay::new_with_cache_idle_timeout(
+    let relay = Relay::new_with_tuning(
         RelayConfig {
             tls: tls.clone(),
             bind: Some(cli.bind),
@@ -213,7 +219,9 @@ async fn main() -> anyhow::Result<()> {
             // meshes supply a tagger to mark internal peers.
             connection_tagger: None,
         },
-        Duration::from_secs(cli.cache_idle_timeout),
+        RelayTuning::default()
+            .with_cache_idle_timeout(Duration::from_secs(cli.cache_idle_timeout))
+            .with_subscribe_timeout(Duration::from_secs(cli.subscribe_timeout)),
     )?;
 
     if cli.dev {
@@ -243,5 +251,21 @@ mod tests {
         let cli = Cli::try_parse_from(["moq-relay-ietf", "--max-request-id", "7"]).unwrap();
 
         assert_eq!(cli.max_request_id, 7);
+    }
+
+    #[test]
+    fn subscribe_timeout_defaults_to_ten_seconds() {
+        let cli = Cli::try_parse_from(["moq-relay-ietf"]).unwrap();
+
+        assert_eq!(cli.subscribe_timeout, 10);
+    }
+
+    /// Unlike --cache-idle-timeout, where zero meaningfully means "never evict",
+    /// a zero subscribe timeout would restore the unbounded wait this flag exists
+    /// to prevent.
+    #[test]
+    fn a_zero_subscribe_timeout_is_rejected() {
+        assert!(Cli::try_parse_from(["moq-relay-ietf", "--subscribe-timeout", "0"]).is_err());
+        assert!(Cli::try_parse_from(["moq-relay-ietf", "--cache-idle-timeout", "0"]).is_ok());
     }
 }

--- a/moq-relay-ietf/src/consumer.rs
+++ b/moq-relay-ietf/src/consumer.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::Context;
 use futures::{stream::FuturesUnordered, FutureExt, StreamExt};
@@ -13,7 +14,8 @@ use moq_transport::{
 use tokio::sync::Semaphore;
 
 use crate::{
-    metrics::GaugeGuard, Coordinator, Locals, Producer, RemoteManager, SessionContext, TrackRequest,
+    metrics::GaugeGuard, Coordinator, Locals, Producer, RemoteManager, SessionContext,
+    TrackRequest, DEFAULT_SUBSCRIBE_TIMEOUT,
 };
 
 const MAX_INBOUND_PUBLISH_TRACKS_PER_SESSION: usize = 1024;
@@ -31,6 +33,9 @@ pub struct Consumer {
     /// Relay-level context for this MoQT session.
     context: SessionContext,
     publish_track_permits: Arc<Semaphore>,
+    /// How long to wait for the upstream to acknowledge a SUBSCRIBE before
+    /// giving up. Never zero.
+    subscribe_timeout: Duration,
 }
 
 impl Consumer {
@@ -50,7 +55,17 @@ impl Consumer {
             forward,
             context,
             publish_track_permits: Arc::new(Semaphore::new(MAX_INBOUND_PUBLISH_TRACKS_PER_SESSION)),
+            subscribe_timeout: DEFAULT_SUBSCRIBE_TIMEOUT,
         }
+    }
+
+    /// Set how long to wait for the upstream to acknowledge a SUBSCRIBE.
+    ///
+    /// A builder method rather than a `new()` parameter so that existing callers
+    /// of [`Consumer::new`] keep compiling.
+    pub fn with_subscribe_timeout(mut self, subscribe_timeout: Duration) -> Self {
+        self.subscribe_timeout = subscribe_timeout;
+        self
     }
 
     /// Run the consumer to handle inbound PUBLISH_NAMESPACE and PUBLISH requests.
@@ -258,6 +273,7 @@ impl Consumer {
                 },
                 Some(TrackRequest { writer, lease, upstream }) = requests.recv() => {
                     let mut subscriber = self.subscriber.clone();
+                    let subscribe_timeout = self.subscribe_timeout;
 
                     tasks.push(async move {
                         let info = writer.info.clone();
@@ -276,22 +292,62 @@ impl Consumer {
                         // `subscribe_open` resolves once the upstream publisher
                         // answers, so its outcome is exactly what downstream
                         // subscribers are waiting on to satisfy draft-16 §8.4.
-                        let subscribe = match subscriber.subscribe_open(writer).await {
-                            Ok(subscribe) => {
-                                upstream.established();
-                                subscribe
-                            }
-                            Err(err) => {
-                                tracing::warn!(
+                        // An upstream is under no obligation to ever answer, so
+                        // the handshake is bounded two ways. Left unbounded it
+                        // would pin this task, the `TrackWriter` it carries, and
+                        // every downstream subscriber waiting on `upstream`, until
+                        // the session died.
+                        //
+                        // - `lease.released()` covers "nobody downstream is waiting
+                        //   for this track any more", which is the condition that
+                        //   actually matters and needs no arbitrary constant.
+                        // - `subscribe_timeout` covers the rest: a subscriber that
+                        //   is still waiting cannot wait forever on a peer that
+                        //   never answers.
+                        //
+                        // Either way the in-flight future is dropped, which drops
+                        // the `Subscribe`, whose `Drop` sends UNSUBSCRIBE — so
+                        // giving up mid-handshake leaves nothing dangling upstream.
+                        let subscribe = tokio::select! {
+                            result = tokio::time::timeout(subscribe_timeout, subscriber.subscribe_open(writer)) => match result {
+                                Ok(Ok(subscribe)) => {
+                                    upstream.established();
+                                    subscribe
+                                }
+                                Ok(Err(err)) => {
+                                    tracing::warn!(
+                                        namespace = %namespace,
+                                        track = %track_name,
+                                        error = %err,
+                                        "failed forwarding subscribe: {:?}", info
+                                    );
+                                    // Release waiting downstream subscribers with the
+                                    // upstream reason so they get a REQUEST_ERROR that
+                                    // matches it, rather than a premature accept.
+                                    upstream.failed(err);
+                                    return Ok(());
+                                }
+                                Err(_elapsed) => {
+                                    tracing::warn!(
+                                        namespace = %namespace,
+                                        track = %track_name,
+                                        timeout = ?subscribe_timeout,
+                                        "upstream did not acknowledge SUBSCRIBE in time: {:?}", info
+                                    );
+                                    metrics::counter!("moq_relay_subscribe_timeouts_total", "source" => "local").increment(1);
+                                    upstream.failed(ServeError::Closed(RequestErrorCode::Timeout as u64));
+                                    return Ok(());
+                                }
+                            },
+                            // Counted by the eviction itself in `Locals`. Dropping
+                            // `upstream` unresolved releases any straggler
+                            // downstream subscriber with an error.
+                            _ = lease.released() => {
+                                tracing::info!(
                                     namespace = %namespace,
                                     track = %track_name,
-                                    error = %err,
-                                    "failed forwarding subscribe: {:?}", info
+                                    "abandoning upstream subscribe for idle cached track"
                                 );
-                                // Release waiting downstream subscribers with the
-                                // upstream reason so they get a REQUEST_ERROR that
-                                // matches it, rather than a premature accept.
-                                upstream.failed(err);
                                 return Ok(());
                             }
                         };

--- a/moq-relay-ietf/src/metrics.rs
+++ b/moq-relay-ietf/src/metrics.rs
@@ -33,6 +33,7 @@
 //! | `moq_relay_upstream_errors_total` | `stage` | Upstream connection failures (stage: connect, session) |
 //! | `moq_relay_namespace_transition_timeouts_total` | - | Namespace pull streams reset after graceful transition timeout |
 //! | `moq_relay_cache_idle_evictions_total` | `source` | Unwatched cache entries evicted, releasing an upstream subscription (source: local, remote) |
+//! | `moq_relay_subscribe_timeouts_total` | `source` | Upstream subscriptions abandoned because SUBSCRIBE was not acknowledged in time (source: local, remote) |
 //! | `moq_relay_change_channel_lagged_total` | `channel` | Change notifications skipped by a lagging receiver, forcing a resync (channel: namespace, track) |
 //! | `moq_relay_lease_registry_lock_poisoned_total` | `operation` | Upstream namespace lease registry lock found poisoned (operation: acquire, release) |
 //!
@@ -124,6 +125,10 @@ pub fn describe_metrics() {
     describe_counter!(
         "moq_relay_cache_idle_evictions_total",
         "Unwatched cache entries evicted, releasing an upstream subscription, by source (local, remote)"
+    );
+    describe_counter!(
+        "moq_relay_subscribe_timeouts_total",
+        "Upstream subscriptions abandoned because SUBSCRIBE was not acknowledged within the configured timeout, by source (local, remote)"
     );
     describe_counter!(
         "moq_relay_change_channel_lagged_total",

--- a/moq-relay-ietf/src/relay.rs
+++ b/moq-relay-ietf/src/relay.rs
@@ -75,16 +75,65 @@ impl RelayConfig {
         Relay::new(self)
     }
 
-    /// Build a relay with a custom pull-through cache idle timeout.
+    /// Build a relay with non-default tuning.
     ///
-    /// See [`Relay::new_with_cache_idle_timeout`]. This is a separate
-    /// constructor rather than a `RelayConfig` field so that adding it does not
-    /// break existing struct-literal construction of [`RelayConfig`].
-    pub fn build_with_cache_idle_timeout(
-        self,
-        cache_idle_timeout: Duration,
-    ) -> anyhow::Result<Relay> {
-        Relay::new_with_cache_idle_timeout(self, cache_idle_timeout)
+    /// See [`Relay::new_with_tuning`]. Tuning is passed here rather than as
+    /// `RelayConfig` fields so that adding a knob does not break existing
+    /// struct-literal construction of [`RelayConfig`].
+    pub fn build_with_tuning(self, tuning: RelayTuning) -> anyhow::Result<Relay> {
+        Relay::new_with_tuning(self, tuning)
+    }
+}
+
+/// How long to wait for an upstream to acknowledge a SUBSCRIBE before giving up.
+///
+/// MoQ does not bound the response to a SUBSCRIBE, so this is a policy choice
+/// rather than a protocol constant. A downstream subscriber is blocked for the
+/// whole window, and upstream is normally a nearby relay or origin for which a
+/// control round trip is well under a second, so ten seconds is generous without
+/// leaving a subscriber waiting long past the point it has given up.
+pub const DEFAULT_SUBSCRIBE_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Tuning knobs for a [`Relay`].
+///
+/// Deliberately separate from [`RelayConfig`]: embedders construct `RelayConfig`
+/// as an exhaustive struct literal, so adding a field there is a breaking change.
+/// This struct is `#[non_exhaustive]` with a `Default` and builder methods, so
+/// future knobs can be added without breaking anyone.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub struct RelayTuning {
+    /// How long a cached track with no downstream subscribers is retained before
+    /// its upstream subscription is released. Zero disables eviction, holding
+    /// upstream subscriptions for the lifetime of the upstream session.
+    pub cache_idle_timeout: Duration,
+
+    /// How long to wait for an upstream to acknowledge a SUBSCRIBE before giving
+    /// up. Must be non-zero; [`Relay::new_with_tuning`] rejects zero.
+    pub subscribe_timeout: Duration,
+}
+
+impl Default for RelayTuning {
+    fn default() -> Self {
+        Self {
+            cache_idle_timeout: DEFAULT_CACHE_IDLE_TIMEOUT,
+            subscribe_timeout: DEFAULT_SUBSCRIBE_TIMEOUT,
+        }
+    }
+}
+
+impl RelayTuning {
+    /// Set how long an unwatched cached track is retained before its upstream
+    /// subscription is released. Zero disables eviction.
+    pub fn with_cache_idle_timeout(mut self, cache_idle_timeout: Duration) -> Self {
+        self.cache_idle_timeout = cache_idle_timeout;
+        self
+    }
+
+    /// Set how long to wait for an upstream to acknowledge a SUBSCRIBE.
+    pub fn with_subscribe_timeout(mut self, subscribe_timeout: Duration) -> Self {
+        self.subscribe_timeout = subscribe_timeout;
+        self
     }
 }
 
@@ -95,24 +144,31 @@ pub struct Relay {
     remotes: RemoteManager,
     upstream_namespaces: UpstreamNamespaces,
     upstream_namespaces_runner: UpstreamNamespacesRunner,
+    tuning: RelayTuning,
 }
 
 impl Relay {
     pub fn new(config: RelayConfig) -> anyhow::Result<Self> {
-        Self::new_with_cache_idle_timeout(config, DEFAULT_CACHE_IDLE_TIMEOUT)
+        Self::new_with_tuning(config, RelayTuning::default())
     }
 
-    /// Create a relay that releases upstream subscriptions for cached tracks that
-    /// have had no downstream subscribers for `cache_idle_timeout`.
+    /// Create a relay with non-default [`RelayTuning`].
     ///
     /// The relay caches tracks it does not publish itself so multiple downstream
-    /// subscribers can share one upstream subscription. Without a timeout that
-    /// subscription outlives the last subscriber and the relay keeps receiving a
-    /// track nobody is watching. A zero timeout restores that behaviour.
-    pub fn new_with_cache_idle_timeout(
-        mut config: RelayConfig,
-        cache_idle_timeout: Duration,
-    ) -> anyhow::Result<Self> {
+    /// subscribers can share one upstream subscription. Without an idle timeout
+    /// that subscription outlives the last subscriber and the relay keeps
+    /// receiving a track nobody is watching; a zero `cache_idle_timeout` restores
+    /// that behaviour.
+    ///
+    /// Returns an error if `tuning.subscribe_timeout` is zero. Waiting forever
+    /// for an upstream to acknowledge a SUBSCRIBE is never the intent, and an
+    /// unbounded wait on a peer is what this timeout exists to prevent, so there
+    /// is deliberately no "disabled" setting.
+    pub fn new_with_tuning(mut config: RelayConfig, tuning: RelayTuning) -> anyhow::Result<Self> {
+        if tuning.subscribe_timeout.is_zero() {
+            anyhow::bail!("subscribe_timeout must be non-zero");
+        }
+
         if config.bind.is_some() && !config.endpoints.is_empty() {
             anyhow::bail!("cannot specify both bind and endpoints");
         }
@@ -141,7 +197,7 @@ impl Relay {
             tracing::info!("mlog output enabled: {}", mlog_dir.display());
         }
 
-        let locals = Locals::with_cache_idle_timeout(cache_idle_timeout);
+        let locals = Locals::with_cache_idle_timeout(tuning.cache_idle_timeout);
 
         // FIXME(itzmanish): have a generic filter to find endpoints for forward, remote etc.
         let remote_clients = config
@@ -156,7 +212,8 @@ impl Relay {
             remote_clients,
             config.session,
         )
-        .with_cache_idle_timeout(cache_idle_timeout);
+        .with_cache_idle_timeout(tuning.cache_idle_timeout)
+        .with_subscribe_timeout(tuning.subscribe_timeout);
         let (upstream_namespaces, upstream_namespaces_runner) =
             UpstreamNamespaces::new(locals.clone(), remotes.clone(), config.coordinator.clone());
 
@@ -166,6 +223,7 @@ impl Relay {
             remotes,
             upstream_namespaces,
             upstream_namespaces_runner,
+            tuning,
         })
     }
 
@@ -177,6 +235,7 @@ impl Relay {
             remotes,
             upstream_namespaces,
             upstream_namespaces_runner,
+            tuning,
         } = self;
 
         let RelayConfig {
@@ -252,14 +311,17 @@ impl Relay {
                         upstream_namespaces.clone(),
                         forward_context.clone(),
                     )),
-                    consumer: Some(Consumer::new(
-                        subscriber,
-                        locals.clone(),
-                        forward_coordinator,
-                        remote_manager.clone(),
-                        None,
-                        forward_context,
-                    )),
+                    consumer: Some(
+                        Consumer::new(
+                            subscriber,
+                            locals.clone(),
+                            forward_coordinator,
+                            remote_manager.clone(),
+                            None,
+                            forward_context,
+                        )
+                        .with_subscribe_timeout(tuning.subscribe_timeout),
+                    ),
                     // Forward connections are always full read-write relay peers,
                     // so no reject loops needed.
                     reject_publishes: None,
@@ -434,7 +496,7 @@ impl Relay {
                             };
 
                             let (consumer, reject_publishes) = if can_publish {
-                                (subscriber.map(|subscriber| Consumer::new(subscriber, locals, coordinator, remotes.clone(), forward, context)), None)
+                                (subscriber.map(|subscriber| Consumer::new(subscriber, locals, coordinator, remotes.clone(), forward, context).with_subscribe_timeout(tuning.subscribe_timeout)), None)
                             } else {
                                 (None, subscriber)
                             };
@@ -476,5 +538,142 @@ impl Relay {
 
         remotes.shutdown().await;
         run_result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use moq_transport::coding::TrackNamespace;
+
+    use crate::{
+        CoordinatorContext, CoordinatorError, CoordinatorResult, NamespaceOrigin,
+        NamespaceRegistration,
+    };
+
+    /// Enough of a coordinator to construct a `RelayConfig`.
+    struct StubCoordinator;
+
+    #[async_trait::async_trait]
+    impl Coordinator for StubCoordinator {
+        async fn register_namespace(
+            &self,
+            _scope: Option<&str>,
+            _namespace: &TrackNamespace,
+            _context: &CoordinatorContext,
+        ) -> CoordinatorResult<NamespaceRegistration> {
+            Ok(NamespaceRegistration::new(()))
+        }
+
+        async fn unregister_namespace(
+            &self,
+            _scope: Option<&str>,
+            _namespace: &TrackNamespace,
+        ) -> CoordinatorResult<()> {
+            Ok(())
+        }
+
+        async fn lookup(
+            &self,
+            _scope: Option<&str>,
+            _namespace: &TrackNamespace,
+        ) -> CoordinatorResult<(NamespaceOrigin, Option<quic::Client>)> {
+            Err(CoordinatorError::NamespaceNotFound)
+        }
+    }
+
+    /// No `bind` and no `endpoints`, so construction always fails — the point is
+    /// *which* error it fails with.
+    fn minimal_config() -> RelayConfig {
+        RelayConfig {
+            bind: None,
+            endpoints: vec![],
+            tls: moq_native_ietf::tls::Args::default()
+                .load()
+                .expect("default TLS config"),
+            qlog_dir: None,
+            mlog_dir: None,
+            announce: None,
+            node: None,
+            coordinator: Arc::new(StubCoordinator),
+            session: SessionConfig::default(),
+            connection_tagger: None,
+        }
+    }
+
+    /// `Relay` is not `Debug`, so `expect_err` is unavailable.
+    fn construction_error(result: anyhow::Result<Relay>) -> String {
+        match result {
+            Ok(_) => panic!("expected relay construction to fail"),
+            Err(err) => err.to_string(),
+        }
+    }
+
+    #[test]
+    fn default_tuning_matches_the_documented_defaults() {
+        let tuning = RelayTuning::default();
+        assert_eq!(tuning.cache_idle_timeout, DEFAULT_CACHE_IDLE_TIMEOUT);
+        assert_eq!(tuning.subscribe_timeout, DEFAULT_SUBSCRIBE_TIMEOUT);
+        assert_eq!(tuning.subscribe_timeout, Duration::from_secs(10));
+    }
+
+    /// Both knobs are `Duration`, so a builder assigning to the wrong field would
+    /// compile and silently mis-tune the relay.
+    #[test]
+    fn each_builder_sets_only_its_own_knob() {
+        let base = RelayTuning::default();
+
+        let idle = base.with_cache_idle_timeout(Duration::from_secs(7));
+        assert_eq!(idle.cache_idle_timeout, Duration::from_secs(7));
+        assert_eq!(idle.subscribe_timeout, base.subscribe_timeout);
+
+        let subscribe = base.with_subscribe_timeout(Duration::from_secs(3));
+        assert_eq!(subscribe.subscribe_timeout, Duration::from_secs(3));
+        assert_eq!(subscribe.cache_idle_timeout, base.cache_idle_timeout);
+    }
+
+    /// There is deliberately no "disabled" setting: an unbounded wait on a peer is
+    /// exactly what the timeout exists to prevent.
+    #[test]
+    fn a_zero_subscribe_timeout_is_rejected() {
+        let tuning = RelayTuning::default().with_subscribe_timeout(Duration::ZERO);
+
+        let err = construction_error(Relay::new_with_tuning(minimal_config(), tuning));
+
+        assert!(
+            err.contains("subscribe_timeout"),
+            "expected a subscribe_timeout error, got: {err}"
+        );
+    }
+
+    /// The counterpart to the above: with a valid timeout, construction gets far
+    /// enough to fail on the missing endpoints instead. This pins the rejection to
+    /// the timeout rather than to any config being invalid.
+    #[test]
+    fn a_nonzero_subscribe_timeout_passes_validation() {
+        let err = construction_error(Relay::new_with_tuning(
+            minimal_config(),
+            RelayTuning::default(),
+        ));
+
+        assert!(
+            err.contains("no endpoints"),
+            "expected to fail past timeout validation, got: {err}"
+        );
+    }
+
+    /// A zero cache idle timeout stays legal: it means "never evict", which is the
+    /// pre-existing behaviour and a reasonable thing to ask for.
+    #[test]
+    fn a_zero_cache_idle_timeout_is_still_allowed() {
+        let tuning = RelayTuning::default().with_cache_idle_timeout(Duration::ZERO);
+
+        let err = construction_error(Relay::new_with_tuning(minimal_config(), tuning));
+
+        assert!(
+            err.contains("no endpoints"),
+            "a zero cache idle timeout must not be rejected, got: {err}"
+        );
     }
 }

--- a/moq-relay-ietf/src/remote.rs
+++ b/moq-relay-ietf/src/remote.rs
@@ -17,8 +17,9 @@ use tokio_util::sync::CancellationToken;
 use url::Url;
 
 use crate::interest::{TrackInterest, TrackInterestGuard};
-use crate::local::DEFAULT_CACHE_IDLE_TIMEOUT;
-use crate::{metrics::GaugeGuard, Coordinator, CoordinatorError, RelayInfo, SessionContext};
+use crate::{
+    metrics::GaugeGuard, Coordinator, CoordinatorError, RelayInfo, RelayTuning, SessionContext,
+};
 
 /// Cache key for upstream relay-to-relay connections.
 ///
@@ -51,9 +52,8 @@ pub struct RemoteManager {
     session_config: SessionConfig,
     remotes: Arc<Mutex<HashMap<RemoteCacheKey, RemoteSlot>>>,
 
-    /// How long an unwatched cross-relay cache entry is retained before its
-    /// upstream subscription is released. Zero disables eviction.
-    cache_idle_timeout: Duration,
+    /// Timeouts applied to this relay's upstream track subscriptions.
+    tuning: RelayTuning,
 }
 
 #[cfg(test)]
@@ -104,6 +104,32 @@ mod tests {
             RemoteManager::new_with_session_config(Arc::new(NoopCoordinator), vec![], config);
 
         assert_eq!(manager.session_config, config);
+    }
+
+    #[test]
+    fn new_uses_default_tuning() {
+        let manager = RemoteManager::new(Arc::new(NoopCoordinator), vec![]);
+
+        assert_eq!(manager.tuning, RelayTuning::default());
+    }
+
+    /// Both knobs are `Duration`, so a builder assigning to the wrong field would
+    /// compile and silently mis-tune the peer connections.
+    #[test]
+    fn each_builder_sets_only_its_own_knob() {
+        let manager = RemoteManager::new(Arc::new(NoopCoordinator), vec![])
+            .with_subscribe_timeout(Duration::from_secs(3));
+
+        assert_eq!(manager.tuning.subscribe_timeout, Duration::from_secs(3));
+        assert_eq!(
+            manager.tuning.cache_idle_timeout,
+            RelayTuning::default().cache_idle_timeout
+        );
+
+        let manager = manager.with_cache_idle_timeout(Duration::from_secs(7));
+
+        assert_eq!(manager.tuning.cache_idle_timeout, Duration::from_secs(7));
+        assert_eq!(manager.tuning.subscribe_timeout, Duration::from_secs(3));
     }
 
     #[test]
@@ -271,7 +297,7 @@ impl RemoteManager {
             clients,
             session_config,
             remotes: Arc::new(Mutex::new(HashMap::new())),
-            cache_idle_timeout: DEFAULT_CACHE_IDLE_TIMEOUT,
+            tuning: RelayTuning::default(),
         }
     }
 
@@ -281,7 +307,13 @@ impl RemoteManager {
     /// A zero timeout disables idle eviction, holding subscriptions to peer
     /// relays for as long as the peer session lives.
     pub fn with_cache_idle_timeout(mut self, cache_idle_timeout: Duration) -> Self {
-        self.cache_idle_timeout = cache_idle_timeout;
+        self.tuning.cache_idle_timeout = cache_idle_timeout;
+        self
+    }
+
+    /// Override how long to wait for a peer relay to acknowledge a SUBSCRIBE.
+    pub fn with_subscribe_timeout(mut self, subscribe_timeout: Duration) -> Self {
+        self.tuning.subscribe_timeout = subscribe_timeout;
         self
     }
 
@@ -454,7 +486,7 @@ impl RemoteManager {
                 cache_key.1,
                 client,
                 self.session_config,
-                self.cache_idle_timeout,
+                self.tuning,
                 RemoteCacheHandle {
                     remotes: Arc::downgrade(&self.remotes),
                     key: cache_key.clone(),
@@ -609,8 +641,8 @@ struct Remote {
     connected: Arc<AtomicBool>,
     /// Cancellation token for the session task.
     cancel: CancellationToken,
-    /// Idle timeout applied to this peer's cached track readers.
-    cache_idle_timeout: Duration,
+    /// Timeouts applied to this peer's track subscriptions.
+    tuning: RelayTuning,
 }
 
 /// Where a connection caches itself, so the session task can evict its own slot
@@ -628,7 +660,7 @@ impl Remote {
         addr: Option<SocketAddr>,
         client: &quic::Client,
         session_config: SessionConfig,
-        cache_idle_timeout: Duration,
+        tuning: RelayTuning,
         cache: RemoteCacheHandle,
     ) -> anyhow::Result<Self> {
         let RemoteCacheHandle {
@@ -721,7 +753,7 @@ impl Remote {
             tracks: Arc::new(Mutex::new(HashMap::new())),
             connected,
             cancel,
-            cache_idle_timeout,
+            tuning,
         })
     }
 
@@ -817,8 +849,15 @@ impl Remote {
             tracing::info!(remote_url = %url, namespace = %key.0, track = %key.1, "subscribing to remote track");
 
             let (writer, reader) = Track::new(namespace.clone(), track_name.clone()).produce();
+
+            // `subscribe_open` waits for the peer to answer, which it is under no
+            // obligation to ever do, so the handshake is bounded three ways: the
+            // peer connection closing, a wall-clock timeout, and — once the entry
+            // exists — idle eviction. Dropping the in-flight future drops the
+            // `Subscribe`, whose `Drop` sends UNSUBSCRIBE, so giving up here
+            // leaves nothing dangling on the peer.
             let subscribe_result = tokio::select! {
-                result = subscriber.subscribe_open(writer) => result,
+                result = tokio::time::timeout(self.tuning.subscribe_timeout, subscriber.subscribe_open(writer)) => result,
                 _ = cancel.cancelled() => {
                     drop(cached);
                     remove_empty_track_slot(&self.tracks, &key, &slot).await;
@@ -827,11 +866,23 @@ impl Remote {
             };
 
             let subscribe = match subscribe_result {
-                Ok(subscribe) => subscribe,
-                Err(err) => {
+                Ok(Ok(subscribe)) => subscribe,
+                Ok(Err(err)) => {
                     drop(cached);
                     remove_empty_track_slot(&self.tracks, &key, &slot).await;
                     return Err(err.into());
+                }
+                Err(_elapsed) => {
+                    tracing::warn!(remote_url = %url, namespace = %key.0, track = %key.1, timeout = ?self.tuning.subscribe_timeout, "remote relay did not acknowledge SUBSCRIBE in time");
+                    metrics::counter!("moq_relay_subscribe_timeouts_total", "source" => "remote")
+                        .increment(1);
+                    drop(cached);
+                    remove_empty_track_slot(&self.tracks, &key, &slot).await;
+                    anyhow::bail!(
+                        "remote relay {} did not acknowledge SUBSCRIBE within {:?}",
+                        self.url,
+                        self.tuning.subscribe_timeout
+                    );
                 }
             };
 
@@ -856,7 +907,7 @@ impl Remote {
             let cleanup_key = key.clone();
             let cleanup_reader = reader.clone();
             let cleanup_slot = slot.clone();
-            let idle_timeout = self.cache_idle_timeout;
+            let idle_timeout = self.tuning.cache_idle_timeout;
             tokio::spawn(async move {
                 tokio::select! {
                     result = subscribe.closed() => {


### PR DESCRIPTION
`subscribe_open` waits for an upstream to answer a SUBSCRIBE, which a peer is under no obligation to ever do, and neither relay path bounded that wait — a never-answered subscribe pinned the task, its `TrackWriter`, and every downstream subscriber waiting on it until the session died. This bounds the handshake two ways on both the local pull-through path and the cross-relay path: it races `lease.released()` against the handshake itself (covering "nobody downstream is waiting any more"), and adds `--subscribe-timeout`, defaulting to 10s, for the case where a subscriber is still waiting. Either way the in-flight future is dropped, which drops the `Subscribe` and sends UNSUBSCRIBE, so giving up leaves nothing dangling upstream; expiry is counted by `moq_relay_subscribe_timeouts_total`.

This forward-ports the same protection from the `draft-ietf-moq-transport-14` branch, adapted to this branch's `UpstreamReady` plumbing. Note that config plumbing changes shape to carry a second knob, with `new_with_cache_idle_timeout` becoming `new_with_tuning(config, RelayTuning)` — happy to keep a deprecated alias instead if you would rather not break embedders.