### PR TITLE
perf(moq-api): reuse pooled connections for origin lookups

### DIFF
--- a/moq-api/src/client.rs
+++ b/moq-api/src/client.rs
@@ -2,9 +2,26 @@
 // SPDX-FileCopyrightText: 2023-2024 Luke Curley and contributors
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use std::time::Duration;
+
 use url::Url;
 
 use crate::{ApiError, Origin};
+
+/// How long an idle connection is kept in the pool.
+///
+/// Origin lookups can be sparse while still being latency sensitive, so an
+/// aggressive timeout just means the next lookup pays for a fresh TCP connect
+/// and TLS handshake before the request is even sent.
+const POOL_IDLE_TIMEOUT: Duration = Duration::from_secs(600);
+
+/// Idle connections kept per host. All requests target a single API host, so a
+/// small pool absorbs concurrent lookups without holding many sockets open.
+const POOL_MAX_IDLE_PER_HOST: usize = 8;
+
+/// TCP keepalive interval, so a connection sitting idle in the pool is not
+/// silently dropped by a NAT or load balancer between requests.
+const TCP_KEEPALIVE: Duration = Duration::from_secs(60);
 
 #[derive(Clone)]
 pub struct Client {
@@ -16,7 +33,15 @@ pub struct Client {
 
 impl Client {
     pub fn new(url: Url) -> Self {
-        let client = reqwest::Client::new();
+        // Mirrors reqwest::Client::new(): building only fails if the TLS backend or the
+        // system resolver cannot be initialized, neither of which these options affect.
+        let client = reqwest::Client::builder()
+            .pool_idle_timeout(POOL_IDLE_TIMEOUT)
+            .pool_max_idle_per_host(POOL_MAX_IDLE_PER_HOST)
+            .tcp_keepalive(TCP_KEEPALIVE)
+            .build()
+            .expect("failed to build HTTP client");
+
         Self { url, client }
     }
 
@@ -56,5 +81,18 @@ impl Client {
         resp.error_for_status()?;
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new_builds_client() {
+        let url = Url::parse("http://localhost:4442/").unwrap();
+        let client = Client::new(url.clone());
+
+        assert_eq!(client.url, url);
     }
 }


### PR DESCRIPTION
Backport of #200 to draft-14

`moq-api`'s HTTP client is constructed with `reqwest::Client::new()`, i.e. reqwest's defaults. That includes a 90 second `pool_idle_timeout`, so whenever origin lookups are spaced further apart than that, the pooled connection has already been closed and the next lookup pays for a TCP connect and a TLS handshake before the request is even sent. These lookups sit on the critical path of a subscribe for a namespace the relay does not serve locally, which makes those two extra round trips directly user-visible.

This builds the client explicitly with a longer idle timeout, a small per-host idle pool, and TCP keepalive so a connection idling in the pool is not silently dropped by a NAT or load balancer. The values are module constants with doc comments, the public API of `Client` is unchanged, and a unit test covers the new construction path.